### PR TITLE
Cleanup local state files before all opta commands

### DIFF
--- a/opta/cli.py
+++ b/opta/cli.py
@@ -70,6 +70,11 @@ cli.add_command(events)
 
 if __name__ == "__main__":
     try:
+        # In case OPTA_DEBUG is set, local state files may not be cleaned up
+        # after the command.
+        # However, we should still clean them up before the next command, or
+        # else it may interfere with it.
+        cleanup_files()
         cli()
     except CalledProcessError as e:
         logger.exception(e)


### PR DESCRIPTION
Chatted with JD, and decided that while OPTA_DEBUG is useful to keep around old state, for debugging purposes, we should clean up that state before the start of any new opta commands.
This prevents local state from interfering/breaking any opta commands, such as apply, destroy, deploy, etc.