### PR TITLE
Fail opta push early if image repository doesnt exist yet

### DIFF
--- a/opta/commands/push.py
+++ b/opta/commands/push.py
@@ -164,8 +164,8 @@ def _raise_if_no_ecr_repo_exists(layer: "Layer") -> None:
             fmt_msg(
                 """
                 Cannot push image because there was no image repository found in the opta state.
-                ~Please make sure to create the opta environment first with *opta apply*.
-                ~See the following docs: https://docs.runx.dev/docs/getting-started/#environment-creation
+                ~Please make sure to create the opta service first with *opta apply*.
+                ~See the following docs: https://docs.runx.dev/docs/getting-started/#service-creation
                 """
             )
         )

--- a/opta/core/terraform.py
+++ b/opta/core/terraform.py
@@ -54,10 +54,13 @@ class Terraform:
     @classmethod
     def get_state(cls) -> dict:
         for state_file in ["./terraform.tfstate", "terraform.tfstate.backup"]:
-            with open(state_file, "r") as file:
-                raw_state = file.read().replace("\n", "")
-            if raw_state != "":
-                return json.loads(raw_state)
+            try:
+                with open(state_file, "r") as file:
+                    raw_state = file.read().replace("\n", "")
+                if raw_state != "":
+                    return json.loads(raw_state)
+            except Exception:
+                continue
         raise UserErrors("Terraform statefiles not found")
 
     @classmethod
@@ -583,7 +586,11 @@ def _fetch_parent_outputs(pull_state: bool = True) -> dict:
 
 def fetch_terraform_state_resources(layer: "Layer") -> dict:
     Terraform.download_state(layer)
-    state = Terraform.get_state()
+    try:
+        state = Terraform.get_state()
+    except Exception as err:
+        logger.error(err)
+        return {}
 
     resources = state.get("resources", [])
 

--- a/tests/commands/test_apply.py
+++ b/tests/commands/test_apply.py
@@ -7,8 +7,8 @@ from pytest_mock import MockFixture
 from opta.commands.apply import apply
 from opta.constants import TF_PLAN_PATH
 from opta.core.kubernetes import tail_module_log, tail_namespace_events
-from opta.layer import Layer
 from opta.module import Module
+from tests.utils import mocked_aws_layer
 
 
 @fixture
@@ -32,10 +32,8 @@ def basic_mocks(mocker: MockFixture) -> None:
 @fixture
 def mocked_layer(mocker: MockFixture) -> Any:
     mocked_layer_class = mocker.patch("opta.commands.apply.Layer")
-    mocked_layer = mocker.Mock(spec=Layer)
+    mocked_layer = mocked_aws_layer(mocker)
     mocked_layer.variables = {}
-    mocked_layer.name = "blah"
-    mocked_layer.cloud = "aws"
     mocked_layer.gen_providers = lambda x: {"provider": {"aws": {"region": "us-east-1"}}}
     mocked_layer_class.load_from_yaml.return_value = mocked_layer
 

--- a/tests/commands/test_inspect.py
+++ b/tests/commands/test_inspect.py
@@ -2,9 +2,9 @@ from click.testing import CliRunner
 from pytest_mock import MockFixture
 
 from opta.commands.inspect_cmd import inspect
-from opta.layer import Layer
 from opta.module import Module
 from opta.resource import Resource
