### PR TITLE
Version constraints inside provider configuration blocks are deprecated

### DIFF
--- a/config/registry.yaml
+++ b/config/registry.yaml
@@ -1,6 +1,10 @@
 backends:
   aws:
     terraform:
+      required_providers:
+        aws:
+          source: "hashicorp/aws"
+          version: "3.38.0"
       backend:
         s3:
           bucket: "{state_storage}"
@@ -9,6 +13,10 @@ backends:
           region: "{provider[region]}"
   google:
     terraform:
+      required_providers:
+        google:
+          source: "hashicorp/google"
+          version: "3.66.1"
       backend:
         gcs:
           bucket: "{state_storage}"

--- a/opta/layer.py
+++ b/opta/layer.py
@@ -33,9 +33,6 @@ from opta.module_processors.runx import RunxProcessor
 from opta.plugins.derived_providers import DerivedProviders
 from opta.utils import deep_merge, hydrate, logger, yaml
 
-AWS_PROVIDER_VERSION = "3.38.0"
-GCP_PROVIDER_VERSION = "3.66.1"
-
 
 class Layer:
     def __init__(
@@ -138,13 +135,10 @@ class Layer:
         org_name = conf.pop("org_name", None)
         providers = conf.pop("providers", {})
         if "aws" in providers:
-            providers["aws"]["version"] = AWS_PROVIDER_VERSION
             providers["aws"]["account_id"] = providers["aws"].get("account_id", "")
             account_id = str(providers["aws"]["account_id"])
             account_id = "0" * (12 - len(account_id)) + account_id
             providers["aws"]["account_id"] = account_id
-        if "google" in providers:
-            providers["google"]["version"] = GCP_PROVIDER_VERSION
         if environments:
             potential_envs: Dict[str, Tuple] = {}
             for env_meta in environments:

--- a/tests/fixtures/basic_apply.py
+++ b/tests/fixtures/basic_apply.py
@@ -2,22 +2,12 @@ BASIC_APPLY = (
     {
         "name": "dev1",
         "org_name": "test",
-        "providers": {
-            "aws": {
-                "account_id": "111111111111",
-                "region": "us-east-1",
-                "version": "3.38.0",
-            }
-        },
+        "providers": {"aws": {"account_id": "111111111111", "region": "us-east-1"}},
         "modules": [{"name": "core", "type": "aws-base"}],
     },
     {
         "provider": {
-            "aws": {
-                "allowed_account_ids": ["111111111111"],
-                "region": "us-east-1",
-                "version": "3.38.0",
-            }
+            "aws": {"allowed_account_ids": ["111111111111"], "region": "us-east-1"}
         },
         "terraform": {
             "backend": {
@@ -27,7 +17,10 @@ BASIC_APPLY = (
                     "dynamodb_table": "opta-tf-state-test-dev1",
                     "region": "us-east-1",
                 }
-            }
+            },
+            "required_providers": {
+                "aws": {"source": "hashicorp/aws", "version": "3.38.0"}
+            },
         },
         "module": {
             "core": {


### PR DESCRIPTION
Quite easy, ran test deploys for gcp and aws environments and services-- not a peep