### PR TITLE
Remove redundant yes/no from prompt

### DIFF
--- a/opta/commands/apply.py
+++ b/opta/commands/apply.py
@@ -108,7 +108,7 @@ def _apply(
             )
             Terraform.show(TF_PLAN_PATH)
             click.confirm(
-                "The above are the planned changes for your opta run. Do you approve (yes/no)?",
+                "The above are the planned changes for your opta run. Do you approve?",
                 abort=True,
             )
             logger.info("Applying your changes (might take a minute)")

--- a/tests/commands/test_apply.py
+++ b/tests/commands/test_apply.py
@@ -47,7 +47,7 @@ def test_apply(mocker: MockFixture) -> None:
         quiet=True,
     )
     mocked_click.confirm.assert_called_once_with(
-        "The above are the planned changes for your opta run. Do you approve (yes/no)?",
+        "The above are the planned changes for your opta run. Do you approve?",
         abort=True,
     )
     tf_show.assert_called_once_with(TF_PLAN_PATH)


### PR DESCRIPTION
It is redundant to ask for `yes/no` and then `y/N` afterwards, when running opta apply:
```
Plan: 0 to add, 9 to change, 0 to destroy.
The above are the planned changes for your opta run. Do you approve (yes/no)? [y/N]:
``` 
The `click.confirm` function already automatically appends [y/N] at the end of the sentence, so `yes/no` is not necessary