### PR TITLE
Terraform apply should not be silenced

### DIFF
--- a/opta/commands/apply.py
+++ b/opta/commands/apply.py
@@ -131,5 +131,5 @@ def _apply(
                         target=tail_namespace_events, args=(layer, 0, 1), daemon=True,
                     )
                     new_thread.start()
-            Terraform.apply(layer, TF_PLAN_PATH, no_init=True, quiet=True)
+            Terraform.apply(layer, TF_PLAN_PATH, no_init=True, quiet=False)
             logger.info("Opta updates complete!")

--- a/tests/commands/test_apply.py
+++ b/tests/commands/test_apply.py
@@ -37,7 +37,9 @@ def test_apply(mocker: MockFixture) -> None:
     runner = CliRunner()
     result = runner.invoke(apply)
     assert result.exit_code == 0
-    tf_apply.assert_called_once_with(mocked_layer, TF_PLAN_PATH, no_init=True, quiet=True)
+    tf_apply.assert_called_once_with(
+        mocked_layer, TF_PLAN_PATH, no_init=True, quiet=False
+    )
     tf_plan.assert_called_once_with(
         "-lock=false",
         "-input=false",


### PR DESCRIPTION
I understand that terraform apply may seem kind of noisy, refreshing/modifying so many resources. But it helps me understand the progress of my apply, and imo I'd rather see that progress instead of just staring at nothing.

Especially when first setting up my environment layer, some terraform apply's can run for 20-40 minutes. If I didn't already know that beforehand, I would have thought my apply silently failed and froze. In fact, I still get that doubt sometimes tbh.