### PR TITLE
use github action, not script in github action

### DIFF
--- a/.github/workflows/create-and-destroy-w-github-action.yml
+++ b/.github/workflows/create-and-destroy-w-github-action.yml
@@ -4,12 +4,7 @@
 # to ensure it still works.
 name: Test Create and Destroy with Deploy Action
 
-# on: workflow_dispatch
-on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
+on: workflow_dispatch
 
 jobs:
   create-and-destroy:


### PR DESCRIPTION
So the flow is, we cut the release in `deploy-action`, and the publishing of that release triggers this workflow, which will build a test-service image and attempt to deploy it using the latest `action.yaml` on the`master` branch of the `deploy-action` repo (not necessarily the release if there was a new commit between cutting the release and this CI).