### PR TITLE
Retry fetching pod logs on all exceptions

### DIFF
--- a/opta/core/kubernetes.py
+++ b/opta/core/kubernetes.py
@@ -230,15 +230,15 @@ def tail_pod_log(
                 since_seconds=seconds,
             ):
                 print(f"{fg(color_idx)}{pod.metadata.name} {logline}{attr(0)}")
-        except ApiException as e:
-            if e.status == 404:
-                print(
-                    f"{fg(color_idx)}Server {pod.metadata.name} has been terminated{attr(0)}"
-                )
-            else:
-                raise
         except Exception as e:
-            if retry_count < 10:
+            if type(e) == ApiException:
+                if e.status == 404:  # type: ignore
+                    print(
+                        f"{fg(color_idx)}Server {pod.metadata.name} has been terminated{attr(0)}"
+                    )
+                    return
+
+            if retry_count < 5:
                 print(
                     f"{fg(color_idx)}Couldn't get logs, waiting a bit and retrying{attr(0)}"
                 )


### PR DESCRIPTION
I found another possible reason why I did not get pod logs earlier today, we only retry fetching pod logs on `ApiExceptions`, but I guess there are some network errors that aren't included, such as the one I just ran into: `Response is not chunked. Header 'transfer-encoding: chunked' is missing.`

We should retry generally on `Exceptions`, to catch the various network/io/unexpected exceptions that may happen.

(As you can see in the screenshot below, no retries ever happened here, or else there would be the message: `Couldn't get logs, waiting a bit and retrying`)
![image](https://user-images.githubusercontent.com/15851351/113559229-3e828c80-95be-11eb-9539-2ea676770dcc.png)
