### PR TITLE
log nice_run errors

### DIFF
--- a/opta/cli.py
+++ b/opta/cli.py
@@ -395,4 +395,4 @@ if __name__ == "__main__":
         cli()
     except CalledProcessError as e:
         logging.exception(e)
-        print(e.stderr.decode("utf-8"))
+        logging.error(e.stderr.decode("utf-8"))


### PR DESCRIPTION
previous behavior:
```
(runxc) ➜  test-service git:(main) ✗ python ../runxc/opta/cli.py inspect --env runx-staging                                                                                                                                                          ...
  File "/Users/kjin1/runx/runxc/opta/nice_subprocess.py", line 94, in nice_run
    raise CalledProcessError(retcode, process.args, output=stdout, stderr=stderr)
subprocess.CalledProcessError: Command '['terraform', 'show', '-json']' returned non-zero exit status 1.
```

new behavior (now shows the shell command error message):
```
(runxc) ➜  test-service git:(main) ✗ python ../runxc/opta/cli.py output --env runx-staging
...
  File "/Users/kjin1/runx/runxc/opta/nice_subprocess.py", line 93, in nice_run
    raise CalledProcessError(retcode, process.args, output=stdout, stderr=stderr)
subprocess.CalledProcessError: Command '['terraform', 'output', '-json']' returned non-zero exit status 1.

Error: error configuring S3 Backend: error validating provider credentials: error calling sts:GetCallerIdentity: InvalidClientTokenId: The security token included in the request is invalid.
        status code: 403, request id: d8dc4070-dacb-4a64-ac2e-c0d7a1c82e20
```