### PR TITLE
Gave SQS queues and SNS topics separate KMS keys

### DIFF
--- a/config/registry.yaml
+++ b/config/registry.yaml
@@ -545,7 +545,6 @@ modules:
       env_name: str
       layer_name: str
       module_name: str
-      kms_key_id: str
       fifo: optional
       content_based_deduplication: optional
       delay_seconds: optional
@@ -567,7 +566,6 @@ modules:
       env_name: str
       layer_name: str
       module_name: str
-      kms_key_id: str
       fifo: optional
       content_based_deduplication: optional
       sqs_subscribers: optional

--- a/config/tf_modules/aws-sns/kms.tf
+++ b/config/tf_modules/aws-sns/kms.tf
@@ -1,0 +1,66 @@
+# Based off the following documents:
+# https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html#key-policy-example
+# https://docs.aws.amazon.com/autoscaling/ec2/userguide/key-policy-requirements-EBS-encryption.html
+data "aws_iam_policy_document" "kms_policy" {
+  statement {
+    sid    = "Enable IAM User/Role Permissions"
+    effect = "Allow"
+    principals {
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
+      type        = "AWS"
+    }
+    actions   = ["kms:*"]
+    resources = ["*"]
+  }
+
+  statement {
+    sid    = "Allow sns access"
+    effect = "Allow"
+    principals {
+      identifiers = ["sns.amazonaws.com"]
+      type        = "Service"
+    }
+    actions = [
+      "kms:Decrypt",
+      "kms:GenerateDataKey*"
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    sid    = "Allow events access"
+    effect = "Allow"
+    principals {
+      identifiers = ["events.amazonaws.com"]
+      type        = "Service"
+    }
+    actions = [
+      "kms:Decrypt",
+      "kms:GenerateDataKey*"
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    sid    = "Allow s3 access"
+    effect = "Allow"
+    principals {
+      identifiers = ["s3.amazonaws.com"]
+      type        = "Service"
+    }
+    actions = [
+      "kms:Decrypt",
+      "kms:GenerateDataKey*"
+    ]
+    resources = ["*"]
+  }
+}
+
+resource "aws_kms_key" "key" {
+  description = "SQS Key"
+  policy      = data.aws_iam_policy_document.kms_policy.json
+  tags = {
+    Name = "opta-${var.layer_name}"
+    terraform = "true"
+  }
+}

--- a/config/tf_modules/aws-sns/main.tf
+++ b/config/tf_modules/aws-sns/main.tf
@@ -1,6 +1,6 @@
 resource "aws_sns_topic" "topic" {
   name            = "${var.env_name}-${var.layer_name}-${var.module_name}"
-  kms_master_key_id = var.kms_key_id
+  kms_master_key_id = aws_kms_key.key.id
   fifo_topic = var.fifo
   content_based_deduplication = var.content_based_deduplication
   delivery_policy = <<EOF

--- a/config/tf_modules/aws-sns/outputs.tf
+++ b/config/tf_modules/aws-sns/outputs.tf
@@ -1,3 +1,7 @@
 output "topic_arn" {
   value = aws_sns_topic.topic.arn
 }
+
+output "kms_arn" {
+  value = aws_kms_key.key.arn
+}

--- a/config/tf_modules/aws-sns/variables.tf
+++ b/config/tf_modules/aws-sns/variables.tf
@@ -15,10 +15,6 @@ variable "module_name" {
   type = string
 }
 
-variable "kms_key_id" {
-  type = string
-}
-
 variable "fifo" {
   type = bool
   default = false

--- a/config/tf_modules/aws-sqs/kms.tf
+++ b/config/tf_modules/aws-sqs/kms.tf
@@ -1,0 +1,66 @@
+# Based off the following documents:
+# https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html#key-policy-example
+# https://docs.aws.amazon.com/autoscaling/ec2/userguide/key-policy-requirements-EBS-encryption.html
+data "aws_iam_policy_document" "kms_policy" {
+  statement {
+    sid    = "Enable IAM User/Role Permissions"
+    effect = "Allow"
+    principals {
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
+      type        = "AWS"
+    }
+    actions   = ["kms:*"]
+    resources = ["*"]
+  }
+
+  statement {
+    sid    = "Allow sns access"
+    effect = "Allow"
+    principals {
+      identifiers = ["sns.amazonaws.com"]
+      type        = "Service"
+    }
+    actions = [
+      "kms:Decrypt",
+      "kms:GenerateDataKey*"
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    sid    = "Allow events access"
+    effect = "Allow"
+    principals {
+      identifiers = ["events.amazonaws.com"]
+      type        = "Service"
+    }
+    actions = [
+      "kms:Decrypt",
+      "kms:GenerateDataKey*"
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    sid    = "Allow s3 access"
+    effect = "Allow"
+    principals {
+      identifiers = ["s3.amazonaws.com"]
+      type        = "Service"
+    }
+    actions = [
+      "kms:Decrypt",
+      "kms:GenerateDataKey*"
+    ]
+    resources = ["*"]
+  }
+}
+
+resource "aws_kms_key" "key" {
+  description = "SQS Key"
+  policy      = data.aws_iam_policy_document.kms_policy.json
+  tags = {
+    Name = "opta-${var.layer_name}"
+    terraform = "true"
+  }
+}

--- a/config/tf_modules/aws-sqs/main.tf
+++ b/config/tf_modules/aws-sqs/main.tf
@@ -1,6 +1,6 @@
 resource "aws_sqs_queue" "terraform_queue" {
   name                      = var.fifo? "${var.env_name}-${var.layer_name}-${var.module_name}.fifo" : "${var.env_name}-${var.layer_name}-${var.module_name}"
-  kms_master_key_id                 = var.kms_key_id
+  kms_master_key_id                 = aws_kms_key.key.id
   fifo_queue                  = var.fifo
   content_based_deduplication = var.content_based_deduplication
   delay_seconds             = var.delay_seconds

--- a/config/tf_modules/aws-sqs/outputs.tf
+++ b/config/tf_modules/aws-sqs/outputs.tf
@@ -9,3 +9,7 @@ output "queue_id" {
 output "queue_name" {
   value = aws_sqs_queue.terraform_queue.name
 }
+
+output "kms_arn" {
+  value = aws_kms_key.key.arn
+}

--- a/config/tf_modules/aws-sqs/variables.tf
+++ b/config/tf_modules/aws-sqs/variables.tf
@@ -15,10 +15,6 @@ variable "module_name" {
   type = string
 }
 
-variable "kms_key_id" {
-  type = string
-}
-
 variable "fifo" {
   type = bool
   default = false

--- a/opta/core/aws.py
+++ b/opta/core/aws.py
@@ -139,6 +139,24 @@ class AWS:
         }
 
     @staticmethod
+    def prepare_kms_write_keys_statements(kms_arns: List[str]) -> dict:
+        return {
+            "Sid": "KMSWrite",
+            "Action": ["kms:GenerateDataKey", "kms:Decrypt"],
+            "Effect": "Allow",
+            "Resource": [kms_arn for kms_arn in kms_arns],
+        }
+
+    @staticmethod
+    def prepare_kms_read_keys_statements(kms_arns: List[str]) -> dict:
+        return {
+            "Sid": "KMSRead",
+            "Action": ["kms:Decrypt"],
+            "Effect": "Allow",
+            "Resource": [kms_arn for kms_arn in kms_arns],
+        }
+
+    @staticmethod
     def delete_bucket(bucket_name: str) -> None:
         # Before a bucket can be deleted, all of the objects inside must be removed.
         bucket = boto3.resource("s3").Bucket(bucket_name)

--- a/opta/module_processors/aws_iam_user.py
+++ b/opta/module_processors/aws_iam_user.py
@@ -1,25 +1,19 @@
-from typing import TYPE_CHECKING, List
+from typing import TYPE_CHECKING
 
-from opta.core.aws import AWS
 from opta.exceptions import UserErrors
-from opta.module_processors.base import ModuleProcessor
+from opta.module_processors.base import AWSIamAssembler, ModuleProcessor
 
 if TYPE_CHECKING:
     from opta.layer import Layer
     from opta.module import Module
 
 
-class AwsIamUserProcessor(ModuleProcessor):
+class AwsIamUserProcessor(ModuleProcessor, AWSIamAssembler):
     def __init__(self, module: "Module", layer: "Layer"):
         if module.data["type"] != "aws-iam-user":
             raise Exception(
                 f"The module {module.name} was expected to be of type aws iam user"
             )
-        self.read_buckets: List[str] = []
-        self.write_buckets: List[str] = []
-        self.publish_queues: List[str] = []
-        self.subscribe_queues: List[str] = []
-        self.publish_topics: List[str] = []
         super(AwsIamUserProcessor, self).__init__(module, layer)
 
     def process(self, module_idx: int) -> None:
@@ -119,74 +113,8 @@ class AwsIamUserProcessor(ModuleProcessor):
                 raise Exception(
                     f"Unsupported module type for k8s service link: {module_type}"
                 )
-        if self.read_buckets:
-            iam_statements.append(
-                AWS.prepare_read_buckets_iam_statements(self.read_buckets)
-            )
-        if self.write_buckets:
-            iam_statements.append(
-                AWS.prepare_write_buckets_iam_statements(self.write_buckets)
-            )
-        if self.publish_queues:
-            iam_statements.append(
-                AWS.prepare_publish_queues_iam_statements(self.publish_queues)
-            )
-        if self.subscribe_queues:
-            iam_statements.append(
-                AWS.prepare_subscribe_queues_iam_statements(self.subscribe_queues)
-            )
-        if self.publish_topics:
-            iam_statements.append(
-                AWS.prepare_publish_sns_iam_statements(self.publish_topics)
-            )
+        iam_statements += self.prepare_iam_statements()
         self.module.data["iam_policy"] = {
             "Version": "2012-10-17",
             "Statement": iam_statements,
         }
-
-    def handle_sqs_link(
-        self, linked_module: "Module", link_permissions: List[str]
-    ) -> None:
-        # If not specified, bucket should get write permissions
-        if link_permissions is None or len(link_permissions) == 0:
-            link_permissions = ["publish", "subscribe"]
-        for permission in link_permissions:
-            if permission == "publish":
-                self.publish_queues.append(
-                    f"${{{{module.{linked_module.name}.queue_arn}}}}"
-                )
-            elif permission == "subscribe":
-                self.subscribe_queues.append(
-                    f"${{{{module.{linked_module.name}.queue_arn}}}}"
-                )
-            else:
-                raise Exception(f"Invalid permission {permission}")
-
-    def handle_sns_link(
-        self, linked_module: "Module", link_permissions: List[str]
-    ) -> None:
-        # If not specified, bucket should get write permissions
-        if link_permissions is None or len(link_permissions) == 0:
-            link_permissions = ["publish"]
-        for permission in link_permissions:
-            if permission == "publish":
-                self.publish_topics.append(
-                    f"${{{{module.{linked_module.name}.topic_arn}}}}"
-                )
-            else:
-                raise Exception(f"Invalid permission {permission}")
-
-    def handle_s3_link(
-        self, linked_module: "Module", link_permissions: List[str]
-    ) -> None:
-        bucket_name = linked_module.data["bucket_name"]
-        # If not specified, bucket should get write permissions
-        if link_permissions is None or len(link_permissions) == 0:
-            link_permissions = ["write"]
-        for permission in link_permissions:
-            if permission == "read":
-                self.read_buckets.append(bucket_name)
-            elif permission == "write":
-                self.write_buckets.append(bucket_name)
-            else:
-                raise Exception(f"Invalid permission {permission}")

--- a/opta/module_processors/aws_sns.py
+++ b/opta/module_processors/aws_sns.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING
 
-from opta.module_processors.base import ModuleProcessor, get_aws_base_module_refs
+from opta.module_processors.base import ModuleProcessor
 
 if TYPE_CHECKING:
     from opta.layer import Layer
@@ -16,6 +16,4 @@ class AwsSnsProcessor(ModuleProcessor):
         super(AwsSnsProcessor, self).__init__(module, layer)
 
     def process(self, module_idx: int) -> None:
-        aws_base_module_refs = get_aws_base_module_refs(self.layer)
-        self.module.data["kms_key_id"] = aws_base_module_refs["kms_account_key_id"]
         super(AwsSnsProcessor, self).process(module_idx)

--- a/opta/module_processors/aws_sqs.py
+++ b/opta/module_processors/aws_sqs.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING
 
-from opta.module_processors.base import ModuleProcessor, get_aws_base_module_refs
+from opta.module_processors.base import ModuleProcessor
 
 if TYPE_CHECKING:
     from opta.layer import Layer
@@ -16,6 +16,4 @@ class AwsSqsProcessor(ModuleProcessor):
         super(AwsSqsProcessor, self).__init__(module, layer)
 
     def process(self, module_idx: int) -> None:
-        aws_base_module_refs = get_aws_base_module_refs(self.layer)
-        self.module.data["kms_key_id"] = aws_base_module_refs["kms_account_key_id"]
         super(AwsSqsProcessor, self).process(module_idx)

--- a/tests/module_processors/test_aws_iam_role.py
+++ b/tests/module_processors/test_aws_iam_role.py
@@ -169,4 +169,16 @@ class TestAwsIamRoleProcessor:
                 "Resource": ["${{module.topic.topic_arn}}"],
                 "Sid": "PublishSns",
             },
+            {
+                "Action": ["kms:GenerateDataKey", "kms:Decrypt"],
+                "Effect": "Allow",
+                "Resource": ["${{module.queue.kms_arn}}", "${{module.topic.kms_arn}}"],
+                "Sid": "KMSWrite",
+            },
+            {
+                "Action": ["kms:Decrypt"],
+                "Effect": "Allow",
+                "Resource": ["${{module.queue.kms_arn}}"],
+                "Sid": "KMSRead",
+            },
         ]

--- a/tests/module_processors/test_aws_iam_user.py
+++ b/tests/module_processors/test_aws_iam_user.py
@@ -142,4 +142,16 @@ class TestAwsIamUserProcessor:
                 "Resource": ["${{module.topic.topic_arn}}"],
                 "Sid": "PublishSns",
             },
+            {
+                "Action": ["kms:GenerateDataKey", "kms:Decrypt"],
+                "Effect": "Allow",
+                "Resource": ["${{module.queue.kms_arn}}", "${{module.topic.kms_arn}}"],
+                "Sid": "KMSWrite",
+            },
+            {
+                "Action": ["kms:Decrypt"],
+                "Effect": "Allow",
+                "Resource": ["${{module.queue.kms_arn}}"],
+                "Sid": "KMSRead",
+            },
         ]

--- a/tests/module_processors/test_k8s_service.py
+++ b/tests/module_processors/test_k8s_service.py
@@ -99,6 +99,21 @@ class TestK8sServiceProcessor:
                     "Resource": ["${{module.topic.topic_arn}}"],
                     "Sid": "PublishSns",
                 },
+                {
+                    "Action": ["kms:GenerateDataKey", "kms:Decrypt"],
+                    "Effect": "Allow",
+                    "Resource": [
+                        "${{module.queue.kms_arn}}",
+                        "${{module.topic.kms_arn}}",
+                    ],
+                    "Sid": "KMSWrite",
+                },
+                {
+                    "Action": ["kms:Decrypt"],
+                    "Effect": "Allow",
+                    "Resource": ["${{module.queue.kms_arn}}"],
+                    "Sid": "KMSRead",
+                },
             ],
         }
 


### PR DESCRIPTION
This way we can give roles/users decrypt/encrypt access just for those keys instead of for the root one of the account we use for the top security stuff.