### PR TITLE
Fix terraform for some aws regions

### DIFF
--- a/config/tf_modules/aws-base/private_subnet.tf
+++ b/config/tf_modules/aws-base/private_subnet.tf
@@ -1,5 +1,5 @@
 resource "aws_subnet" "private_subnets" {
-  count                = length(var.private_ipv4_cidr_blocks)
+  count                = local.private_subnet_count
   cidr_block           = var.private_ipv4_cidr_blocks[count.index]
   availability_zone_id = data.aws_availability_zones.current.zone_ids[count.index]
   vpc_id               = aws_vpc.vpc.id
@@ -13,7 +13,7 @@ resource "aws_subnet" "private_subnets" {
 }
 
 resource "aws_route_table" "private_route_tables" {
-  count  = length(var.private_ipv4_cidr_blocks)
+  count  = local.private_subnet_count
   vpc_id = aws_vpc.vpc.id
   tags = {
     Name      = "opta-${var.layer_name}-private-${data.aws_availability_zones.current.zone_ids[count.index]}"
@@ -22,13 +22,13 @@ resource "aws_route_table" "private_route_tables" {
 }
 
 resource "aws_route_table_association" "private_associations" {
-  count          = length(var.private_ipv4_cidr_blocks)
+  count          = local.private_subnet_count
   route_table_id = aws_route_table.private_route_tables[count.index].id
   subnet_id      = aws_subnet.private_subnets[count.index].id
 }
 
 resource "aws_eip" "nat_eips" {
-  count = length(var.private_ipv4_cidr_blocks)
+  count = local.private_subnet_count
   vpc   = true
   tags = {
     Name      = "opta-${var.layer_name}-nat-ip-${data.aws_availability_zones.current.zone_ids[count.index]}"
@@ -37,7 +37,7 @@ resource "aws_eip" "nat_eips" {
 }
 
 resource "aws_nat_gateway" "nat_gateways" {
-  count         = length(var.private_ipv4_cidr_blocks)
+  count         = local.private_subnet_count
   allocation_id = aws_eip.nat_eips[count.index].id
   subnet_id     = aws_subnet.public_subnets[count.index].id
   tags = {
@@ -47,7 +47,7 @@ resource "aws_nat_gateway" "nat_gateways" {
 }
 
 resource "aws_route" "nat_routes" {
-  count                  = length(var.private_ipv4_cidr_blocks)
+  count                  = local.private_subnet_count
   route_table_id         = aws_route_table.private_route_tables[count.index].id
   destination_cidr_block = "0.0.0.0/0"
   nat_gateway_id         = aws_nat_gateway.nat_gateways[count.index].id

--- a/config/tf_modules/aws-base/public_subnet.tf
+++ b/config/tf_modules/aws-base/public_subnet.tf
@@ -1,5 +1,5 @@
 resource "aws_subnet" "public_subnets" {
-  count                   = length(var.public_ipv4_cidr_blocks)
+  count                   = local.public_subnet_count
   cidr_block              = var.public_ipv4_cidr_blocks[count.index]
   availability_zone_id    = data.aws_availability_zones.current.zone_ids[count.index]
   vpc_id                  = aws_vpc.vpc.id
@@ -31,14 +31,14 @@ resource "aws_internet_gateway" "igw" {
 }
 
 resource "aws_route" "igw_routes" {
-  count                  = length(var.public_ipv4_cidr_blocks)
+  count                  = local.public_subnet_count
   route_table_id         = aws_route_table.public_route_table.id
   destination_cidr_block = "0.0.0.0/0"
   gateway_id             = aws_internet_gateway.igw.id
 }
 
 resource "aws_route_table_association" "public_association" {
-  count          = length(var.public_ipv4_cidr_blocks)
+  count          = local.public_subnet_count
   route_table_id = aws_route_table.public_route_table.id
   subnet_id      = aws_subnet.public_subnets[count.index].id
 }

--- a/config/tf_modules/aws-base/variables.tf
+++ b/config/tf_modules/aws-base/variables.tf
@@ -41,3 +41,14 @@ variable "public_ipv4_cidr_blocks" {
     "10.0.16.0/21"
   ]
 }
+
+locals {
+  public_subnet_count = min(
+    length(var.public_ipv4_cidr_blocks),
+    length(data.aws_availability_zones.current.zone_ids)
+  )
+  private_subnet_count = min(
+    length(var.private_ipv4_cidr_blocks),
+    length(data.aws_availability_zones.current.zone_ids)
+  )
+}


### PR DESCRIPTION
some regions, like us-west-1, only have 2 AZs instead of 3 (which is the number of subnet CIDR blocks we configure by default:
```
default     = [
    "10.0.0.0/21",
    "10.0.8.0/21",
    "10.0.16.0/21"
  ]
```
this results in the following error when setting up the aws-base module in the env layer:
![image](https://user-images.githubusercontent.com/15851351/111971479-01989f00-8ac2-11eb-9e48-cbb965e323d0.png)
