### PR TITLE
Pin linkerd version to working

### DIFF
--- a/config/tf_modules/k8s-base/linkerd.tf
+++ b/config/tf_modules/k8s-base/linkerd.tf
@@ -58,6 +58,9 @@ resource "helm_release" "linkerd" {
   chart = "linkerd2"
   name = "linkerd"
   repository = "https://helm.linkerd.io/stable"
+  # Version 2.10.0 is not backwards compatible.
+  version = "2.9.4"
+
   set {
     name  = "global.identityTrustAnchorsPEM"
     value = tls_self_signed_cert.trustanchor_cert.cert_pem


### PR DESCRIPTION
version 2.10.0 is breaking, and if we need to upgrade to it, we need to update the chart field from
`global.identityTrustAnchorsPEM` -> `identityTrustAnchorsPEM`

for now, pin to previous version to prevent necessary redeployment of pods