### PR TITLE
GCP fixes

### DIFF
--- a/config/registry.yaml
+++ b/config/registry.yaml
@@ -330,6 +330,7 @@ modules:
       gke_channel: optional
       vpc_self_link: str
       private_subnet_self_link: str
+      node_zone_names: optional
     outputs:
       k8s_endpoint:
         export: true
@@ -366,6 +367,7 @@ modules:
       hosted_zone_name: optional
       cert_self_link: optional
       delegated: optional
+      zone_names: optional
     outputs: {}
   gcp-postgres:
     location: gcp-postgres

--- a/config/tf_modules/gcp-gke/default_node_group.tf
+++ b/config/tf_modules/gcp-gke/default_node_group.tf
@@ -26,7 +26,7 @@ resource "google_container_node_pool" "default" {
     ]
 
     workload_metadata_config {
-      node_metadata = "SECURE"
+      node_metadata = "GKE_METADATA_SERVER"
     }
     labels = {
       node_pool_name = "opta-${var.layer_name}-default"

--- a/config/tf_modules/gcp-gke/gke.tf
+++ b/config/tf_modules/gcp-gke/gke.tf
@@ -13,6 +13,7 @@
 resource "google_container_cluster" "primary" {
   name     = "opta-${var.layer_name}"
   location = data.google_client_config.current.region
+  node_locations = var.node_zone_names
 
   # We can't create a cluster with no node pool defined, but we want to only use
   # separately managed node pools. So we create the smallest possible default

--- a/config/tf_modules/gcp-gke/iam.tf
+++ b/config/tf_modules/gcp-gke/iam.tf
@@ -1,5 +1,5 @@
 resource "random_string" "node_group_hash" {
-  length = 8
+  length = 4
   special = false
   lower = true
   upper = false

--- a/config/tf_modules/gcp-gke/variables.tf
+++ b/config/tf_modules/gcp-gke/variables.tf
@@ -20,6 +20,10 @@ variable "gke_channel" {
   default = "REGULAR"
 }
 
+variable "node_zone_names" {
+  type = list(string)
+}
+
 data "google_secret_manager_secret_version" "kms_suffix" {
   secret = "opta-${var.layer_name}-kms-suffix"
 }

--- a/config/tf_modules/gcp-k8s-base/load_balancer.tf
+++ b/config/tf_modules/gcp-k8s-base/load_balancer.tf
@@ -10,12 +10,11 @@ resource "google_compute_health_check" "healthcheck" {
   }
 }
 
-data "google_compute_zones" "zones" {}
 
 data "google_compute_network_endpoint_group" "http" {
-  count = length(data.google_compute_zones.zones.names)
+  count = length(var.zone_names)
   name = "opta-${var.layer_name}-http"
-  zone = data.google_compute_zones.zones.names[count.index]
+  zone = var.zone_names[count.index]
   depends_on = [
     helm_release.ingress-nginx
   ]
@@ -23,9 +22,9 @@ data "google_compute_network_endpoint_group" "http" {
 
 
 data "google_compute_network_endpoint_group" "https" {
-  count = length(data.google_compute_zones.zones.names)
+  count = length(var.zone_names)
   name = "opta-${var.layer_name}-https"
-  zone = data.google_compute_zones.zones.names[count.index]
+  zone = var.zone_names[count.index]
   depends_on = [
     helm_release.ingress-nginx
   ]

--- a/config/tf_modules/gcp-k8s-base/variables.tf
+++ b/config/tf_modules/gcp-k8s-base/variables.tf
@@ -3,7 +3,7 @@ locals {
   container_ports = var.delegated ? { http: 80, https: 443 } : { http: 80, https: 443 }
   config = { ssl-redirect: false }
   annotations = var.delegated? "{\"exposed_ports\": {\"80\":{\"name\": \"opta-${var.layer_name}-http\"}, \"443\":{\"name\": \"opta-${var.layer_name}-https\"}}}" : "{\"exposed_ports\": {\"80\":{\"name\": \"opta-${var.layer_name}-http\"}}}"
-  negs = var.delegated ? compact(concat(data.google_compute_network_endpoint_group.http.*.id, data.google_compute_network_endpoint_group.https.*.id))  : compact(data.google_compute_network_endpoint_group.http.*.id)
+  negs = var.delegated ? concat(data.google_compute_network_endpoint_group.http.*.id, data.google_compute_network_endpoint_group.https.*.id)  : data.google_compute_network_endpoint_group.http.*.id
 }
 
 data "google_client_config" "current" {}
@@ -49,4 +49,9 @@ variable "cert_self_link" {
 variable "hosted_zone_name" {
   type = string
   default = null
+}
+
+variable "zone_names" {
+  type = list(string)
+  default = []
 }

--- a/examples/gcp/env/opta.yml
+++ b/examples/gcp/env/opta.yml
@@ -1,16 +1,16 @@
-name: jd-gcp-test-1
+name: jd-gcp-test-1-blah
 org_name: jd-opta
 providers:
   google:
     region: us-central1
-    project: jds-throwaway-1
+    project: jds-throwaway-1-310508
 modules:
   - type: gcp-base
   - type: gcp-dns
     domain: gcp-staging-1.runx.dev
     subdomains:
       - jd
-    delegated: true
+    delegated: false
   - type: gcp-gke
     max_nodes: 6
   - type: gcp-k8s-base

--- a/opta/module_processors/gcp_gke.py
+++ b/opta/module_processors/gcp_gke.py
@@ -1,5 +1,6 @@
 from typing import TYPE_CHECKING
 
+from opta.core.gcp import GCP
 from opta.exceptions import UserErrors
 from opta.module_processors.base import ModuleProcessor
 
@@ -28,4 +29,5 @@ class GcpGkeProcessor(ModuleProcessor):
         self.module.data[
             "private_subnet_self_link"
         ] = f"${{{{module.{gcp_base_module.name}.private_subnet_self_link}}}}"
+        self.module.data["node_zone_names"] = GCP(self.layer).get_current_zones()
         super(GcpGkeProcessor, self).process(module_idx)

--- a/opta/module_processors/gcp_k8s_base.py
+++ b/opta/module_processors/gcp_k8s_base.py
@@ -1,5 +1,6 @@
 from typing import TYPE_CHECKING
 
+from opta.core.gcp import GCP
 from opta.module_processors.base import GcpK8sModuleProcessor
 
 if TYPE_CHECKING:
@@ -31,4 +32,5 @@ class GcpK8sBaseProcessor(GcpK8sModuleProcessor):
             self.module.data[
                 "delegated"
             ] = f"${{{{module.{gcp_dns_module.name}.delegated}}}}"
+        self.module.data["zone_names"] = GCP(self.layer).get_current_zones()
         super(GcpK8sBaseProcessor, self).process(module_idx)


### PR DESCRIPTION
1. Fix the backend_service network endpoint group issue by passing in azs for gke creation and neg searching
2. Better error message if gcp bucket temporarily unavailable b/c the name is retained by gcp for 30 days after its destruction
3. Fixing gke metadata server issue