### PR TITLE
refactor fetching state and outputs

### DIFF
--- a/opta/cleanup_files.py
+++ b/opta/cleanup_files.py
@@ -20,5 +20,6 @@ def cleanup_files() -> None:
         shutil.rmtree(TF_DIR)
 
     for f in os.listdir("."):
-        if os.path.isfile(f) and f.startswith("tmp.opta."):
-            os.remove(f)
+        if os.path.isfile(f):
+            if f.startswith("tmp.opta.") or f.endswith("terraform.tfstate"):
+                os.remove(f)

--- a/opta/core/terraform.py
+++ b/opta/core/terraform.py
@@ -545,7 +545,12 @@ def get_terraform_outputs(layer: "Layer") -> dict:
 
 
 def fetch_terraform_state_resources(layer: "Layer") -> dict:
-    Terraform.download_state(layer)
+    success = Terraform.download_state(layer)
+    if not success:
+        raise UserErrors(
+            "Could not fetch remote terraform state, assuming no resources exist yet."
+        )
+
     state = Terraform.get_state(layer)
 
     resources = state.get("resources", [])


### PR DESCRIPTION
This PR allows you to fetch and read parent state.

Currently it's not really feasible, bc state is always downloaded to `terraform.tfstate`. Downloading parent state would override the current layer state (if it exists).

This PR moves the downloaded state to be `{layer_name}.terraform.tfstate` to avoid the collision.