### PR TITLE
Continue opta command even if GCP credentials cant be refreshed

### DIFF
--- a/opta/core/gcp.py
+++ b/opta/core/gcp.py
@@ -39,6 +39,8 @@ class GCP:
         try:
             # Refresh credentials to get new access token
             cls.credentials.refresh(google.auth.transport.requests.Request())
+        # TODO: Check if this error only occurs for service accounts, and if so, only
+        # catch it for service accounts instead of catch-all.
         except RefreshError:
             logger.info(
                 fmt_msg(


### PR DESCRIPTION
I created a (CI/CD) service account which I gave both `Owner and Editor` permissions. Whenever I run opta with it, I get the following error:
![image](https://user-images.githubusercontent.com/15851351/114540448-c269f380-9c12-11eb-932e-9ce124d0526d.png)

The culprit is this line:
https://github.com/run-x/runxc/blob/722dec36cdbeedc2999efc22993650b6dd449a45/opta/core/gcp.py#L40
It runs fine when I use my credentials from `gcloud auth application-default login`, but it raises the above exception when I use credentials from my service account, set by `export GOOGLE_APPLICATION_CREDENTIALS=<path>`

From the docs, it sounds like credentials.refresh() is a "must-run" command, but this doesn't apply to service accounts? idk
https://google-auth.readthedocs.io/en/latest/reference/google.auth.credentials.html