### PR TITLE
Retry tailing pod logs more times (in case it takes a bit more time for them to be ready

### DIFF
--- a/opta/core/kubernetes.py
+++ b/opta/core/kubernetes.py
@@ -236,7 +236,7 @@ def tail_pod_log(
                     f"{fg(color_idx)}Server {pod.metadata.name} has been terminated{attr(0)}"
                 )
                 return
-            elif retry_count < 5:
+            elif retry_count < 10:
                 print(
                     f"{fg(color_idx)}Couldn't get logs, waiting a bit and retrying{attr(0)}"
                 )


### PR DESCRIPTION
a few times when I ran the deployment, I didn't get pod logs at all. Unfortunately I didn't save the full logs, but I'm guessing it was because the retries were exhausted, the pods took a bit longer to start. Increasing retries here