### PR TITLE
Fix opta validate/apply

### DIFF
--- a/opta/layer.py
+++ b/opta/layer.py
@@ -261,3 +261,11 @@ class Layer:
         if provider_name == "aws" and "account_id" in provider_data:
             aws_account_id = provider_data.pop("account_id")
             provider_data["allowed_account_ids"] = [aws_account_id]
+
+    # Get the root-most layer
+    def root(self) -> "Layer":
+        layer = self
+        while layer.parent is not None:
+            layer = layer.parent
+
+        return layer


### PR DESCRIPTION
I was getting this error when running opta apply:
```
(runxc) ➜  test-service git:(main) ✗ OPTA_DEBUG=true python ../runxc/opta/cli.py apply --env staging
...
ERROR: [Errno 2] No such file or directory: 'git@github.com:run-x/runx-infra.git//staging/opta.yml?ref=main'                                                                                                                                        [250/1848]
Traceback (most recent call last):
  File "../runxc/opta/cli.py", line 87, in <module>
    cli()
  File "/Users/kjin1/.local/share/virtualenvs/runxc-4xU_RsaM/lib/python3.8/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/Users/kjin1/.local/share/virtualenvs/runxc-4xU_RsaM/lib/python3.8/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/Users/kjin1/.local/share/virtualenvs/runxc-4xU_RsaM/lib/python3.8/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/kjin1/.local/share/virtualenvs/runxc-4xU_RsaM/lib/python3.8/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/kjin1/.local/share/virtualenvs/runxc-4xU_RsaM/lib/python3.8/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/Users/kjin1/runx/runxc/opta/commands/apply.py", line 59, in apply
    _apply(config, env, refresh, max_module, image_tag, test)
  File "/Users/kjin1/runx/runxc/opta/commands/apply.py", line 73, in _apply
    layer = Layer.load_from_yaml(config, env)
  File "/Users/kjin1/runx/runxc/opta/layer.py", line 87, in load_from_yaml
    return cls.load_from_dict(conf, env)
  File "/Users/kjin1/runx/runxc/opta/layer.py", line 107, in load_from_dict
    current_parent = cls.load_from_yaml(parent_path, None)
  File "/Users/kjin1/runx/runxc/opta/layer.py", line 85, in load_from_yaml
    validate_yaml(config)
  File "/Users/kjin1/runx/runxc/opta/commands/validate.py", line 84, in validate_yaml
    data = yamale.make_data(config_file_path)
  File "/Users/kjin1/.local/share/virtualenvs/runxc-4xU_RsaM/lib/python3.8/site-packages/yamale/yamale.py", line 29, in make_data
    raw_data = readers.parse_yaml(path, parser, content=content)
  File "/Users/kjin1/.local/share/virtualenvs/runxc-4xU_RsaM/lib/python3.8/site-packages/yamale/readers/yaml_reader.py", line 34, in parse_yaml
    with open(path) as f:
FileNotFoundError: [Errno 2] No such file or directory: 'git@github.com:run-x/runx-infra.git//staging/opta.yml?ref=main'
```