### PR TITLE
Introduce org_id

### DIFF
--- a/opta/layer.py
+++ b/opta/layer.py
@@ -171,7 +171,15 @@ class Layer:
             return self.meta["state_storage"]
         elif self.parent is not None:
             return self.parent.state_storage()
-        return f"opta-tf-state-{self.meta['name']}"
+        elif "org_id" not in self.meta:
+            # TODO: Remove this once everyone is updated
+            print(
+                "\nWARNING: You should specify a unique org_id in environment yml files\
+                   \nWARNING: This will break in future releases\n"
+            )
+            return f"opta-tf-state-{self.meta['name']}"
+        else:
+            return f"opta-tf-state-{self.meta['org_id']}-{self.meta['name']}"
 
     def gen_providers(self, block_idx: int, backend_enabled: bool) -> Dict[Any, Any]:
         ret: Dict[Any, Any] = {"provider": {}}

--- a/tests/fixtures/apply.py
+++ b/tests/fixtures/apply.py
@@ -1,7 +1,49 @@
 BASIC_APPLY = (
     {
         "meta": {
-            "create-env": "dev1",
+            "name": "dev1",
+            "org_id": "test",
+            "providers": {"aws": {"allowed_account_ids": ["abc"], "region": "us-east-1"}},
+        },
+        "modules": {
+            "core": {
+                "type": "aws-state-init",
+                "bucket_name": "{state_storage}",
+                "dynamodb_lock_table_name": "{state_storage}",
+            }
+        },
+    },
+    {
+        "provider": {"aws": {"allowed_account_ids": ["abc"], "region": "us-east-1"}},
+        "terraform": {
+            "backend": {
+                "s3": {
+                    "bucket": "opta-tf-state-test-dev1",
+                    "key": "dev1",
+                    "dynamodb_table": "opta-tf-state-test-dev1",
+                    "region": "us-east-1",
+                }
+            }
+        },
+        "module": {
+            "core": {
+                "source": "./config/tf_modules/aws-state-init",
+                "bucket_name": "opta-tf-state-test-dev1",
+                "dynamodb_lock_table_name": "opta-tf-state-test-dev1",
+            }
+        },
+        "output": {
+            "state_bucket_id": {"value": "${module.core.state_bucket_id }"},
+            "state_bucket_arn": {"value": "${module.core.state_bucket_arn }"},
+            "kms_account_key_arn": {"value": "${module.core.kms_account_key_arn }"},
+            "kms_account_key_id": {"value": "${module.core.kms_account_key_id }"},
+        },
+    },
+)
+
+APPLY_WITHOUT_ORG_ID = (
+    {
+        "meta": {
             "name": "dev1",
             "providers": {"aws": {"allowed_account_ids": ["abc"], "region": "us-east-1"}},
         },

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -16,7 +16,7 @@ from opta.cli import (
     at_exit_callback,
     cli,
 )
-from tests.fixtures.apply import BASIC_APPLY
+from tests.fixtures.apply import APPLY_WITHOUT_ORG_ID, BASIC_APPLY
 
 
 class TestCLI:
@@ -48,7 +48,7 @@ class TestCLI:
     def test_basic_apply(self, mocker: MockFixture) -> None:
         mocked_exists = mocker.patch("os.path.exists")
         mocked_exists.return_value = True
-        test_cases: Any = [BASIC_APPLY]
+        test_cases: Any = [BASIC_APPLY, APPLY_WITHOUT_ORG_ID]
 
         runner = CliRunner()
         for (i, o) in test_cases:


### PR DESCRIPTION
- Basically, every env yaml should have a org_id key which would help us make their bucket names unique.
- I introduced as a warning for now but we can make it enforced down the line once all of our internal files are updated.

Will update docs once this merges.
