### PR TITLE
Hidden cleanup command

### DIFF
--- a/opta/cli.py
+++ b/opta/cli.py
@@ -9,6 +9,7 @@ import click
 import opta.sentry  # noqa: F401 This leads to initialization of sentry sdk
 from opta.amplitude import amplitude_client
 from opta.commands.apply import apply
+from opta.commands.cleanup import cleanup
 from opta.commands.deploy import deploy
 from opta.commands.destroy import destroy
 from opta.commands.events import events
@@ -67,6 +68,7 @@ def _cleanup() -> None:
 
 # Add commands
 cli.add_command(apply)
+cli.add_command(cleanup)
 cli.add_command(deploy)
 cli.add_command(destroy)
 cli.add_command(rollback)

--- a/opta/commands/cleanup.py
+++ b/opta/commands/cleanup.py
@@ -1,0 +1,20 @@
+import os
+import shutil
+
+import click
+
+TERRAFORM_DIR = ".terraform"
+TERRAFORM_LOCK = ".terraform.lock.hcl"
+
+
+@click.command(hidden=True)
+def cleanup() -> None:
+    """Additionally cleans up all generated terraform files"""
+    if os.path.isdir(TERRAFORM_DIR):
+        shutil.rmtree(TERRAFORM_DIR)
+
+    if os.path.exists(TERRAFORM_LOCK):
+        os.remove(TERRAFORM_LOCK)
+
+    # Note that opta.cli._cleanup() cleans up a few other
+    # opta generated files.


### PR DESCRIPTION
when developing/testing, I often find myself manually deleting all the terraform related files with `rm -r .terraform`, `rm .terraform.lock`, to avoid any state being passed over from a previous `opta apply run`. This hidden cleanup command makes it more conveinent for me to run `opta cleanup` to clean up _everything_.

Note that we already do _some_ cleanup after every opta command anyways, so this apply command won't duplicate the logic.
https://github.com/run-x/runxc/blob/214e99eaecf254102c889fe4d316b1affca94f1a/opta/cli.py#L102