### PR TITLE
Delete opta resources properly

### DIFF
--- a/opta/cli.py
+++ b/opta/cli.py
@@ -256,6 +256,7 @@ def _apply(
         # but have not been touched by any block.
         # Modules are untouched if the customer deletes or renames them in the
         # opta config file.
+        # TODO: Warn user when things are getting deleted (when we have opta diffs)
         if block_idx + 1 == len(blocks_to_process):
             untouched_modules = list(total_modules_applied - current_module_keys)
             target_modules += untouched_modules


### PR DESCRIPTION
removing resources from opta config didn't actually delete them in aws because of how we use -targets only on resources that are currently in the config.
On the last block run, add untouched resources as targets as well so they can be deleted

untouched resources are resources that have not been touched in any of the block runs