### PR TITLE
Revert "Don't let nginx drop api_key header"

### DIFF
--- a/config/tf_modules/k8s-service/k8s-service/templates/ingress.yaml
+++ b/config/tf_modules/k8s-service/k8s-service/templates/ingress.yaml
@@ -12,7 +12,6 @@ metadata:
     nginx.ingress.kubernetes.io/configuration-snippet: |
       proxy_set_header l5d-dst-override $service_name.$namespace.svc.cluster.local:$service_port;
       grpc_set_header l5d-dst-override $service_name.$namespace.svc.cluster.local:$service_port;
-      underscores_in_headers on;
 spec:
   rules:
     - host: {{ .Values.domain }}


### PR DESCRIPTION
Reverts run-x/runxc#50 which broke CD:
```
Error: exit status 1
2021/01/31 22:24:50 [emerg] 531#531: "underscores_in_headers" directive is not allowed here in /tmp/nginx-cfg031801590:659
nginx: [emerg] "underscores_in_headers" directive is not allowed here in /tmp/nginx-cfg031801590:659
nginx: configuration file /tmp/nginx-cfg031801590 test failed
```

Instead of debugging what exactly is wrong, we can just pass "api-key" for now instead (thanks to @uadnan's suggestion)
