### PR TITLE
Don't let nginx drop api_key header

### DIFF
--- a/config/tf_modules/k8s-service/k8s-service/templates/ingress.yaml
+++ b/config/tf_modules/k8s-service/k8s-service/templates/ingress.yaml
@@ -12,6 +12,7 @@ metadata:
     nginx.ingress.kubernetes.io/configuration-snippet: |
       proxy_set_header l5d-dst-override $service_name.$namespace.svc.cluster.local:$service_port;
       grpc_set_header l5d-dst-override $service_name.$namespace.svc.cluster.local:$service_port;
+      underscores_in_headers on;
 spec:
   rules:
     - host: {{ .Values.domain }}


### PR DESCRIPTION
By default, nginx drops headers with underscore in them, which is unexpected. Don't drop headers with underscores in them in general

context: https://stackoverflow.com/questions/22856136/why-do-http-servers-forbid-underscores-in-http-header-names