### PR TITLE
Fix bug in module source path computation

### DIFF
--- a/opta/module.py
+++ b/opta/module.py
@@ -115,8 +115,10 @@ class Module:
             ),
             os.getcwd(),
         )
-        # Note: This breaks should runxc ever be prefixed with "."
-        if "." != relative_path[0]:
+
+        # Terraform requires the module paths to be relative so add a ./ when
+        # that's not the output of os.path.relpath
+        if not (relative_path.startswith("./") or relative_path.startswith("../")):
             relative_path = f"./{relative_path}"
 
         return relative_path


### PR DESCRIPTION
# Description
If `cwd` is an ancestor of the opta installation dir (or source dir) then the relative path does not have `./` at the beginning.
This makes terraform think of it as a remote path and leads to an error.

We tried to solve it earlier by checking for the first char but that didn't account for the edge case where the dir name itself has a '.' (which happens when we install the opta binary).

The right solution here is to check for `./` and `../` explicitly.

# Test plan
- Build binary and put opta.yml in `~` then run `opta apply` and make sure you don't get errors.