+from tests.utils import mocked_aws_layer
 
 REGISTRY = {
     "modules": {
@@ -34,8 +34,7 @@ TERRAFORM_STATE = {
 def test_inspect(mocker: MockFixture) -> None:
     # Mock tf file generation
     mocked_layer_class = mocker.patch("opta.commands.inspect_cmd.Layer")
-    mocked_layer = mocker.Mock(spec=Layer)
-    mocked_layer.cloud = "aws"
+    mocked_layer = mocked_aws_layer(mocker)
     mocked_layer_class.load_from_yaml.return_value = mocked_layer
     mocker.patch("opta.commands.inspect_cmd.gen_all")
     # Mock that the terraform CLI tool exists.

--- a/tests/commands/test_kubectl.py
+++ b/tests/commands/test_kubectl.py
@@ -5,14 +5,13 @@ from click.testing import CliRunner
 from pytest_mock import MockFixture
 
 from opta.commands.kubectl import configure_kubectl
-from opta.layer import Layer
+from tests.utils import mocked_aws_layer
 
 
 def test_configure_kubectl(mocker: MockFixture) -> None:
     # Mock tf file generation
     mocked_layer_class = mocker.patch("opta.commands.kubectl.Layer")
-    mocked_layer = mocker.Mock(spec=Layer)
-    mocked_layer.cloud = "aws"
+    mocked_layer = mocked_aws_layer(mocker)
     mocked_layer_class.load_from_yaml.return_value = mocked_layer
     mocker.patch("opta.commands.kubectl.gen_all")
 

--- a/tests/commands/test_logs.py
+++ b/tests/commands/test_logs.py
@@ -2,15 +2,13 @@ from click.testing import CliRunner
 from pytest_mock import MockFixture
 
 from opta.commands.logs import logs
-from opta.layer import Layer
 from opta.module import Module
+from tests.utils import mocked_aws_layer
 
 
 def test_logs(mocker: MockFixture) -> None:
     mocked_layer_class = mocker.patch("opta.commands.logs.Layer")
-    mocked_layer = mocker.Mock(spec=Layer)
-    mocked_layer.name = "layer_name"
-    mocked_layer.cloud = "aws"
+    mocked_layer = mocked_aws_layer(mocker)
     mocked_layer_class.load_from_yaml.return_value = mocked_layer
     layer_gen_all = mocker.patch("opta.commands.logs.gen_all")
     configure_kubectl = mocker.patch("opta.commands.logs.configure_kubectl")

--- a/tests/commands/test_output.py
+++ b/tests/commands/test_output.py
@@ -4,7 +4,7 @@ from click.testing import CliRunner
 from pytest_mock import MockFixture
 
 from opta.commands.output import _load_extra_aws_outputs, _load_extra_gcp_outputs, output
-from opta.layer import Layer
+from tests.utils import mocked_aws_layer, mocked_gcp_layer
 
 TERRAFORM_STATE = {
     "resources": [
@@ -44,8 +44,7 @@ TERRAFORM_OUTPUTS = {
 def test_output_aws(mocker: MockFixture) -> None:
     mocker.patch("opta.cli.os.remove")
     mocked_layer_class = mocker.patch("opta.commands.output.Layer")
-    mocked_layer = mocker.Mock(spec=Layer)
-    mocked_layer.cloud = "aws"
+    mocked_layer = mocked_aws_layer(mocker)
     mocked_layer_class.load_from_yaml.return_value = mocked_layer
     mocker.patch("opta.commands.output.gen_all")
     mocker.patch("opta.core.terraform.Terraform.get_state", return_value=TERRAFORM_STATE)
@@ -71,8 +70,7 @@ def test_output_aws(mocker: MockFixture) -> None:
 def test_output_gcp(mocker: MockFixture) -> None:
     mocker.patch("opta.cli.os.remove")
     mocked_layer_class = mocker.patch("opta.commands.output.Layer")
-    mocked_layer = mocker.Mock(spec=Layer)
-    mocked_layer.cloud = "google"
+    mocked_layer = mocked_gcp_layer(mocker)
     mocked_layer_class.load_from_yaml.return_value = mocked_layer
     mocker.patch("opta.commands.output.gen_all")
     mocker.patch("opta.core.terraform.Terraform.get_state", return_value=TERRAFORM_STATE)
@@ -96,8 +94,7 @@ def test_output_gcp(mocker: MockFixture) -> None:
 
 
 def test_load_extra_aws_outputs(mocker: MockFixture) -> None:
-    mocked_layer = mocker.Mock(spec=Layer)
-    mocked_layer.cloud = "aws"
+    mocked_layer = mocked_aws_layer(mocker)
     mocked_layer.gen_providers.return_value = {"provider": {"aws": {"region": "blah"}}}
     mocked_root = mocker.Mock()
     mocked_layer.root.return_value = mocked_root

--- a/tests/commands/test_secret.py
+++ b/tests/commands/test_secret.py
@@ -8,16 +8,14 @@ from pytest_mock import MockFixture
 
 from opta.amplitude import AmplitudeClient, amplitude_client
 from opta.commands.secret import list_command, update, view
-from opta.layer import Layer
+from tests.utils import mocked_aws_layer
 
 
 class TestSecretManager:
     @fixture
     def mocked_layer(self, mocker: MockFixture) -> Any:
         mocked_load_layer = mocker.patch("opta.commands.secret.Layer.load_from_yaml")
-        mocked_layer = mocker.Mock(spec=Layer)
-        mocked_layer.name = "dummy_layer"
-        mocked_layer.cloud = "aws"
+        mocked_layer = mocked_aws_layer(mocker)
         mocked_load_layer.return_value = mocked_layer
         return mocked_load_layer
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,6 +1,10 @@
 import json
 from typing import Any, Callable, List
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, Mock
+
+from pytest_mock import MockFixture
+
+from opta.layer import Layer
 
 
 class MockedCmdJsonOut:
@@ -31,3 +35,17 @@ def mocked_function(
         return return_value
 
     return dummy_function
+
+
+def mocked_aws_layer(mocker: MockFixture) -> "Mock":
+    mocked_layer = mocker.Mock(spec=Layer)
+    mocked_layer.name = "dummy_layer"
+    mocked_layer.cloud = "aws"
+    return mocked_layer
+
+
+def mocked_gcp_layer(mocker: MockFixture) -> "Mock":
+    mocked_layer = mocker.Mock(spec=Layer)
+    mocked_layer.name = "dummy_layer"
+    mocked_layer.cloud = "google"
+    return mocked_layer


### PR DESCRIPTION
fyi that docker push can only be run in the service layer, and there is already a check for that.
If there is no ECR/GCR resource that exists yet, then docker push should fail early with a descriptive error message telling the user to run `opta apply` first.