### PR TITLE
Fix opta when no outputs in service layer

### DIFF
--- a/opta/module.py
+++ b/opta/module.py
@@ -66,6 +66,12 @@ class Module:
                     )
         if depends_on is not None:
             module_blk["module"][self.name]["depends_on"] = depends_on
+
+        # If there are no outputs, don't set the output key. Terraform doesn't like an
+        # empty output block.
+        if module_blk["output"] == {}:
+            del module_blk["output"]
+
         return module_blk
 
     # Generate an override file in the module, that adds extra tags to every resource.


### PR DESCRIPTION
Currently when an opta config doesn't have any module outputs, it breaks with the following terraform error:
![image](https://user-images.githubusercontent.com/15851351/114519715-ea9b2780-9bfd-11eb-8df5-83c8007a6c33.png)
