### PR TITLE
fix tf modules import

### DIFF
--- a/opta/module.py
+++ b/opta/module.py
@@ -58,7 +58,7 @@ class BaseModule:
             ),
             os.getcwd(),
         )
-        # Note: This breaks if runxc is ever prefixed with '.'
+        # Note: This breaks should runxc ever be prefixed with '.'
         if '.' != relative_path[0]:
             relative_path = f"./{relative_path}"
 


### PR DESCRIPTION
opta deployment has been breaking because of a problem in the terraform module import paths.

os.relpath does not add a `./` for direct nested paths, so code it in, as terraform needs it.

```
Error: Module not found

The module address "runxc/config/tf_modules/aws-rds" could not be resolved.

If you intended this as a path relative to the current module, use
"./runxc/config/tf_modules/aws-rds" instead. The "./" prefix indicates that
the address is a relative filesystem path.
```
