### PR TITLE
Fix incompatability between black and flake8 for line breaks

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -4,6 +4,8 @@ extend-ignore =
     # See https://github.com/PyCQA/pycodestyle/issues/373
     E203,
     E401,
+    # https://github.com/psf/black/issues/1029
+    W503,
 exclude =
     srv/migrations
     env


### PR DESCRIPTION
When the operator is before the line break like this,
```
income = (gross_wages +
          taxable_interest)
```
black re-formats it like this
```
income = (gross_wages +
          taxable_interest)
```

but flake8 thinks the former is the correct format in [W503](https://www.flake8rules.com/rules/W503.html), so one of the two must be ignored.