### PR TITLE
Disable codecov/patch ci check

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,6 @@
 coverage:
   status:
+    patch: off
     project:
       default: # This can be anything, but it needs to exist as the name
         # basic settings


### PR DESCRIPTION
This config change disables the `codecov/patch` check. It's annoying that this fails and turns the entire commit red. Like we discussed in Slack, we don't care about individual PR diff coverage, but the repo coverage as a whole.

![image](https://user-images.githubusercontent.com/15851351/107630785-473f8d80-6c21-11eb-9536-8c88f9713c77.png)
