### PR TITLE
fix deploy action CI (point to correct branch)

### DIFF
--- a/.github/workflows/create-and-destroy-w-github-action.yml
+++ b/.github/workflows/create-and-destroy-w-github-action.yml
@@ -30,7 +30,6 @@ jobs:
         with:
           repository: "run-x/deploy-action"
           path: "deploy-action"
-          ref: kjin/deploy-action-ci
           ssh-key: ${{ secrets.SSH_KEY }}
       - name: Setup ssh
         uses: webfactory/ssh-agent@v0.4.1


### PR DESCRIPTION
the CI was still checking out my old branch from when I was testing. It should check out the default, "main", instead