### PR TITLE
Add exponential backoff when trying to configure kubectl

### DIFF
--- a/opta/utils.py
+++ b/opta/utils.py
@@ -6,7 +6,8 @@ from logging.handlers import QueueHandler, QueueListener
 from queue import Queue
 from shutil import which
 from textwrap import dedent
-from typing import Any, Dict, List, Tuple
+from time import sleep
+from typing import Any, Dict, Generator, List, Tuple
 
 from opta.constants import VERSION
 from opta.datadog_logging import DatadogLogHandler
@@ -139,3 +140,14 @@ def all_substrings(string: str, delimiter: str = "") -> List[str]:
 
     add_words(0, 1)
     return all_substrings
+
+
+# Exponential backoff for some external requests that may not work 100% on the
+# first try.
+def exp_backoff(num_tries: int = 3) -> Generator:
+    seconds = 2
+
+    for _ in range(num_tries):
+        yield
+        sleep(seconds)
+        seconds *= seconds

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,20 @@
+from pytest_mock import MockFixture
+
+from opta.utils import exp_backoff
+
+
+def test_exp_backoff(mocker: MockFixture) -> None:
+    # Sleep should be exponential for each iteration
+    mocked_sleep = mocker.patch("opta.utils.sleep")
+    retries = 3
+    for _ in exp_backoff(num_tries=retries):
+        pass
+    raw_call_args = mocked_sleep.call_args_list
+    sleep_param_history = [arg[0][0] for arg in raw_call_args]
+    assert sleep_param_history == [2, 4, 16]
+
+    # Sleep should not be called if body succeeded and exited.
+    mocked_sleep = mocker.patch("opta.utils.sleep")
+    for _ in exp_backoff(num_tries=retries):
+        break
+    assert mocked_sleep.call_count == 0


### PR DESCRIPTION
When setting up the opta env, I noticed that if the datadog module was right after the k8s-base module, there was a chance that the cluster may not be in a ready state yet. The datadog module requires configuring kubectl to point to the cluster, which would then fail.
This PR adds exponential back off to the above step to avoid the race condition