### PR TITLE
Allow public_uri:all

### DIFF
--- a/config/tf_modules/gcp-k8s-service/k8s-service/templates/ingress.yaml
+++ b/config/tf_modules/gcp-k8s-service/k8s-service/templates/ingress.yaml
@@ -19,7 +19,9 @@ metadata:
     {{- end }}
 spec:
   rules:
-    - host: {{ .Values.domain }}
+    - {{ if not (eq .Values.domain "all" ) }}
+      host: {{ .Values.domain }}
+      {{ end }}
       http:
         paths:
           - path: {{ .Values.pathPrefix }}{{ if not (eq .Values.pathPrefix "/") }}(/|$)(.*){{ end }}

--- a/config/tf_modules/k8s-service/k8s-service/templates/ingress.yaml
+++ b/config/tf_modules/k8s-service/k8s-service/templates/ingress.yaml
@@ -19,7 +19,9 @@ metadata:
     {{- end }}
 spec:
   rules:
-    - host: {{ .Values.domain }}
+    - {{ if not (eq .Values.domain "all" ) }}
+      host: {{ .Values.domain }}
+      {{ end }}
       http:
         paths:
           - path: {{ .Values.pathPrefix }}{{ if not (eq .Values.pathPrefix "/") }}(/|$)(.*){{ end }}


### PR DESCRIPTION
## Description
- `public_uri:all` routes all traffic - irrespective of the host header. I think this will be very useful during demos - as we'd be able to access the app with just the ip

## Test plan
- Run it with and without `all` and make sure it works as expected.