### PR TITLE
Forgot to add a yaml.Loader to yaml.load call

### DIFF
--- a/opta/module_processors/k8s_base.py
+++ b/opta/module_processors/k8s_base.py
@@ -57,15 +57,15 @@ class K8sBaseProcessor(AWSK8sModuleProcessor):
         opta_arns_config_map: V1ConfigMap = v1.read_namespaced_config_map(
             "opta-arns", "default"
         )
-        admin_arns = yaml.load(opta_arns_config_map.data["adminArns"])
+        admin_arns = yaml.load(opta_arns_config_map.data["adminArns"], Loader=yaml.Loader)
         current_data = aws_auth_config_map.data
-        old_map_roles = yaml.load(current_data["mapRoles"])
+        old_map_roles = yaml.load(current_data["mapRoles"], Loader=yaml.Loader)
         new_map_roles = [
             old_map_role
             for old_map_role in old_map_roles
             if not old_map_role["username"].startswith("opta-managed")
         ]
-        old_map_users = yaml.load(current_data["mapUsers"])
+        old_map_users = yaml.load(current_data["mapUsers"], Loader=yaml.Loader)
         new_map_users = [
             old_map_user
             for old_map_user in old_map_users


### PR DESCRIPTION
It doesn't change the code behavior, but this stops annoying deprecation warnings