### PR TITLE
Exit with code 1 when apply fails

### DIFF
--- a/opta/cli.py
+++ b/opta/cli.py
@@ -97,6 +97,7 @@ if __name__ == "__main__":
         sys.exit(1)
     except Exception as e:
         logger.exception(e)
+        sys.exit(1)
     finally:
         dd_listener.stop()
         dd_handler.flush()


### PR DESCRIPTION
Earlier https://github.com/run-x/runxc/pull/119 broke terraform apply, but the CI didn't catch this failure because we don't always exit with code 1 when catching runtime exceptions