### PR TITLE
Add reconfigure flag to prevent copying to s3 state

### DIFF
--- a/opta/commands/destroy.py
+++ b/opta/commands/destroy.py
@@ -50,7 +50,7 @@ def destroy(config: str, env: Optional[str], auto_approve: bool) -> None:
 
     for layer in destroy_order:
         gen_all(layer)
-        Terraform.init("-reconfigure")
+        Terraform.init()
         Terraform.destroy_all(layer, *tf_flags)
 
 

--- a/opta/core/terraform.py
+++ b/opta/core/terraform.py
@@ -30,6 +30,10 @@ class Terraform:
 
     @classmethod
     def init(cls, *tf_flags: str) -> None:
+        # When prompted to copy local terraform state to s3 or gcp, say no by default.
+        if "-force-copy" not in tf_flags and "-reconfigure" not in tf_flags:
+            tf_flags = ("-reconfigure", *tf_flags)
+
         nice_run(["terraform", "init", *tf_flags], check=True)
 
     # Get outputs of the current terraform state


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/15851351/113393724-4d660680-9354-11eb-9dd7-a6fb74ed1284.png)

sometimes we get this prompt and we should say no to copying local state to s3/gcp. Because s3/gcp state should be the source of truth and local state may be stale, or belong to a different terraform state altogether.

this is based on my experience with the reconfigure flag, I don't really understand the docs here.
https://www.terraform.io/docs/cli/commands/init.html#backend-initialization