### PR TITLE
Fixed the weird event message about connection refused

### DIFF
--- a/opta/core/kubernetes.py
+++ b/opta/core/kubernetes.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, List, Optional, Set, Tuple
 
 import pytz
 from colored import attr, fg
-from kubernetes.client import ApiException, CoreV1Api, V1Event, V1Pod
+from kubernetes.client import ApiException, CoreV1Api, V1Event, V1ObjectReference, V1Pod
 from kubernetes.config import load_kube_config
 from kubernetes.watch import Watch
 
@@ -276,7 +276,7 @@ def tail_namespace_events(
         print(
             f"{fg(color_idx)}{event.last_timestamp} Namespace {layer.name} event: {event.message}{attr(0)}"
         )
-
+    deleted_pods = set()
     while True:
         try:
             for stream_obj in watch.stream(
@@ -284,6 +284,15 @@ def tail_namespace_events(
             ):
                 event = stream_obj["object"]
                 if event.last_timestamp > start_time:
+                    if "Deleted pod:" in event.message:
+                        deleted_pods.add(event.message.split(" ")[-1])
+                    involved_object: Optional[V1ObjectReference] = event.involved_object
+                    if (
+                        involved_object is not None
+                        and involved_object.kind == "Pod"
+                        and involved_object.name in deleted_pods
+                    ):
+                        continue
                     print(
                         f"{fg(color_idx)}{event.last_timestamp} Namespace {layer.name} event: {event.message}{attr(0)}"
                     )


### PR DESCRIPTION
The reason we are having this is because during an update, when the old version is being replaced and the old containers are being killed, they go out guns blazing with a final event from the system saying that they (obviously) failed their health check. We won't show those anymore as with this change we ignore events for pods that have been deleted