### PR TITLE
Fix deleting RDS and DocDB databases

### DIFF
--- a/config/tf_modules/aws-documentdb/main.tf
+++ b/config/tf_modules/aws-documentdb/main.tf
@@ -27,4 +27,5 @@ resource "aws_docdb_cluster" "cluster" {
   kms_key_id = var.kms_account_key_arn
   vpc_security_group_ids = var.security_group == "" ? [data.aws_security_group.security_group[0].id] : [var.security_group]
   apply_immediately = true
+  skip_final_snapshot = true
 }

--- a/config/tf_modules/aws-rds/main.tf
+++ b/config/tf_modules/aws-rds/main.tf
@@ -23,6 +23,7 @@ resource "aws_rds_cluster" "db_cluster" {
   master_password = random_password.pg_password.result
   vpc_security_group_ids = var.security_group == "" ? [data.aws_security_group.security_group[0].id] : [var.security_group]
   apply_immediately = true
+  skip_final_snapshot = true
 }
 
 resource "aws_rds_cluster_instance" "db_instance" {


### PR DESCRIPTION
Currently when you try to delete an RDS or DocDB cluster, you run into the following terraform apply error:

```
Error: RDS Cluster FinalSnapshotIdentifier is required when a final snapshot is required
```
(or the docdb equivalent)

This is because [skip_final_snapshot](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/docdb_cluster#skip_final_snapshot) by default is set to `False` which creates a snapshot using the value of `final_snapshot_identifier`, which is unset.

TLDR we can't delete any RDS / DocDB clusters unless `skip_final_snapshot = true` or we support db snapshots.