### PR TITLE
Fix gcp test service ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,8 @@ jobs:
           python ../opta/cli.py apply --config opta-gcp.yml --env staging --test
 
   deploy_test_service:
-    # if: ${{ github.ref == 'refs/heads/main' }}
+    if: ${{ github.ref == 'refs/heads/main' }}
+    needs: test_cli
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
currently the `deploy_test_service` fails because it is running concurrently with the `test_cli` job. They both try to acquire the same terraform state lock, so only one of them succeeds (the earlier one).

Also this `deploy_test_service` should only run on the main branch, and I guess I forgot to uncomment the `if`