### PR TITLE
Use image tag for non-auto deploys

### DIFF
--- a/config/tf_modules/gcp-k8s-service/main.tf
+++ b/config/tf_modules/gcp-k8s-service/main.tf
@@ -29,7 +29,7 @@ resource "helm_release" "k8s-service" {
         memory: "${var.resource_request["memory"]}Mi"
       },
       deployPods: (var.image != "AUTO") || (var.tag != null),
-      image: var.image == "AUTO" ? (var.tag == null ? "": "${data.google_container_registry_repository.root.repository_url}/${var.layer_name}/${var.module_name}:${var.tag}") : var.image
+      image: var.image == "AUTO" ? (var.tag == null ? "": "${data.google_container_registry_repository.root.repository_url}/${var.layer_name}/${var.module_name}:${var.tag}") : (var.tag == null ? var.image : "${var.image}:${var.tag}")
       version: var.tag == null ? "latest" : var.tag
       livenessProbePath: var.healthcheck_path == null || var.liveness_probe_path != "/healthcheck"? var.liveness_probe_path : var.healthcheck_path,
       readinessProbePath: var.healthcheck_path == null || var.readiness_probe_path != "/healthcheck"? var.readiness_probe_path : var.healthcheck_path,

--- a/config/tf_modules/k8s-service/main.tf
+++ b/config/tf_modules/k8s-service/main.tf
@@ -29,7 +29,7 @@ resource "helm_release" "k8s-service" {
         memory: "${var.resource_request["memory"]}Mi"
       },
       deployPods: (var.image != "AUTO") || (var.tag != null),
-      image: var.image == "AUTO" ? (var.tag == null ? "": "${aws_ecr_repository.repo[0].repository_url}:${var.tag}") : var.image
+      image: var.image == "AUTO" ? (var.tag == null ? "": "${aws_ecr_repository.repo[0].repository_url}:${var.tag}") : (var.tag == null ? var.image : "${var.image}:${var.tag}")
       version: var.tag == null ? "latest" : var.tag
       livenessProbePath: var.healthcheck_path == null || var.liveness_probe_path != "/healthcheck"? var.liveness_probe_path : var.healthcheck_path,
       readinessProbePath: var.healthcheck_path == null || var.readiness_probe_path != "/healthcheck"? var.readiness_probe_path : var.healthcheck_path,


### PR DESCRIPTION
# Description
- Pretty straightforward. The tag variable was already making it's way to terraform - so I just updated the helm var accordingly.

# Test plan
- [x] Test AWS deploy - with a docker hub repo and a image-tag flag - succeeds
- [x] Test AWS deploy - with a docker hub repo and no image-tag flag - uses latest and succeeds
- [x] Test AWS deploy - with a docker hub repo and image-tag in file - succeeds
- [x] Test AWS deploy - with AUTO - succeeds

- [x] Test GCP deploy - with a docker hub repo and a image-tag flag - succeeds
- [x] Test GCP deploy - with a docker hub repo and no image-tag flag - uses latest and succeeds
- [x] Test GCP deploy - with a docker hub repo and image-tag in file - succeeds
- [x] Test GCP deploy - with AUTO - succeeds