### PR TITLE
Let opta push optionally terraform init if needed

### DIFF
--- a/tests/commands/test_push.py
+++ b/tests/commands/test_push.py
@@ -17,7 +17,7 @@ TERRAFORM_OUTPUTS = {"docker_repo_url": REGISTRY_URL}
 class TestGetRegistryUrl:
     def test_get_registry_url(self, mocker: MockFixture) -> None:
         mocker.patch(
-            "opta.commands.push.Terraform.get_outputs", return_value=TERRAFORM_OUTPUTS
+            "opta.commands.push.get_terraform_outputs", return_value=TERRAFORM_OUTPUTS
         )
 
         docker_repo_url = get_registry_url()
@@ -25,7 +25,7 @@ class TestGetRegistryUrl:
 
     def test_no_docker_repo_url_in_output(self, mocker: MockFixture) -> None:
         mocker.patch("os.path.isdir", return_value=True)
-        mocker.patch("opta.commands.push.Terraform.get_outputs", return_value={})
+        mocker.patch("opta.commands.push.get_terraform_outputs", return_value={})
 
         with pytest.raises(Exception) as e_info:
             get_registry_url()


### PR DESCRIPTION
```
 source $(pipenv --venv)/bin/activate
  export PYTHONPATH=$(pwd)
  cd ..
  python ./runxc/opta/cli.py push app:$IMAGE_VERSION --env staging
  shell: /bin/bash -e {0}
  env:
    ECR_REPO: ***.dkr.ecr.us-east-1.amazonaws.com/test-service-runx-app
    IMAGE_VERSION: 5e6ffbb65803891d45d071bcf8a223767452c246
    SSH_AUTH_SOCK: /tmp/ssh-t5c9NgsKdaxC/agent.2524
    SSH_AGENT_PID: 2525
    pythonLocation: /opt/hostedtoolcache/Python/3.8.7/x64
    LD_LIBRARY_PATH: /opt/hostedtoolcache/Python/3.8.7/x64/lib
    AWS_DEFAULT_REGION: us-east-1
    AWS_REGION: us-east-1
    AWS_ACCESS_KEY_ID: ***
    AWS_SECRET_ACCESS_KEY: ***
ERROR: Command '['terraform', 'output', '-json']' returned non-zero exit status 1.
Traceback (most recent call last):
  File "./runxc/opta/cli.py", line 161, in <module>
    cli()
  File "/home/runner/.local/share/virtualenvs/runxc-xo5BZeII/lib/python3.8/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/home/runner/.local/share/virtualenvs/runxc-xo5BZeII/lib/python3.8/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/home/runner/.local/share/virtualenvs/runxc-xo5BZeII/lib/python3.8/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/runner/.local/share/virtualenvs/runxc-xo5BZeII/lib/python3.8/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/runner/.local/share/virtualenvs/runxc-xo5BZeII/lib/python3.8/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/home/runner/work/test-service/test-service/runxc/opta/commands/push.py", line 82, in push
    registry_url = get_registry_url()
  File "/home/runner/work/test-service/test-service/runxc/opta/commands/push.py", line 16, in get_registry_url
    outputs = Terraform.get_outputs()
  File "/home/runner/work/test-service/test-service/runxc/opta/core/terraform.py", line 27, in get_outputs
    raw_output = nice_run(
  File "/home/runner/work/test-service/test-service/runxc/opta/nice_subprocess.py", line 93, in nice_run
    raise CalledProcessError(retcode, process.args, output=stdout, stderr=stderr)
subprocess.CalledProcessError: Command '['terraform', 'output', '-json']' returned non-zero exit status 1.
ERROR: 
```