### PR TITLE
Don't cleanup local state in destroy command

### DIFF
--- a/opta/commands/destroy.py
+++ b/opta/commands/destroy.py
@@ -7,7 +7,6 @@ from google.cloud import storage
 from google.cloud.exceptions import NotFound
 
 from opta.amplitude import amplitude_client
-from opta.cleanup_files import cleanup_files
 from opta.core.gcp import GCP
 from opta.core.generator import gen_all
 from opta.core.terraform import Terraform
@@ -29,8 +28,6 @@ from opta.utils import fmt_msg, logger
 def destroy(config: str, env: Optional[str], auto_approve: bool) -> None:
     """Destroy all opta resources from the current config"""
     amplitude_client.send_event(amplitude_client.DESTROY_EVENT)
-    logger.info("Cleaning up local state files")
-    cleanup_files()
     layer = Layer.load_from_yaml(config, env)
     if not Terraform.verify_storage(layer):
         logger.info(


### PR DESCRIPTION
we ran into a problem yesterday where local state seemed to be persisting in @juandiegopalomino's environment. It appears that it was because the `OPTA_DEBUG` flag was set.

Keeping local state around leads to all kinds of issues, which is why we remove it by default. Customers should never know about or set the OPTA_DEBUG=true flag.

Removing these lines from destroy, as they are irrelevant.