### PR TITLE
Redirecting http to https when ssl is present

### DIFF
--- a/config/tf_modules/k8s-base/variables.tf
+++ b/config/tf_modules/k8s-base/variables.tf
@@ -1,5 +1,15 @@
 locals {
-  target_ports = var.cert_arn == "" ? { http: "http" } : { http: "http", https: "http" }
+  target_ports = var.cert_arn == "" ? { http: "http" } : { http: "http", https: "special" }
+  container_ports = var.cert_arn == "" ? { http: 80, https: 443 } : { http: 80, https: 443, special: 8000 }
+  config = var.cert_arn == "" ? { ssl-redirect: false } : {
+    ssl-redirect: false
+    server-snippet: <<EOF
+          listen 8000;
+          if ( $server_port = 80 ) {
+             return 308 https://$host$request_uri;
+          }
+          EOF
+  }
 }
 
 data "aws_eks_cluster" "main" {

--- a/opta/cli.py
+++ b/opta/cli.py
@@ -165,7 +165,7 @@ if __name__ == "__main__":
             logger.error(e.stderr.decode("utf-8"))
         sys.exit(1)
     except UserErrors as e:
-        logger.debug(e)
+        logger.error(e)
         sys.exit(1)
     except Exception as e:
         logger.exception(e)


### PR DESCRIPTION
Following this solution: https://github.com/kubernetes/ingress-nginx/issues/2724#issuecomment-593769295

Tested it with both no https and with https.
ALL SERVICES WILL REDIRECT PUBLIC TRAFFIC HTTP TO HTTPS IF SSL IS PRESENT, NO EXCEPTION