### PR TITLE
Update k8s service delay to 30s

### DIFF
--- a/config/tf_modules/k8s-service/k8s-service/templates/deployment.yaml
+++ b/config/tf_modules/k8s-service/k8s-service/templates/deployment.yaml
@@ -65,6 +65,7 @@ spec:
             {{ end }}
             {{- end }}
           livenessProbe:
+            initialDelaySeconds: 30
             {{ if hasKey .Values.port "tcp" }}
             tcpSocket:
             {{ end }}
@@ -74,7 +75,7 @@ spec:
             {{ end }}
               port: main
           readinessProbe:
-            initialDelaySeconds: 10
+            initialDelaySeconds: 30
             periodSeconds: 10
             {{ if hasKey .Values.port "tcp" }}
             tcpSocket:


### PR DESCRIPTION
Longer term, we should make this configurable. But as a default, I think 30s is better than 10s. Thoughts?