### PR TITLE
Ran terraform format and added it to our ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,15 @@ jobs:
           source $(pipenv --venv)/bin/activate
       - name: Security
         run: make security_tests
+  terraform_format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Run terraform format
+        run: |
+          terraform version
+          terraform fmt -recursive -check ./config/tf_modules
+
   python:
     runs-on: ubuntu-latest
     steps:

--- a/config/tf_modules/aws-base/db_subnet.tf
+++ b/config/tf_modules/aws-base/db_subnet.tf
@@ -2,7 +2,7 @@ resource "aws_db_subnet_group" "main" {
   name       = "opta-${var.layer_name}"
   subnet_ids = aws_subnet.private_subnets[*].id
   tags = {
-    "purpose": "postgres"
-    "ignore-if-seemingly-out-of-place": "yup"
+    "purpose" : "postgres"
+    "ignore-if-seemingly-out-of-place" : "yup"
   }
 }

--- a/config/tf_modules/aws-base/documentdb_subnet.tf
+++ b/config/tf_modules/aws-base/documentdb_subnet.tf
@@ -2,7 +2,7 @@ resource "aws_docdb_subnet_group" "main" {
   name       = "opta-${var.layer_name}-docdb"
   subnet_ids = aws_subnet.private_subnets[*].id
   tags = {
-    "purpose": "docdb"
-    "ignore-if-seemingly-out-of-place": "yup"
+    "purpose" : "docdb"
+    "ignore-if-seemingly-out-of-place" : "yup"
   }
 }

--- a/config/tf_modules/aws-base/kms.tf
+++ b/config/tf_modules/aws-base/kms.tf
@@ -96,7 +96,7 @@ resource "aws_kms_key" "key" {
   description = "Base key for account"
   policy      = data.aws_iam_policy_document.kms_policy.json
   tags = {
-    Name = "opta-${var.layer_name}"
+    Name      = "opta-${var.layer_name}"
     terraform = "true"
   }
 }

--- a/config/tf_modules/aws-base/private_subnet.tf
+++ b/config/tf_modules/aws-base/private_subnet.tf
@@ -5,10 +5,10 @@ resource "aws_subnet" "private_subnets" {
   vpc_id               = aws_vpc.vpc.id
 
   tags = {
-    Name      = "opta-${var.layer_name}-private-${data.aws_availability_zones.current.zone_ids[count.index]}"
+    Name                                           = "opta-${var.layer_name}-private-${data.aws_availability_zones.current.zone_ids[count.index]}"
     "kubernetes.io/cluster/opta-${var.layer_name}" = "shared"
-    type = "private"
-    terraform = "true"
+    type                                           = "private"
+    terraform                                      = "true"
   }
 }
 
@@ -41,7 +41,7 @@ resource "aws_nat_gateway" "nat_gateways" {
   allocation_id = aws_eip.nat_eips[count.index].id
   subnet_id     = aws_subnet.public_subnets[count.index].id
   tags = {
-    Name = "opta-${var.layer_name}-${data.aws_availability_zones.current.zone_ids[count.index]}"
+    Name      = "opta-${var.layer_name}-${data.aws_availability_zones.current.zone_ids[count.index]}"
     terraform = "true"
   }
 }

--- a/config/tf_modules/aws-base/public_subnet.tf
+++ b/config/tf_modules/aws-base/public_subnet.tf
@@ -6,10 +6,10 @@ resource "aws_subnet" "public_subnets" {
   map_public_ip_on_launch = true
 
   tags = {
-    Name                         = "opta-${var.layer_name}-public-${data.aws_availability_zones.current.zone_ids[count.index]}"
+    Name                                           = "opta-${var.layer_name}-public-${data.aws_availability_zones.current.zone_ids[count.index]}"
     "kubernetes.io/cluster/opta-${var.layer_name}" = "shared"
-    type = "public"
-    terraform                    = "true"
+    type                                           = "public"
+    terraform                                      = "true"
   }
 }
 

--- a/config/tf_modules/aws-base/variables.tf
+++ b/config/tf_modules/aws-base/variables.tf
@@ -1,9 +1,9 @@
 data "aws_caller_identity" "current" {}
-data aws_availability_zones "current" {}
+data "aws_availability_zones" "current" {}
 
 variable "env_name" {
   description = "Env name"
-  type = string
+  type        = string
 }
 
 variable "layer_name" {
@@ -13,19 +13,19 @@ variable "layer_name" {
 
 variable "module_name" {
   description = "Module name"
-  type = string
+  type        = string
 }
 
 variable "total_ipv4_cidr_block" {
   description = "Cidr block to reserve for whole vpc"
   type        = string
-  default = "10.0.0.0/16"
+  default     = "10.0.0.0/16"
 }
 
 variable "private_ipv4_cidr_blocks" {
   description = "Cidr blocks for private subnets. One for each desired AZ"
   type        = list(string)
-  default     = [
+  default = [
     "10.0.128.0/21",
     "10.0.136.0/21",
     "10.0.144.0/21"
@@ -35,7 +35,7 @@ variable "private_ipv4_cidr_blocks" {
 variable "public_ipv4_cidr_blocks" {
   description = "Cidr blocks for public subnets. One for each desired AZ"
   type        = list(string)
-  default     = [
+  default = [
     "10.0.0.0/21",
     "10.0.8.0/21",
     "10.0.16.0/21"

--- a/config/tf_modules/aws-dns/certs.tf
+++ b/config/tf_modules/aws-dns/certs.tf
@@ -1,7 +1,7 @@
 # Following example https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-3-upgrade#resource-aws_acm_certificate
 # which should have addressed the issue https://github.com/terraform-providers/terraform-provider-aws/issues/8531
 resource "aws_acm_certificate" "certificate" {
-  count = var.delegated ? 1 : 0
+  count                     = var.delegated ? 1 : 0
   domain_name               = aws_route53_zone.public.name
   subject_alternative_names = ["*.${aws_route53_zone.public.name}"]
   validation_method         = "DNS"
@@ -12,7 +12,7 @@ resource "aws_acm_certificate" "certificate" {
 
 resource "aws_route53_record" "validation_record" {
   for_each = {
-    for dvo in (var.delegated ? aws_acm_certificate.certificate[0].domain_validation_options: []) : dvo.domain_name => {
+    for dvo in(var.delegated ? aws_acm_certificate.certificate[0].domain_validation_options : []) : dvo.domain_name => {
       name   = dvo.resource_record_name
       record = dvo.resource_record_value
       type   = dvo.resource_record_type
@@ -27,16 +27,16 @@ resource "aws_route53_record" "validation_record" {
 }
 
 resource "aws_acm_certificate_validation" "example_com" {
-  count = var.delegated ? 1 : 0
+  count                   = var.delegated ? 1 : 0
   certificate_arn         = aws_acm_certificate.certificate[0].arn
   validation_record_fqdns = [for record in aws_route53_record.validation_record : record.fqdn]
 }
 
 resource "aws_acm_certificate" "imported_certificate" {
-  count = var.upload_cert ? 1 : 0
-  private_key = data.aws_ssm_parameter.private_key[0].value
-  certificate_body = data.aws_ssm_parameter.certificate_body[0].value
-  certificate_chain = var.cert_chain_included? data.aws_ssm_parameter.certificate_chain[0].value : null
+  count             = var.upload_cert ? 1 : 0
+  private_key       = data.aws_ssm_parameter.private_key[0].value
+  certificate_body  = data.aws_ssm_parameter.certificate_body[0].value
+  certificate_chain = var.cert_chain_included ? data.aws_ssm_parameter.certificate_chain[0].value : null
   tags = {
     Name = "opta-${var.env_name}"
   }

--- a/config/tf_modules/aws-dns/main.tf
+++ b/config/tf_modules/aws-dns/main.tf
@@ -1,7 +1,7 @@
 resource "aws_route53_zone" "public" {
   name = var.domain
   tags = {
-    Name = "opta-${var.env_name}"
+    Name               = "opta-${var.env_name}"
     "opta-environment" = var.env_name
   }
   force_destroy = true

--- a/config/tf_modules/aws-dns/variables.tf
+++ b/config/tf_modules/aws-dns/variables.tf
@@ -4,7 +4,7 @@ variable "domain" {
 
 variable "env_name" {
   description = "Env name"
-  type = string
+  type        = string
 }
 
 variable "layer_name" {
@@ -14,48 +14,48 @@ variable "layer_name" {
 
 variable "module_name" {
   description = "Module name"
-  type = string
+  type        = string
 }
 
 variable "delegated" {
-  type = bool
+  type    = bool
   default = false
 }
 
 variable "upload_cert" {
-  type = bool
+  type    = bool
   default = false
 }
 
 variable "cert_chain_included" {
-  type = bool
+  type    = bool
   default = false
 }
 
 variable "force_update" {
-  type = bool
+  type    = bool
   default = false
 }
 
 variable "external_cert_arn" {
-  type = string
+  type    = string
   default = ""
 }
 
 data "aws_ssm_parameter" "private_key" {
-  count = var.upload_cert ? 1 : 0
-  name = "/opta-${var.env_name}/dns-private-key.pem"
+  count           = var.upload_cert ? 1 : 0
+  name            = "/opta-${var.env_name}/dns-private-key.pem"
   with_decryption = true
 }
 
 data "aws_ssm_parameter" "certificate_body" {
-  count = var.upload_cert ? 1 : 0
-  name = "/opta-${var.env_name}/dns-certificate-body.pem"
+  count           = var.upload_cert ? 1 : 0
+  name            = "/opta-${var.env_name}/dns-certificate-body.pem"
   with_decryption = true
 }
 
 data "aws_ssm_parameter" "certificate_chain" {
-  count = var.cert_chain_included ? 1 : 0
-  name = "/opta-${var.env_name}/dns-certificate-chain.pem"
+  count           = var.cert_chain_included ? 1 : 0
+  name            = "/opta-${var.env_name}/dns-certificate-chain.pem"
   with_decryption = true
 }

--- a/config/tf_modules/aws-documentdb/main.tf
+++ b/config/tf_modules/aws-documentdb/main.tf
@@ -1,5 +1,5 @@
 resource "random_password" "documentdb_auth" {
-  length = 20
+  length  = 20
   special = false
 }
 
@@ -12,24 +12,24 @@ data "aws_kms_key" "main" {
 }
 
 resource "aws_docdb_cluster_instance" "cluster_instances" {
-  count              = 1
-  identifier         = "opta-${var.layer_name}-${var.module_name}-${count.index}"
-  cluster_identifier = aws_docdb_cluster.cluster.id
-  instance_class     = var.instance_class
-  apply_immediately = true
+  count                      = 1
+  identifier                 = "opta-${var.layer_name}-${var.module_name}-${count.index}"
+  cluster_identifier         = aws_docdb_cluster.cluster.id
+  instance_class             = var.instance_class
+  apply_immediately          = true
   auto_minor_version_upgrade = true
 }
 
 resource "aws_docdb_cluster" "cluster" {
-  cluster_identifier = "opta-${var.layer_name}-${var.module_name}"
-  master_username    = "master_user"
-  master_password    = random_password.documentdb_auth.result
-  db_subnet_group_name = "opta-${var.env_name}-docdb"
-  engine_version = var.engine_version
-  storage_encrypted = true
-  kms_key_id = data.aws_kms_key.main.arn
-  vpc_security_group_ids = [data.aws_security_group.security_group.id]
+  cluster_identifier      = "opta-${var.layer_name}-${var.module_name}"
+  master_username         = "master_user"
+  master_password         = random_password.documentdb_auth.result
+  db_subnet_group_name    = "opta-${var.env_name}-docdb"
+  engine_version          = var.engine_version
+  storage_encrypted       = true
+  kms_key_id              = data.aws_kms_key.main.arn
+  vpc_security_group_ids  = [data.aws_security_group.security_group.id]
   backup_retention_period = 5
-  apply_immediately = true
-  skip_final_snapshot = true
+  apply_immediately       = true
+  skip_final_snapshot     = true
 }

--- a/config/tf_modules/aws-documentdb/output.tf
+++ b/config/tf_modules/aws-documentdb/output.tf
@@ -7,6 +7,6 @@ output "db_user" {
 }
 
 output "db_password" {
-  value = aws_docdb_cluster.cluster.master_password
+  value     = aws_docdb_cluster.cluster.master_password
   sensitive = true
 }

--- a/config/tf_modules/aws-documentdb/variables.tf
+++ b/config/tf_modules/aws-documentdb/variables.tf
@@ -1,6 +1,6 @@
 variable "env_name" {
   description = "Env name"
-  type = string
+  type        = string
 }
 
 variable "layer_name" {
@@ -10,15 +10,15 @@ variable "layer_name" {
 
 variable "module_name" {
   description = "Module name"
-  type = string
+  type        = string
 }
 
 variable "engine_version" {
-  type = string
+  type    = string
   default = "4.0.0"
 }
 
 variable "instance_class" {
-  type = string
+  type    = string
   default = "db.r5.large"
 }

--- a/config/tf_modules/aws-eks/eks.tf
+++ b/config/tf_modules/aws-eks/eks.tf
@@ -6,7 +6,7 @@ resource "aws_eks_cluster" "cluster" {
   vpc_config {
     subnet_ids              = var.private_subnet_ids
     endpoint_private_access = false # TODO: make this true once we got VPN figured out
-    endpoint_public_access  = true # TODO: make this false once we got VPN figured out
+    endpoint_public_access  = true  # TODO: make this false once we got VPN figured out
   }
 
   encryption_config {

--- a/config/tf_modules/aws-eks/variables.tf
+++ b/config/tf_modules/aws-eks/variables.tf
@@ -10,7 +10,7 @@ variable "private_subnet_ids" {
 
 variable "env_name" {
   description = "Env name"
-  type = string
+  type        = string
 }
 
 variable "layer_name" {
@@ -20,7 +20,7 @@ variable "layer_name" {
 
 variable "module_name" {
   description = "Module name"
-  type = string
+  type        = string
 }
 
 variable "max_nodes" {

--- a/config/tf_modules/aws-iam-role/main.tf
+++ b/config/tf_modules/aws-iam-role/main.tf
@@ -1,5 +1,5 @@
 resource "aws_iam_policy" "vanilla_policy" {
-  name = "${var.env_name}-${var.layer_name}-${var.module_name}"
+  name   = "${var.env_name}-${var.layer_name}-${var.module_name}"
   policy = jsonencode(var.iam_policy)
 }
 
@@ -30,7 +30,7 @@ data "aws_iam_policy_document" "iam_trusts" {
       effect  = "Allow"
       principals {
         identifiers = [statement.value]
-        type = "AWS"
+        type        = "AWS"
       }
     }
   }
@@ -40,35 +40,35 @@ data "aws_iam_policy_document" "iam_trusts" {
     actions = ["sts:AssumeRole"]
     principals {
       identifiers = ["events.amazonaws.com"]
-      type = "Service"
+      type        = "Service"
     }
   }
 }
 
 resource "aws_iam_role" "role" {
   assume_role_policy = data.aws_iam_policy_document.iam_trusts.json
-  name = "${var.env_name}-${var.layer_name}-${var.module_name}"
+  name               = "${var.env_name}-${var.layer_name}-${var.module_name}"
 }
 
 resource "aws_iam_role_policy_attachment" "vanilla_role_attachment" {
   policy_arn = aws_iam_policy.vanilla_policy.arn
-  role = aws_iam_role.role.name
+  role       = aws_iam_role.role.name
 }
 
 resource "aws_iam_role_policy_attachment" "extra_policies_attachment" {
-  count = length(var.extra_iam_policies)
+  count      = length(var.extra_iam_policies)
   policy_arn = var.extra_iam_policies[count.index]
-  role = aws_iam_role.role.name
+  role       = aws_iam_role.role.name
 }
 
 resource "aws_iam_role_policy" "pass_role_to_self" {
-  role = aws_iam_role.role.id
+  role   = aws_iam_role.role.id
   policy = data.aws_iam_policy_document.pass_role_to_self.json
 }
 
 data "aws_iam_policy_document" "pass_role_to_self" {
   statement {
-    sid = "AllowToPassSelf"
+    sid    = "AllowToPassSelf"
     effect = "Allow"
     actions = [
       "iam:GetRole",

--- a/config/tf_modules/aws-iam-role/veriables.tf
+++ b/config/tf_modules/aws-iam-role/veriables.tf
@@ -1,6 +1,6 @@
 variable "env_name" {
   description = "Env name"
-  type = string
+  type        = string
 }
 
 variable "layer_name" {
@@ -10,21 +10,21 @@ variable "layer_name" {
 
 variable "module_name" {
   description = "Module name"
-  type = string
+  type        = string
 }
 
 variable "kubernetes_trusts" {
   type = list(object({
-    open_id_url = string
-    open_id_arn = string
+    open_id_url  = string
+    open_id_arn  = string
     service_name = string
-    namespace = string
+    namespace    = string
   }))
   default = []
 }
 
 variable "allowed_iams" {
-  type = list(string)
+  type    = list(string)
   default = []
 }
 
@@ -32,6 +32,6 @@ variable "iam_policy" {
 }
 
 variable "extra_iam_policies" {
-  type = list(string)
+  type    = list(string)
   default = []
 }

--- a/config/tf_modules/aws-iam-user/main.tf
+++ b/config/tf_modules/aws-iam-user/main.tf
@@ -1,5 +1,5 @@
 resource "aws_iam_policy" "vanilla_policy" {
-  name = "${var.env_name}-${var.layer_name}-${var.module_name}"
+  name   = "${var.env_name}-${var.layer_name}-${var.module_name}"
   policy = jsonencode(var.iam_policy)
 }
 
@@ -9,23 +9,23 @@ resource "aws_iam_user" "user" {
 
 resource "aws_iam_user_policy_attachment" "vanilla_role_attachment" {
   policy_arn = aws_iam_policy.vanilla_policy.arn
-  user = aws_iam_user.user.name
+  user       = aws_iam_user.user.name
 }
 
 resource "aws_iam_user_policy_attachment" "extra_policies_attachment" {
-  count = length(var.extra_iam_policies)
+  count      = length(var.extra_iam_policies)
   policy_arn = var.extra_iam_policies[count.index]
-  user = aws_iam_user.user.name
+  user       = aws_iam_user.user.name
 }
 
 resource "aws_iam_user_policy" "pass_role_to_self" {
   policy = data.aws_iam_policy_document.pass_role_to_self.json
-  user = aws_iam_user.user.id
+  user   = aws_iam_user.user.id
 }
 
 data "aws_iam_policy_document" "pass_role_to_self" {
   statement {
-    sid = "AllowToPassSelf"
+    sid    = "AllowToPassSelf"
     effect = "Allow"
     actions = [
       "iam:GetRole",

--- a/config/tf_modules/aws-iam-user/veriables.tf
+++ b/config/tf_modules/aws-iam-user/veriables.tf
@@ -1,6 +1,6 @@
 variable "env_name" {
   description = "Env name"
-  type = string
+  type        = string
 }
 
 variable "layer_name" {
@@ -10,13 +10,13 @@ variable "layer_name" {
 
 variable "module_name" {
   description = "Module name"
-  type = string
+  type        = string
 }
 
 variable "iam_policy" {
 }
 
 variable "extra_iam_policies" {
-  type = list(string)
+  type    = list(string)
   default = []
 }

--- a/config/tf_modules/aws-nodegroup/variables.tf
+++ b/config/tf_modules/aws-nodegroup/variables.tf
@@ -7,15 +7,15 @@ data "aws_eks_cluster" "main" {
 locals {
   default_labels = var.use_gpu ? {
     node_group_name = "opta-${var.layer_name}-${var.module_name}"
-    gpu: "true"
-  } : {
+    gpu : "true"
+    } : {
     node_group_name = "opta-${var.layer_name}-${var.module_name}"
   }
 }
 
 variable "env_name" {
   description = "Env name"
-  type = string
+  type        = string
 }
 
 variable "layer_name" {
@@ -25,7 +25,7 @@ variable "layer_name" {
 
 variable "module_name" {
   description = "Module name"
-  type = string
+  type        = string
 }
 
 variable "max_nodes" {
@@ -49,12 +49,12 @@ variable "node_instance_type" {
 }
 
 variable "use_gpu" {
-  type = bool
+  type    = bool
   default = false
 }
 
 variable "labels" {
-  type = map(string)
+  type    = map(string)
   default = {}
 }
 

--- a/config/tf_modules/aws-postgres/main.tf
+++ b/config/tf_modules/aws-postgres/main.tf
@@ -1,5 +1,5 @@
 resource "random_password" "pg_password" {
-  length = 20
+  length  = 20
   special = false
 }
 
@@ -12,34 +12,34 @@ data "aws_kms_key" "main" {
 }
 
 resource "aws_rds_cluster" "db_cluster" {
-  cluster_identifier = "opta-${var.layer_name}-${var.module_name}"
-  db_subnet_group_name = "opta-${var.env_name}"
-  database_name = "app"
-  engine = "aurora-postgresql"
-  engine_version = var.engine_version
-  master_username = "postgres"
-  master_password = random_password.pg_password.result
-  vpc_security_group_ids = [data.aws_security_group.security_group.id]
+  cluster_identifier      = "opta-${var.layer_name}-${var.module_name}"
+  db_subnet_group_name    = "opta-${var.env_name}"
+  database_name           = "app"
+  engine                  = "aurora-postgresql"
+  engine_version          = var.engine_version
+  master_username         = "postgres"
+  master_password         = random_password.pg_password.result
+  vpc_security_group_ids  = [data.aws_security_group.security_group.id]
   backup_retention_period = 5
-  apply_immediately = true
-  skip_final_snapshot = true
-  storage_encrypted = true
-  kms_key_id = data.aws_kms_key.main.arn
-  deletion_protection = var.safety
+  apply_immediately       = true
+  skip_final_snapshot     = true
+  storage_encrypted       = true
+  kms_key_id              = data.aws_kms_key.main.arn
+  deletion_protection     = var.safety
   lifecycle {
     ignore_changes = [storage_encrypted, kms_key_id]
   }
 }
 
 resource "aws_rds_cluster_instance" "db_instance" {
-  count = 1
-  identifier         = "opta-${var.layer_name}-${var.module_name}-${count.index}"
-  cluster_identifier = aws_rds_cluster.db_cluster.id
-  instance_class     = var.instance_class
-  engine             = aws_rds_cluster.db_cluster.engine
-  engine_version     = aws_rds_cluster.db_cluster.engine_version
-  apply_immediately = true
-  auto_minor_version_upgrade = false
-  performance_insights_enabled = true
+  count                           = 1
+  identifier                      = "opta-${var.layer_name}-${var.module_name}-${count.index}"
+  cluster_identifier              = aws_rds_cluster.db_cluster.id
+  instance_class                  = var.instance_class
+  engine                          = aws_rds_cluster.db_cluster.engine
+  engine_version                  = aws_rds_cluster.db_cluster.engine_version
+  apply_immediately               = true
+  auto_minor_version_upgrade      = false
+  performance_insights_enabled    = true
   performance_insights_kms_key_id = data.aws_kms_key.main.arn
 }

--- a/config/tf_modules/aws-postgres/outputs.tf
+++ b/config/tf_modules/aws-postgres/outputs.tf
@@ -3,7 +3,7 @@ output "db_user" {
 }
 
 output "db_password" {
-  value = aws_rds_cluster.db_cluster.master_password
+  value     = aws_rds_cluster.db_cluster.master_password
   sensitive = true
 }
 

--- a/config/tf_modules/aws-postgres/variables.tf
+++ b/config/tf_modules/aws-postgres/variables.tf
@@ -1,6 +1,6 @@
 variable "env_name" {
   description = "Env name"
-  type = string
+  type        = string
 }
 
 variable "layer_name" {
@@ -10,20 +10,20 @@ variable "layer_name" {
 
 variable "module_name" {
   description = "Module name"
-  type = string
+  type        = string
 }
 
 variable "engine_version" {
-  type = string
+  type    = string
   default = "11.9"
 }
 
 variable "instance_class" {
-  type = string
+  type    = string
   default = "db.t3.medium"
 }
 
 variable "safety" {
-  type = bool
+  type    = bool
   default = false
 }

--- a/config/tf_modules/aws-redis/main.tf
+++ b/config/tf_modules/aws-redis/main.tf
@@ -1,5 +1,5 @@
 resource "random_password" "redis_auth" {
-  length = 20
+  length  = 20
   special = false
 }
 
@@ -13,21 +13,21 @@ data "aws_kms_key" "main" {
 
 resource "aws_elasticache_replication_group" "redis_cluster" {
   automatic_failover_enabled    = true
-  auto_minor_version_upgrade = true
-  security_group_ids = [data.aws_security_group.security_group.id]
-  subnet_group_name = "opta-${var.env_name}"
+  auto_minor_version_upgrade    = true
+  security_group_ids            = [data.aws_security_group.security_group.id]
+  subnet_group_name             = "opta-${var.env_name}"
   replication_group_id          = "opta-${var.layer_name}-${var.module_name}"
   replication_group_description = "Elasticache opta-${var.layer_name}-${var.module_name}"
   node_type                     = var.node_type
-  engine_version = var.redis_version
+  engine_version                = var.redis_version
   number_cache_clusters         = 2
   port                          = 6379
-  apply_immediately = true
-  multi_az_enabled = true
-  auth_token = random_password.redis_auth.result
-  transit_encryption_enabled = true
-  at_rest_encryption_enabled = true
-  kms_key_id = data.aws_kms_key.main.arn
+  apply_immediately             = true
+  multi_az_enabled              = true
+  auth_token                    = random_password.redis_auth.result
+  transit_encryption_enabled    = true
+  at_rest_encryption_enabled    = true
+  kms_key_id                    = data.aws_kms_key.main.arn
   lifecycle {
     ignore_changes = [engine_version]
   }

--- a/config/tf_modules/aws-redis/outputs.tf
+++ b/config/tf_modules/aws-redis/outputs.tf
@@ -1,5 +1,5 @@
 output "cache_auth_token" {
-  value = aws_elasticache_replication_group.redis_cluster.auth_token
+  value     = aws_elasticache_replication_group.redis_cluster.auth_token
   sensitive = true
 }
 

--- a/config/tf_modules/aws-redis/variables.tf
+++ b/config/tf_modules/aws-redis/variables.tf
@@ -1,11 +1,11 @@
 variable "node_type" {
-  type = string
+  type    = string
   default = "cache.m4.large"
 }
 
 variable "env_name" {
   description = "Env name"
-  type = string
+  type        = string
 }
 
 variable "layer_name" {
@@ -15,10 +15,10 @@ variable "layer_name" {
 
 variable "module_name" {
   description = "Module name"
-  type = string
+  type        = string
 }
 
 variable "redis_version" {
-  type = string
+  type    = string
   default = "6.x"
 }

--- a/config/tf_modules/aws-s3/bucket.tf
+++ b/config/tf_modules/aws-s3/bucket.tf
@@ -11,17 +11,17 @@ resource "aws_s3_bucket" "bucket" {
 }
 
 resource "aws_s3_bucket_public_access_block" "block" {
-  count = var.block_public? 1 : 0
+  count  = var.block_public ? 1 : 0
   bucket = aws_s3_bucket.bucket.id
 
-  block_public_acls   = true
-  block_public_policy = true
-  ignore_public_acls = true
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
   restrict_public_buckets = true
 }
 
 resource "aws_s3_bucket_policy" "policy" {
-  count = var.bucket_policy == null ? 0 : 1
+  count  = var.bucket_policy == null ? 0 : 1
   bucket = aws_s3_bucket.bucket.id
-  policy = var.bucket_policy == null? null : jsonencode(var.bucket_policy)
+  policy = var.bucket_policy == null ? null : jsonencode(var.bucket_policy)
 }

--- a/config/tf_modules/aws-s3/variables.tf
+++ b/config/tf_modules/aws-s3/variables.tf
@@ -1,6 +1,6 @@
 variable "env_name" {
   description = "Env name"
-  type = string
+  type        = string
 }
 
 variable "layer_name" {
@@ -10,7 +10,7 @@ variable "layer_name" {
 
 variable "module_name" {
   description = "Module name"
-  type = string
+  type        = string
 }
 
 variable "bucket_name" {
@@ -18,12 +18,12 @@ variable "bucket_name" {
 }
 
 variable "block_public" {
-  type = bool
+  type    = bool
   default = true
 }
 
 variable "bucket_policy" {
-  type = map(any)
+  type    = map(any)
   default = null
 }
 

--- a/config/tf_modules/aws-ses/main.tf
+++ b/config/tf_modules/aws-ses/main.tf
@@ -60,8 +60,8 @@ resource "aws_route53_record" "amazonses_dkim_record" {
 
 data "aws_iam_policy_document" "sender" {
   statement {
-    sid = "SendEmail"
-    actions = ["ses:Send*"]
+    sid       = "SendEmail"
+    actions   = ["ses:Send*"]
     resources = ["*"]
     condition {
       test     = "StringLike"
@@ -72,6 +72,6 @@ data "aws_iam_policy_document" "sender" {
 }
 
 resource "aws_iam_policy" "sender" {
-  name = "${var.env_name}-${var.layer_name}-${var.module_name}-sender"
+  name   = "${var.env_name}-${var.layer_name}-${var.module_name}-sender"
   policy = data.aws_iam_policy_document.sender.json
 }

--- a/config/tf_modules/aws-ses/variables.tf
+++ b/config/tf_modules/aws-ses/variables.tf
@@ -2,7 +2,7 @@ data "aws_region" "current" {}
 
 variable "env_name" {
   description = "Env name"
-  type = string
+  type        = string
 }
 
 variable "layer_name" {
@@ -12,7 +12,7 @@ variable "layer_name" {
 
 variable "module_name" {
   description = "Module name"
-  type = string
+  type        = string
 }
 
 variable "domain" {
@@ -24,6 +24,6 @@ variable "zone_id" {
 }
 
 variable "mail_from_prefix" {
-  type = string
+  type    = string
   default = "mail"
 }

--- a/config/tf_modules/aws-sns/kms.tf
+++ b/config/tf_modules/aws-sns/kms.tf
@@ -60,7 +60,7 @@ resource "aws_kms_key" "key" {
   description = "SQS Key"
   policy      = data.aws_iam_policy_document.kms_policy.json
   tags = {
-    Name = "opta-${var.layer_name}"
+    Name      = "opta-${var.layer_name}"
     terraform = "true"
   }
 }

--- a/config/tf_modules/aws-sns/main.tf
+++ b/config/tf_modules/aws-sns/main.tf
@@ -1,9 +1,9 @@
 resource "aws_sns_topic" "topic" {
-  name            = "${var.env_name}-${var.layer_name}-${var.module_name}"
-  kms_master_key_id = aws_kms_key.key.id
-  fifo_topic = var.fifo
+  name                        = "${var.env_name}-${var.layer_name}-${var.module_name}"
+  kms_master_key_id           = aws_kms_key.key.id
+  fifo_topic                  = var.fifo
   content_based_deduplication = var.content_based_deduplication
-  delivery_policy = <<EOF
+  delivery_policy             = <<EOF
 {
   "http": {
     "defaultHealthyRetryPolicy": {
@@ -64,7 +64,7 @@ data "aws_iam_policy_document" "sns_topic_policy" {
 
 ## SQS Subscriptions
 resource "aws_sns_topic_subscription" "user_updates_sqs_target" {
-  count = length(var.sqs_subscribers)
+  count     = length(var.sqs_subscribers)
   topic_arn = aws_sns_topic.topic.arn
   protocol  = "sqs"
   endpoint  = var.sqs_subscribers[count.index]

--- a/config/tf_modules/aws-sns/variables.tf
+++ b/config/tf_modules/aws-sns/variables.tf
@@ -2,7 +2,7 @@ data "aws_caller_identity" "current" {}
 
 variable "env_name" {
   description = "Env name"
-  type = string
+  type        = string
 }
 
 variable "layer_name" {
@@ -12,20 +12,20 @@ variable "layer_name" {
 
 variable "module_name" {
   description = "Module name"
-  type = string
+  type        = string
 }
 
 variable "fifo" {
-  type = bool
+  type    = bool
   default = false
 }
 
 variable "content_based_deduplication" {
-  type = bool
+  type    = bool
   default = false
 }
 
 variable "sqs_subscribers" {
-  type = list(string)
+  type    = list(string)
   default = []
 }

--- a/config/tf_modules/aws-sqs/kms.tf
+++ b/config/tf_modules/aws-sqs/kms.tf
@@ -60,7 +60,7 @@ resource "aws_kms_key" "key" {
   description = "SQS Key"
   policy      = data.aws_iam_policy_document.kms_policy.json
   tags = {
-    Name = "opta-${var.layer_name}"
+    Name      = "opta-${var.layer_name}"
     terraform = "true"
   }
 }

--- a/config/tf_modules/aws-sqs/main.tf
+++ b/config/tf_modules/aws-sqs/main.tf
@@ -1,11 +1,11 @@
 resource "aws_sqs_queue" "terraform_queue" {
-  name                      = var.fifo? "${var.env_name}-${var.layer_name}-${var.module_name}.fifo" : "${var.env_name}-${var.layer_name}-${var.module_name}"
-  kms_master_key_id                 = aws_kms_key.key.id
+  name                        = var.fifo ? "${var.env_name}-${var.layer_name}-${var.module_name}.fifo" : "${var.env_name}-${var.layer_name}-${var.module_name}"
+  kms_master_key_id           = aws_kms_key.key.id
   fifo_queue                  = var.fifo
   content_based_deduplication = var.content_based_deduplication
-  delay_seconds             = var.delay_seconds
-  message_retention_seconds = var.message_retention_seconds
-  receive_wait_time_seconds = var.receive_wait_time_seconds
+  delay_seconds               = var.delay_seconds
+  message_retention_seconds   = var.message_retention_seconds
+  receive_wait_time_seconds   = var.receive_wait_time_seconds
 
   tags = {
     Environment = "production"
@@ -15,7 +15,7 @@ resource "aws_sqs_queue" "terraform_queue" {
 ## SQS Queue policy
 resource "aws_sqs_queue_policy" "default" {
 
-  policy = data.aws_iam_policy_document.sqs_queue_policy.json
+  policy    = data.aws_iam_policy_document.sqs_queue_policy.json
   queue_url = aws_sqs_queue.terraform_queue.id
 }
 

--- a/config/tf_modules/aws-sqs/variables.tf
+++ b/config/tf_modules/aws-sqs/variables.tf
@@ -2,7 +2,7 @@ data "aws_caller_identity" "current" {}
 
 variable "env_name" {
   description = "Env name"
-  type = string
+  type        = string
 }
 
 variable "layer_name" {
@@ -12,30 +12,30 @@ variable "layer_name" {
 
 variable "module_name" {
   description = "Module name"
-  type = string
+  type        = string
 }
 
 variable "fifo" {
-  type = bool
+  type    = bool
   default = false
 }
 
 variable "content_based_deduplication" {
-  type = bool
+  type    = bool
   default = false
 }
 
 variable "delay_seconds" {
-  type = number
+  type    = number
   default = 0
 }
 
 variable "message_retention_seconds" {
-  type = number
+  type    = number
   default = 345600
 }
 
 variable "receive_wait_time_seconds" {
-  type = number
+  type    = number
   default = 0
 }

--- a/config/tf_modules/datadog/main.tf
+++ b/config/tf_modules/datadog/main.tf
@@ -1,62 +1,62 @@
 terraform {
   required_providers {
     helm = {
-      source = "hashicorp/helm"
+      source  = "hashicorp/helm"
       version = ">= 2.0.2"
     }
   }
 }
 
 resource "random_password" "cluster_agent_token" {
-  length = 32
+  length  = 32
   special = false
 }
 
 resource "helm_release" "datadog" {
-  count = (var.api_key == null || var.api_key == "") ? 0 : 1
+  count      = (var.api_key == null || var.api_key == "") ? 0 : 1
   repository = "https://helm.datadoghq.com"
-  chart = "datadog"
-  name = "${var.layer_name}-${var.module_name}"
+  chart      = "datadog"
+  name       = "${var.layer_name}-${var.module_name}"
 
   values = [
     yamlencode({
-      datadog: {
-        collectEvents: true
-        leaderElection: true
-        env: [
+      datadog : {
+        collectEvents : true
+        leaderElection : true
+        env : [
           {
-            name: "DD_ENV"
-            value: var.layer_name
+            name : "DD_ENV"
+            value : var.layer_name
           }
         ]
-        dogstatsd: {
-          useHostPort: true
-          nonLocalTraffic: true
+        dogstatsd : {
+          useHostPort : true
+          nonLocalTraffic : true
         }
-        logs: {
-          enabled: true
-          containerCollectAll: true
+        logs : {
+          enabled : true
+          containerCollectAll : true
         }
-        clusterName: var.layer_name
+        clusterName : var.layer_name
 
-        apm: {
-          enabled: true
+        apm : {
+          enabled : true
         }
-        podLabelsAsTags: {
-          app: "kube_app"
-          release: "helm_release"
+        podLabelsAsTags : {
+          app : "kube_app"
+          release : "helm_release"
         }
       }
-      clusterAgent: {
-        useHostNetwork: true
-        enabled: true
-        token: random_password.cluster_agent_token.result
-        metricsProvider: {
-          enabled: true
+      clusterAgent : {
+        useHostNetwork : true
+        enabled : true
+        token : random_password.cluster_agent_token.result
+        metricsProvider : {
+          enabled : true
         }
-        admissionController: {
-          enabled: true
-          mutateUnlabelled: true
+        admissionController : {
+          enabled : true
+          mutateUnlabelled : true
         }
       }
     })
@@ -68,10 +68,10 @@ resource "helm_release" "datadog" {
     value = var.api_key
   }
 
-  namespace = "datadog"
+  namespace        = "datadog"
   create_namespace = true
-  atomic          = true
-  cleanup_on_fail = true
-  recreate_pods   = true
+  atomic           = true
+  cleanup_on_fail  = true
+  recreate_pods    = true
 }
 

--- a/config/tf_modules/datadog/variables.tf
+++ b/config/tf_modules/datadog/variables.tf
@@ -1,6 +1,6 @@
 variable "env_name" {
   description = "Env name"
-  type = string
+  type        = string
 }
 
 variable "layer_name" {
@@ -10,12 +10,12 @@ variable "layer_name" {
 
 variable "module_name" {
   description = "Module name"
-  type = string
+  type        = string
 }
 
 variable "api_key" {
   description = "Datadog API key"
-  type = string
-  default = null
+  type        = string
+  default     = null
 }
 

--- a/config/tf_modules/gcp-base/firewall.tf
+++ b/config/tf_modules/gcp-base/firewall.tf
@@ -1,6 +1,6 @@
 resource "google_compute_firewall" "firewall" {
-  name = "opta-${var.layer_name}-${data.google_client_config.current.region}-private"
-  network = google_compute_network.vpc.id
+  name      = "opta-${var.layer_name}-${data.google_client_config.current.region}-private"
+  network   = google_compute_network.vpc.id
   direction = "INGRESS"
   allow {
     protocol = "tcp"

--- a/config/tf_modules/gcp-base/kms.tf
+++ b/config/tf_modules/gcp-base/kms.tf
@@ -23,18 +23,18 @@ resource "google_kms_key_ring" "keyring" {
 }
 
 resource "google_kms_crypto_key" "key" {
-  name            = "opta-${var.layer_name}-${random_id.key_suffix.hex}"
-  key_ring        = google_kms_key_ring.keyring.id
+  name     = "opta-${var.layer_name}-${random_id.key_suffix.hex}"
+  key_ring = google_kms_key_ring.keyring.id
 }
 
 resource "google_kms_crypto_key_iam_member" "gke" {
   crypto_key_id = google_kms_crypto_key.key.id
-  member = "serviceAccount:service-${data.google_project.current.number}@container-engine-robot.iam.gserviceaccount.com"
-  role = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+  member        = "serviceAccount:service-${data.google_project.current.number}@container-engine-robot.iam.gserviceaccount.com"
+  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
 }
 
 resource "google_kms_crypto_key_iam_member" "gcs" {
   crypto_key_id = google_kms_crypto_key.key.id
   role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
-  member = "serviceAccount:${data.google_storage_project_service_account.gcs_account.email_address}"
+  member        = "serviceAccount:${data.google_storage_project_service_account.gcs_account.email_address}"
 }

--- a/config/tf_modules/gcp-base/private_subnet.tf
+++ b/config/tf_modules/gcp-base/private_subnet.tf
@@ -5,10 +5,10 @@ resource "google_compute_subnetwork" "project_subnet" {
   network                  = google_compute_network.vpc.id
   secondary_ip_range {
     ip_cidr_range = var.cluster_ipv4_cidr_block
-    range_name = "gke-pods"
+    range_name    = "gke-pods"
   }
   secondary_ip_range {
     ip_cidr_range = var.services_ipv4_cidr_block
-    range_name = "gke-services"
+    range_name    = "gke-services"
   }
 }

--- a/config/tf_modules/gcp-base/router.tf
+++ b/config/tf_modules/gcp-base/router.tf
@@ -4,15 +4,15 @@ resource "google_compute_router" "router" {
 }
 
 resource "google_compute_address" "address" {
-  count  = 2
-  name   = "opta-${var.layer_name}-${data.google_client_config.current.region}-${count.index}"
+  count = 2
+  name  = "opta-${var.layer_name}-${data.google_client_config.current.region}-${count.index}"
 }
 
 resource "google_compute_router_nat" "nat" {
   name                               = "opta-${var.layer_name}-${data.google_client_config.current.region}"
   router                             = google_compute_router.router.name
-  nat_ip_allocate_option = "MANUAL_ONLY"
-  nat_ips = google_compute_address.address.*.self_link
+  nat_ip_allocate_option             = "MANUAL_ONLY"
+  nat_ips                            = google_compute_address.address.*.self_link
   source_subnetwork_ip_ranges_to_nat = "ALL_SUBNETWORKS_ALL_IP_RANGES"
 
   log_config {

--- a/config/tf_modules/gcp-base/variables.tf
+++ b/config/tf_modules/gcp-base/variables.tf
@@ -4,7 +4,7 @@ data "google_storage_project_service_account" "gcs_account" {}
 
 variable "env_name" {
   description = "Env name"
-  type = string
+  type        = string
 }
 
 variable "layer_name" {
@@ -14,7 +14,7 @@ variable "layer_name" {
 
 variable "module_name" {
   description = "Module name"
-  type = string
+  type        = string
 }
 
 variable "private_ipv4_cidr_block" {
@@ -24,11 +24,11 @@ variable "private_ipv4_cidr_block" {
 }
 
 variable "cluster_ipv4_cidr_block" {
-  type = string
+  type    = string
   default = "10.0.32.0/19"
 }
 
 variable "services_ipv4_cidr_block" {
-  type = string
+  type    = string
   default = "10.0.64.0/20"
 }

--- a/config/tf_modules/gcp-base/vpc.tf
+++ b/config/tf_modules/gcp-base/vpc.tf
@@ -1,16 +1,16 @@
 resource "google_compute_network" "vpc" {
-  name = "opta-${var.layer_name}"
-  auto_create_subnetworks = false
+  name                            = "opta-${var.layer_name}"
+  auto_create_subnetworks         = false
   delete_default_routes_on_create = true
 }
 
 
 resource "google_compute_route" "default" {
-  name = "opta-${var.layer_name}-${data.google_client_config.current.region}-default"
+  name             = "opta-${var.layer_name}-${data.google_client_config.current.region}-default"
   next_hop_gateway = "default-internet-gateway"
-  priority = 1000
-  dest_range = "0.0.0.0/0"
-  network = google_compute_network.vpc.id
+  priority         = 1000
+  dest_range       = "0.0.0.0/0"
+  network          = google_compute_network.vpc.id
 }
 
 resource "google_compute_global_address" "private_ip_alloc" {

--- a/config/tf_modules/gcp-dns/certs.tf
+++ b/config/tf_modules/gcp-dns/certs.tf
@@ -7,7 +7,7 @@ resource "random_id" "cert_suffix" {
 
 resource "google_compute_managed_ssl_certificate" "certificate" {
   count = var.delegated ? 1 : 0
-  name = "opta-${var.layer_name}-${random_id.cert_suffix.hex}"
+  name  = "opta-${var.layer_name}-${random_id.cert_suffix.hex}"
 
   managed {
     domains = concat([var.domain], local.full_subdomains)

--- a/config/tf_modules/gcp-dns/variables.tf
+++ b/config/tf_modules/gcp-dns/variables.tf
@@ -9,13 +9,13 @@ variable "domain" {
 }
 
 variable "subdomains" {
-  type = list(string)
+  type    = list(string)
   default = []
 }
 
 variable "env_name" {
   description = "Env name"
-  type = string
+  type        = string
 }
 
 variable "layer_name" {
@@ -25,11 +25,11 @@ variable "layer_name" {
 
 variable "module_name" {
   description = "Module name"
-  type = string
+  type        = string
 }
 
 variable "delegated" {
-  type = bool
+  type    = bool
   default = false
 }
 

--- a/config/tf_modules/gcp-gcs/bucket.tf
+++ b/config/tf_modules/gcp-gcs/bucket.tf
@@ -1,6 +1,6 @@
 resource "google_storage_bucket" "bucket" {
-  name          = var.bucket_name
-  location      = data.google_client_config.current.region
+  name     = var.bucket_name
+  location = data.google_client_config.current.region
   encryption {
     default_kms_key_name = data.google_kms_crypto_key.kms.id
   }

--- a/config/tf_modules/gcp-gcs/variables.tf
+++ b/config/tf_modules/gcp-gcs/variables.tf
@@ -11,12 +11,12 @@ data "google_kms_key_ring" "key_ring" {
 
 data "google_kms_crypto_key" "kms" {
   key_ring = data.google_kms_key_ring.key_ring.self_link
-  name = "opta-${var.env_name}-${data.google_secret_manager_secret_version.kms_suffix.secret_data}"
+  name     = "opta-${var.env_name}-${data.google_secret_manager_secret_version.kms_suffix.secret_data}"
 }
 
 variable "env_name" {
   description = "Env name"
-  type = string
+  type        = string
 }
 
 variable "layer_name" {
@@ -26,7 +26,7 @@ variable "layer_name" {
 
 variable "module_name" {
   description = "Module name"
-  type = string
+  type        = string
 }
 
 variable "bucket_name" {
@@ -34,6 +34,6 @@ variable "bucket_name" {
 }
 
 variable "block_public" {
-  type = bool
+  type    = bool
   default = true
 }

--- a/config/tf_modules/gcp-gke/default_node_group.tf
+++ b/config/tf_modules/gcp-gke/default_node_group.tf
@@ -1,7 +1,7 @@
 resource "google_container_node_pool" "default" {
-  name       = "opta-${var.layer_name}-default"
-  cluster    = google_container_cluster.primary.name
-  location = data.google_client_config.current.region
+  name               = "opta-${var.layer_name}-default"
+  cluster            = google_container_cluster.primary.name
+  location           = data.google_client_config.current.region
   initial_node_count = var.min_nodes
 
   autoscaling {
@@ -10,7 +10,7 @@ resource "google_container_node_pool" "default" {
   }
 
   management {
-    auto_repair = true
+    auto_repair  = true
     auto_upgrade = true
   }
 
@@ -18,7 +18,7 @@ resource "google_container_node_pool" "default" {
     preemptible  = false
     machine_type = var.node_instance_type
     disk_size_gb = var.node_disk_size
-    tags = ["opta-${var.layer_name}-nodes"]
+    tags         = ["opta-${var.layer_name}-nodes"]
 
     service_account = google_service_account.gke_node.email
     oauth_scopes = [

--- a/config/tf_modules/gcp-gke/gke.tf
+++ b/config/tf_modules/gcp-gke/gke.tf
@@ -11,8 +11,8 @@
 //}
 
 resource "google_container_cluster" "primary" {
-  name     = "opta-${var.layer_name}"
-  location = data.google_client_config.current.region
+  name           = "opta-${var.layer_name}"
+  location       = data.google_client_config.current.region
   node_locations = var.node_zone_names
 
   # We can't create a cluster with no node pool defined, but we want to only use
@@ -21,7 +21,7 @@ resource "google_container_cluster" "primary" {
   remove_default_node_pool = true
   initial_node_count       = 1
 
-  network = var.vpc_self_link
+  network    = var.vpc_self_link
   subnetwork = var.private_subnet_self_link
   workload_identity_config {
     identity_namespace = "${data.google_client_config.current.project}.svc.id.goog"
@@ -33,7 +33,7 @@ resource "google_container_cluster" "primary" {
   }
 
   database_encryption {
-    state = "ENCRYPTED"
+    state    = "ENCRYPTED"
     key_name = data.google_kms_crypto_key.kms.self_link
   }
 
@@ -46,7 +46,7 @@ resource "google_container_cluster" "primary" {
     channel = var.gke_channel
   }
   ip_allocation_policy {
-    cluster_secondary_range_name = "gke-pods"
+    cluster_secondary_range_name  = "gke-pods"
     services_secondary_range_name = "gke-services"
   }
 }

--- a/config/tf_modules/gcp-gke/iam.tf
+++ b/config/tf_modules/gcp-gke/iam.tf
@@ -1,8 +1,8 @@
 resource "random_string" "node_group_hash" {
-  length = 4
+  length  = 4
   special = false
-  lower = true
-  upper = false
+  lower   = true
+  upper   = false
 }
 
 // https://cloud.google.com/kubernetes-engine/docs/how-to/hardening-your-cluster#use_least_privilege_sa
@@ -12,27 +12,27 @@ resource "google_service_account" "gke_node" {
 }
 
 resource "google_project_iam_member" "gke_node_log_writer" {
-  role    = "roles/logging.logWriter"
-  member  = "serviceAccount:${google_service_account.gke_node.email}"
+  role   = "roles/logging.logWriter"
+  member = "serviceAccount:${google_service_account.gke_node.email}"
 }
 
 resource "google_project_iam_member" "gke_node_metric_writer" {
-  role    = "roles/monitoring.metricWriter"
-  member  = "serviceAccount:${google_service_account.gke_node.email}"
+  role   = "roles/monitoring.metricWriter"
+  member = "serviceAccount:${google_service_account.gke_node.email}"
 }
 
 resource "google_project_iam_member" "gke_node_monitoring_viewer" {
-  role    = "roles/monitoring.viewer"
-  member  = "serviceAccount:${google_service_account.gke_node.email}"
+  role   = "roles/monitoring.viewer"
+  member = "serviceAccount:${google_service_account.gke_node.email}"
 }
 
 resource "google_project_iam_member" "gke_node_stackdriver_writer" {
-  role    = "roles/stackdriver.resourceMetadata.writer"
-  member  = "serviceAccount:${google_service_account.gke_node.email}"
+  role   = "roles/stackdriver.resourceMetadata.writer"
+  member = "serviceAccount:${google_service_account.gke_node.email}"
 }
 
 resource "google_storage_bucket_iam_member" "viewer" {
   bucket = "artifacts.${data.google_client_config.current.project}.appspot.com"
-  role = "roles/storage.objectViewer"
+  role   = "roles/storage.objectViewer"
   member = "serviceAccount:${google_service_account.gke_node.email}"
 }

--- a/config/tf_modules/gcp-gke/variables.tf
+++ b/config/tf_modules/gcp-gke/variables.tf
@@ -2,7 +2,7 @@ data "google_client_config" "current" {}
 
 variable "env_name" {
   description = "Env name"
-  type = string
+  type        = string
 }
 
 variable "layer_name" {
@@ -12,11 +12,11 @@ variable "layer_name" {
 
 variable "module_name" {
   description = "Module name"
-  type = string
+  type        = string
 }
 
 variable "gke_channel" {
-  type = string
+  type    = string
   default = "REGULAR"
 }
 
@@ -35,7 +35,7 @@ data "google_kms_key_ring" "key_ring" {
 
 data "google_kms_crypto_key" "kms" {
   key_ring = data.google_kms_key_ring.key_ring.self_link
-  name = "opta-${var.env_name}-${data.google_secret_manager_secret_version.kms_suffix.secret_data}"
+  name     = "opta-${var.env_name}-${data.google_secret_manager_secret_version.kms_suffix.secret_data}"
 }
 
 variable "vpc_self_link" {

--- a/config/tf_modules/gcp-k8s-base/cert_manager.tf
+++ b/config/tf_modules/gcp-k8s-base/cert_manager.tf
@@ -1,15 +1,15 @@
 resource "helm_release" "cert_manager" {
-  chart = "cert-manager"
-  repository = "https://charts.jetstack.io"
-  name = "cert-manager"
-  namespace = "cert-manager"
+  chart            = "cert-manager"
+  repository       = "https://charts.jetstack.io"
+  name             = "cert-manager"
+  namespace        = "cert-manager"
   create_namespace = true
-  atomic = true
-  cleanup_on_fail = true
-  version = "1.3.1"
+  atomic           = true
+  cleanup_on_fail  = true
+  version          = "1.3.1"
   values = [
     yamlencode({
-      installCRDs: true
+      installCRDs : true
     })
   ]
 }

--- a/config/tf_modules/gcp-k8s-base/ingress_nginx.tf
+++ b/config/tf_modules/gcp-k8s-base/ingress_nginx.tf
@@ -1,68 +1,68 @@
 // NOTE: following this solution for http -> https redirect: https://github.com/kubernetes/ingress-nginx/issues/2724#issuecomment-593769295
 resource "helm_release" "ingress-nginx" {
-  chart = "ingress-nginx"
-  name = "ingress-nginx"
-  repository = "https://kubernetes.github.io/ingress-nginx"
-  namespace = "ingress-nginx"
+  chart            = "ingress-nginx"
+  name             = "ingress-nginx"
+  repository       = "https://kubernetes.github.io/ingress-nginx"
+  namespace        = "ingress-nginx"
   create_namespace = true
-  atomic = true
-  cleanup_on_fail = true
+  atomic           = true
+  cleanup_on_fail  = true
   values = [
     yamlencode({
-      controller: {
-        config: local.config
-        podAnnotations: {
-          "linkerd.io/inject": "enabled"
+      controller : {
+        config : local.config
+        podAnnotations : {
+          "linkerd.io/inject" : "enabled"
         }
-        resources: {
-          requests: {
-            cpu: "200m"
-            memory: "250Mi"
+        resources : {
+          requests : {
+            cpu : "200m"
+            memory : "250Mi"
           }
         }
-        autoscaling: {
-          enabled: var.high_availability ? true : false
-          minReplicas: var.high_availability ? 3 : 1
+        autoscaling : {
+          enabled : var.high_availability ? true : false
+          minReplicas : var.high_availability ? 3 : 1
         }
-        affinity: {
-          podAntiAffinity: {
-            preferredDuringSchedulingIgnoredDuringExecution: [
+        affinity : {
+          podAntiAffinity : {
+            preferredDuringSchedulingIgnoredDuringExecution : [
               {
-                weight: 50
-                podAffinityTerm: {
-                  labelSelector: {
-                    matchExpressions: [
+                weight : 50
+                podAffinityTerm : {
+                  labelSelector : {
+                    matchExpressions : [
                       {
-                        key: "app.kubernetes.io/name"
-                        operator: "In"
-                        values: ["ingress-nginx"]
+                        key : "app.kubernetes.io/name"
+                        operator : "In"
+                        values : ["ingress-nginx"]
                       },
                       {
-                        key: "app.kubernetes.io/instance"
-                        operator: "In"
-                        values: ["ingress-nginx"]
+                        key : "app.kubernetes.io/instance"
+                        operator : "In"
+                        values : ["ingress-nginx"]
                       },
                       {
-                        key: "app.kubernetes.io/component"
-                        operator: "In"
-                        values: ["controller"]
+                        key : "app.kubernetes.io/component"
+                        operator : "In"
+                        values : ["controller"]
                       }
                     ]
                   }
-                  topologyKey: "topology.kubernetes.io/zone"
+                  topologyKey : "topology.kubernetes.io/zone"
                 }
               }
             ]
           }
         }
-        containerPort: local.container_ports
-        service: {
-          loadBalancerSourceRanges: ["0.0.0.0/0"]
-          externalTrafficPolicy: "Local"
-          enableHttps: true
-          targetPorts: local.target_ports
-          annotations: {
-            "cloud.google.com/neg": local.annotations
+        containerPort : local.container_ports
+        service : {
+          loadBalancerSourceRanges : ["0.0.0.0/0"]
+          externalTrafficPolicy : "Local"
+          enableHttps : true
+          targetPorts : local.target_ports
+          annotations : {
+            "cloud.google.com/neg" : local.annotations
           }
         }
       }

--- a/config/tf_modules/gcp-k8s-base/linkerd.tf
+++ b/config/tf_modules/gcp-k8s-base/linkerd.tf
@@ -55,8 +55,8 @@ resource "tls_locally_signed_cert" "issuer_cert" {
 
 
 resource "helm_release" "linkerd" {
-  chart = "linkerd2"
-  name = "linkerd"
+  chart      = "linkerd2"
+  name       = "linkerd"
   repository = "https://helm.linkerd.io/stable"
   # Version 2.10.0 is not backwards compatible.
   version = "2.9.4"
@@ -81,7 +81,7 @@ resource "helm_release" "linkerd" {
     value = tls_private_key.issuer_key.private_key_pem
   }
 
-  values = var.high_availability ?  [
+  values = var.high_availability ? [
     file("${path.module}/values-ha.yaml") # Adding the high-availability default values.
   ] : []
 }

--- a/config/tf_modules/gcp-k8s-base/opta_base.tf
+++ b/config/tf_modules/gcp-k8s-base/opta_base.tf
@@ -1,6 +1,6 @@
 resource "helm_release" "opta_base" {
-  chart = "${path.module}/opta-base"
-  name = "opta-base"
+  chart     = "${path.module}/opta-base"
+  name      = "opta-base"
   namespace = "default"
   depends_on = [
     helm_release.cert_manager

--- a/config/tf_modules/gcp-k8s-base/variables.tf
+++ b/config/tf_modules/gcp-k8s-base/variables.tf
@@ -1,15 +1,15 @@
 locals {
-  target_ports = { http: "http", https: "https" }
-  container_ports = { http: 80, https: 443 }
-  config = { ssl-redirect: false }
-  annotations = "{\"exposed_ports\": { \"443\":{\"name\": \"opta-${var.layer_name}-https\"}}}"
-  negs = formatlist("https://www.googleapis.com/compute/v1/projects/%s/zones/%s/networkEndpointGroups/opta-%s-https", data.google_client_config.current.project, var.zone_names, var.layer_name)
+  target_ports    = { http : "http", https : "https" }
+  container_ports = { http : 80, https : 443 }
+  config          = { ssl-redirect : false }
+  annotations     = "{\"exposed_ports\": { \"443\":{\"name\": \"opta-${var.layer_name}-https\"}}}"
+  negs            = formatlist("https://www.googleapis.com/compute/v1/projects/%s/zones/%s/networkEndpointGroups/opta-%s-https", data.google_client_config.current.project, var.zone_names, var.layer_name)
 }
 
 data "google_client_config" "current" {}
 
 data "google_container_cluster" "main" {
-  name = "opta-${var.env_name}"
+  name     = "opta-${var.env_name}"
   location = data.google_client_config.current.region
 }
 data "google_compute_network" "vpc" {
@@ -18,7 +18,7 @@ data "google_compute_network" "vpc" {
 
 variable "env_name" {
   description = "Env name"
-  type = string
+  type        = string
 }
 
 variable "layer_name" {
@@ -28,30 +28,30 @@ variable "layer_name" {
 
 variable "module_name" {
   description = "Module name"
-  type = string
+  type        = string
 }
 
 variable "high_availability" {
-  type = bool
+  type    = bool
   default = true
 }
 
 variable "delegated" {
-  type = bool
+  type    = bool
   default = false
 }
 
 variable "cert_self_link" {
-  type = string
+  type    = string
   default = null
 }
 
 variable "hosted_zone_name" {
-  type = string
+  type    = string
   default = null
 }
 
 variable "zone_names" {
-  type = list(string)
+  type    = list(string)
   default = []
 }

--- a/config/tf_modules/gcp-k8s-service/iam.tf
+++ b/config/tf_modules/gcp-k8s-service/iam.tf
@@ -5,23 +5,23 @@ resource "google_service_account" "k8s_service" {
 
 resource "google_service_account_iam_binding" "trust_k8s_workload_idu" {
   service_account_id = google_service_account.k8s_service.name
-  role = "roles/iam.workloadIdentityUser"
+  role               = "roles/iam.workloadIdentityUser"
   members = [
     "serviceAccount:${data.google_client_config.current.project}.svc.id.goog[${var.layer_name}/${var.module_name}]"
   ]
 }
 
 resource "google_storage_bucket_iam_member" "bucket_viewer" {
-  count = length(var.read_buckets)
+  count  = length(var.read_buckets)
   bucket = var.read_buckets[count.index]
-  role = "roles/storage.objectViewer"
+  role   = "roles/storage.objectViewer"
   member = "serviceAccount:${google_service_account.k8s_service.email}"
 }
 
 resource "google_storage_bucket_iam_member" "viewer" {
-  count = length(var.write_buckets)
+  count  = length(var.write_buckets)
   bucket = var.write_buckets[count.index]
-  role = "roles/storage.objectAdmin"
+  role   = "roles/storage.objectAdmin"
   member = "serviceAccount:${google_service_account.k8s_service.email}"
 }
 

--- a/config/tf_modules/gcp-k8s-service/main.tf
+++ b/config/tf_modules/gcp-k8s-service/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     kubernetes = {
-      source = "hashicorp/kubernetes"
+      source  = "hashicorp/kubernetes"
       version = ">= 1.13.3"
     }
   }
@@ -9,37 +9,37 @@ terraform {
 
 resource "helm_release" "k8s-service" {
   chart = "${path.module}/k8s-service"
-  name = "${var.layer_name}-${var.module_name}"
+  name  = "${var.layer_name}-${var.module_name}"
   values = [
     yamlencode({
-      deployment_timestamp: timestamp()
-      autoscaling: {
-        minReplicas: var.min_containers,
-        maxReplicas: var.min_containers,
-        targetCPUUtilizationPercentage: var.autoscaling_target_cpu_percentage
-        targetMemoryUtilizationPercentage: var.autoscaling_target_mem_percentage
+      deployment_timestamp : timestamp()
+      autoscaling : {
+        minReplicas : var.min_containers,
+        maxReplicas : var.min_containers,
+        targetCPUUtilizationPercentage : var.autoscaling_target_cpu_percentage
+        targetMemoryUtilizationPercentage : var.autoscaling_target_mem_percentage
       },
-      port: var.port,
-      containerResourceLimits: {
-        cpu: "${var.resource_request["cpu"] * 2}m"
-        memory: "${var.resource_request["memory"] * 2}Mi"
+      port : var.port,
+      containerResourceLimits : {
+        cpu : "${var.resource_request["cpu"] * 2}m"
+        memory : "${var.resource_request["memory"] * 2}Mi"
       },
-      containerResourceRequests: {
-        cpu: "${var.resource_request["cpu"]}m"
-        memory: "${var.resource_request["memory"]}Mi"
+      containerResourceRequests : {
+        cpu : "${var.resource_request["cpu"]}m"
+        memory : "${var.resource_request["memory"]}Mi"
       },
-      deployPods: (var.image != "AUTO") || (var.tag != null),
-      image: var.image == "AUTO" ? (var.tag == null ? "": "${data.google_container_registry_repository.root.repository_url}/${var.layer_name}/${var.module_name}:${var.tag}") : (var.tag == null ? var.image : "${var.image}:${var.tag}")
-      version: var.tag == null ? "latest" : var.tag
-      livenessProbePath: var.healthcheck_path == null || var.liveness_probe_path != "/healthcheck"? var.liveness_probe_path : var.healthcheck_path,
-      readinessProbePath: var.healthcheck_path == null || var.readiness_probe_path != "/healthcheck"? var.readiness_probe_path : var.healthcheck_path,
-      envVars: var.env_vars,
-      linkSecrets: var.link_secrets,
-      manualSecrets: var.manual_secrets,
-      uriComponents: local.uri_components,
-      layerName: var.layer_name,
-      moduleName: var.module_name
-      googleServiceAccount: google_service_account.k8s_service.email
+      deployPods : (var.image != "AUTO") || (var.tag != null),
+      image : var.image == "AUTO" ? (var.tag == null ? "" : "${data.google_container_registry_repository.root.repository_url}/${var.layer_name}/${var.module_name}:${var.tag}") : (var.tag == null ? var.image : "${var.image}:${var.tag}")
+      version : var.tag == null ? "latest" : var.tag
+      livenessProbePath : var.healthcheck_path == null || var.liveness_probe_path != "/healthcheck" ? var.liveness_probe_path : var.healthcheck_path,
+      readinessProbePath : var.healthcheck_path == null || var.readiness_probe_path != "/healthcheck" ? var.readiness_probe_path : var.healthcheck_path,
+      envVars : var.env_vars,
+      linkSecrets : var.link_secrets,
+      manualSecrets : var.manual_secrets,
+      uriComponents : local.uri_components,
+      layerName : var.layer_name,
+      moduleName : var.module_name
+      googleServiceAccount : google_service_account.k8s_service.email
     })
   ]
   atomic          = true

--- a/config/tf_modules/gcp-k8s-service/variables.tf
+++ b/config/tf_modules/gcp-k8s-service/variables.tf
@@ -3,18 +3,18 @@ data "google_client_config" "current" {}
 
 
 locals {
-  uri_components = [for s in var.public_uri: {
-    domain: trim(split("/", s)[0], "."),
-    pathPrefix: (length(split("/", s)) > 1 ? "/${join("/",slice(split("/", s), 1, length(split("/", s))))}" : "/")
+  uri_components = [for s in var.public_uri : {
+    domain : trim(split("/", s)[0], "."),
+    pathPrefix : (length(split("/", s)) > 1 ? "/${join("/", slice(split("/", s), 1, length(split("/", s))))}" : "/")
   }]
-  env_short = substr(var.env_name, 0, 9)
-  layer_short = substr(var.layer_name, 0, 9)
+  env_short    = substr(var.env_name, 0, 9)
+  layer_short  = substr(var.layer_name, 0, 9)
   module_short = substr(var.module_name, 0, 9)
 }
 
 variable "env_name" {
   description = "Env name"
-  type = string
+  type        = string
 }
 
 variable "layer_name" {
@@ -24,107 +24,107 @@ variable "layer_name" {
 
 variable "module_name" {
   description = "Module name"
-  type = string
+  type        = string
 }
 
 variable "port" {
   description = "Port to be exposed as :80"
-  type = map(number)
+  type        = map(number)
 }
 
 variable "image" {
   description = "External Image to be deployed"
-  type = string
+  type        = string
 }
 
 variable "tag" {
   description = "Tag of image to be deployed"
-  type = string
-  default = null
+  type        = string
+  default     = null
 }
 
 variable "min_containers" {
   description = "Min value for HPA autoscaling"
-  type = string
-  default = 1
+  type        = string
+  default     = 1
 }
 
 variable "max_containers" {
   description = "Max value for HPA autoscaling"
-  type = string
-  default = 3
+  type        = string
+  default     = 3
 }
 
 variable "autoscaling_target_cpu_percentage" {
   description = "Percentage of requested cpu after which autoscaling kicks in"
-  default = 80
+  default     = 80
 }
 
 variable "autoscaling_target_mem_percentage" {
   description = "Percentage of requested memory after which autoscaling kicks in"
-  default = 80
+  default     = 80
 }
 
 variable "liveness_probe_path" {
   description = "Url path for liveness probe"
-  type = string
-  default = "/healthcheck"
+  type        = string
+  default     = "/healthcheck"
 }
 
 variable "readiness_probe_path" {
   description = "Url path for readiness probe"
-  type = string
-  default = "/healthcheck"
+  type        = string
+  default     = "/healthcheck"
 }
 
 variable "healthcheck_path" {
-  type = string
+  type    = string
   default = null
 }
 
 variable "resource_request" {
-  type = map
+  type = map(any)
   default = {
-    cpu: 100
-    memory: 128
+    cpu : 100
+    memory : 128
   }
 }
 
 variable "env_vars" {
   description = "Environment variables to pass to the container"
   type = list(object({
-    name = string
+    name  = string
     value = string
   }))
   default = []
 }
 
 variable "public_uri" {
-  type = list(string)
+  type    = list(string)
   default = []
 }
 
 variable "domain" {
-  type = string
+  type    = string
   default = ""
 }
 
 variable "link_secrets" {
-  type = list(map(string))
+  type    = list(map(string))
   default = []
 }
 
 variable "manual_secrets" {
-  type = list(string)
+  type    = list(string)
   default = []
 }
 
 variable "read_buckets" {
-  type = list(string)
+  type    = list(string)
   default = []
 }
 
 variable "write_buckets" {
-  type = list(string)
+  type    = list(string)
   default = []
 }

--- a/config/tf_modules/gcp-postgres/main.tf
+++ b/config/tf_modules/gcp-postgres/main.tf
@@ -3,29 +3,29 @@ resource "random_id" "key_suffix" {
 }
 
 resource "random_password" "root_auth" {
-  length = 20
+  length  = 20
   special = false
 }
 
 # TODO: add encryption key name once out of beta
 resource "google_sql_database_instance" "instance" {
-  name   = "opta-${var.layer_name}-${var.module_name}-${random_id.key_suffix.hex}"
-  database_version = "POSTGRES_${var.engine_version}"
+  name                = "opta-${var.layer_name}-${var.module_name}-${random_id.key_suffix.hex}"
+  database_version    = "POSTGRES_${var.engine_version}"
   deletion_protection = var.safety
 
   settings {
-    disk_autoresize = true
-    disk_type       = "PD_SSD"
-    pricing_plan    = "PER_USE"
+    disk_autoresize   = true
+    disk_type         = "PD_SSD"
+    pricing_plan      = "PER_USE"
     availability_type = "REGIONAL"
-    tier = var.instance_tier
+    tier              = var.instance_tier
     ip_configuration {
       ipv4_enabled    = false
       private_network = data.google_compute_network.vpc.id
     }
     backup_configuration {
-      enabled            = true
-      start_time         = "23:00"
+      enabled    = true
+      start_time = "23:00"
     }
   }
 

--- a/config/tf_modules/gcp-postgres/outputs.tf
+++ b/config/tf_modules/gcp-postgres/outputs.tf
@@ -3,7 +3,7 @@ output "db_user" {
 }
 
 output "db_password" {
-  value = google_sql_user.root.password
+  value     = google_sql_user.root.password
   sensitive = true
 }
 

--- a/config/tf_modules/gcp-postgres/variables.tf
+++ b/config/tf_modules/gcp-postgres/variables.tf
@@ -4,7 +4,7 @@ data "google_compute_network" "vpc" {
 
 variable "env_name" {
   description = "Env name"
-  type = string
+  type        = string
 }
 
 variable "layer_name" {
@@ -14,20 +14,20 @@ variable "layer_name" {
 
 variable "module_name" {
   description = "Module name"
-  type = string
+  type        = string
 }
 
 variable "engine_version" {
-  type = string
+  type    = string
   default = "11"
 }
 
 variable "instance_tier" {
-  type = string
+  type    = string
   default = "db-f1-micro"
 }
 
 variable "safety" {
-  type = bool
+  type    = bool
   default = false
 }

--- a/config/tf_modules/gcp-redis/main.tf
+++ b/config/tf_modules/gcp-redis/main.tf
@@ -1,11 +1,11 @@
 # TODO: TLS transit encryption
 resource "google_redis_instance" "main" {
-  memory_size_gb = var.memory_size_gb
-  name = "opta-${var.layer_name}-${var.module_name}"
-  display_name = "opta-${var.layer_name}-${var.module_name}"
-  tier = var.high_availability ? "STANDARD_HA" : "BASIC"
+  memory_size_gb     = var.memory_size_gb
+  name               = "opta-${var.layer_name}-${var.module_name}"
+  display_name       = "opta-${var.layer_name}-${var.module_name}"
+  tier               = var.high_availability ? "STANDARD_HA" : "BASIC"
   authorized_network = data.google_compute_network.vpc.id
   connect_mode       = "PRIVATE_SERVICE_ACCESS"
-  redis_version = var.redis_version
-  auth_enabled = true
+  redis_version      = var.redis_version
+  auth_enabled       = true
 }

--- a/config/tf_modules/gcp-redis/outputs.tf
+++ b/config/tf_modules/gcp-redis/outputs.tf
@@ -1,5 +1,5 @@
 output "cache_auth_token" {
-  value = google_redis_instance.main.auth_string
+  value     = google_redis_instance.main.auth_string
   sensitive = true
 }
 

--- a/config/tf_modules/gcp-redis/variables.tf
+++ b/config/tf_modules/gcp-redis/variables.tf
@@ -3,13 +3,13 @@ data "google_compute_network" "vpc" {
 }
 
 variable "node_type" {
-  type = string
+  type    = string
   default = "cache.m4.large"
 }
 
 variable "env_name" {
   description = "Env name"
-  type = string
+  type        = string
 }
 
 variable "layer_name" {
@@ -19,20 +19,20 @@ variable "layer_name" {
 
 variable "module_name" {
   description = "Module name"
-  type = string
+  type        = string
 }
 
 variable "redis_version" {
-  type = string
+  type    = string
   default = "REDIS_5_0"
 }
 
 variable "high_availability" {
-  type = bool
+  type    = bool
   default = true
 }
 
 variable "memory_size_gb" {
-  type = number
+  type    = number
   default = 2
 }

--- a/config/tf_modules/helm-chart/main.tf
+++ b/config/tf_modules/helm-chart/main.tf
@@ -1,33 +1,33 @@
 resource "helm_release" "remote_chart" {
-  count = var.repository == null? 0 : 1
-  chart = var.chart
-  repository = var.repository
-  version = var.chart_version
-  name = "${var.layer_name}-${var.module_name}"
-  atomic = var.atomic
-  cleanup_on_fail = var.cleanup_on_fail
-  namespace = var.namespace
+  count            = var.repository == null ? 0 : 1
+  chart            = var.chart
+  repository       = var.repository
+  version          = var.chart_version
+  name             = "${var.layer_name}-${var.module_name}"
+  atomic           = var.atomic
+  cleanup_on_fail  = var.cleanup_on_fail
+  namespace        = var.namespace
   create_namespace = var.create_namespace
   values = var.values_file == null ? [yamlencode(var.values)] : [
     file(var.values_file),
     yamlencode(var.values)
   ]
-  timeout = var.timeout
+  timeout           = var.timeout
   dependency_update = var.dependency_update
 }
 
 resource "helm_release" "local_chart" {
-  count = var.repository == null? 1 : 0
-  chart = var.chart
-  name = "${var.layer_name}-${var.module_name}"
-  atomic = var.atomic
-  cleanup_on_fail = var.cleanup_on_fail
-  namespace = var.namespace
+  count            = var.repository == null ? 1 : 0
+  chart            = var.chart
+  name             = "${var.layer_name}-${var.module_name}"
+  atomic           = var.atomic
+  cleanup_on_fail  = var.cleanup_on_fail
+  namespace        = var.namespace
   create_namespace = var.create_namespace
   values = var.values_file == null ? [yamlencode(var.values)] : [
     file(var.values_file),
     yamlencode(var.values)
   ]
-  timeout = var.timeout
+  timeout           = var.timeout
   dependency_update = var.dependency_update
 }

--- a/config/tf_modules/helm-chart/variables.tf
+++ b/config/tf_modules/helm-chart/variables.tf
@@ -1,5 +1,5 @@
 variable "repository" {
-  type = string
+  type    = string
   default = null
 }
 
@@ -8,32 +8,32 @@ variable "chart" {
 }
 
 variable "namespace" {
-  type = string
+  type    = string
   default = "default"
 }
 
 variable "create_namespace" {
-  type = bool
+  type    = bool
   default = false
 }
 
 variable "atomic" {
-  type = bool
+  type    = bool
   default = true
 }
 
 variable "cleanup_on_fail" {
-  type = bool
+  type    = bool
   default = true
 }
 
 variable "chart_version" {
-  type = string
+  type    = string
   default = null
 }
 
 variable "values_file" {
-  type = string
+  type    = string
   default = null
 }
 
@@ -43,7 +43,7 @@ variable "values" {
 
 variable "env_name" {
   description = "Env name"
-  type = string
+  type        = string
 }
 
 variable "layer_name" {
@@ -53,16 +53,16 @@ variable "layer_name" {
 
 variable "module_name" {
   description = "Module name"
-  type = string
+  type        = string
 }
 
 variable "timeout" {
-  type = number
+  type    = number
   default = 300
 }
 
 variable "dependency_update" {
-  type = bool
+  type    = bool
   default = true
 }
 

--- a/config/tf_modules/k8s-base/autoscaler.tf
+++ b/config/tf_modules/k8s-base/autoscaler.tf
@@ -10,12 +10,12 @@ data "aws_iam_policy_document" "autoscaler" {
       "ec2:DescribeLaunchTemplateVersions"
     ]
     resources = ["*"]
-    sid = "autoscaling"
+    sid       = "autoscaling"
   }
 }
 
 resource "aws_iam_policy" "autoscaler" {
-  name = "opta-${var.env_name}-k8s-autoscaler"
+  name   = "opta-${var.env_name}-k8s-autoscaler"
   policy = data.aws_iam_policy_document.autoscaler.json
 }
 
@@ -39,36 +39,36 @@ data "aws_iam_policy_document" "trust_k8s_openid" {
 
 resource "aws_iam_role" "autoscaler" {
   assume_role_policy = data.aws_iam_policy_document.trust_k8s_openid.json
-  name = "opta-${var.env_name}-k8s-autoscaler"
+  name               = "opta-${var.env_name}-k8s-autoscaler"
 }
 
 resource "aws_iam_role_policy_attachment" "autoscaler" {
   policy_arn = aws_iam_policy.autoscaler.arn
-  role = aws_iam_role.autoscaler.name
+  role       = aws_iam_role.autoscaler.name
 }
 
 resource "helm_release" "autoscaler" {
-  chart = "cluster-autoscaler"
-  name = "cluster-autoscaler"
+  chart      = "cluster-autoscaler"
+  name       = "cluster-autoscaler"
   repository = "https://kubernetes.github.io/autoscaler"
   values = [
     yamlencode({
-      autoDiscovery: {
-        clusterName: var.eks_cluster_name
+      autoDiscovery : {
+        clusterName : var.eks_cluster_name
       },
-      rbac: {
-        serviceAccount: {
-          annotations: {
-            "eks.amazonaws.com/role-arn": aws_iam_role.autoscaler.arn
+      rbac : {
+        serviceAccount : {
+          annotations : {
+            "eks.amazonaws.com/role-arn" : aws_iam_role.autoscaler.arn
           }
-          name: "autoscaler"
+          name : "autoscaler"
         }
       }
-      awsRegion: data.aws_region.current.name
+      awsRegion : data.aws_region.current.name
     })
   ]
-  namespace = "autoscaler"
+  namespace        = "autoscaler"
   create_namespace = true
-  cleanup_on_fail = true
-  atomic = true
+  cleanup_on_fail  = true
+  atomic           = true
 }

--- a/config/tf_modules/k8s-base/cert_manager.tf
+++ b/config/tf_modules/k8s-base/cert_manager.tf
@@ -1,15 +1,15 @@
 resource "helm_release" "cert_manager" {
-  chart = "cert-manager"
-  repository = "https://charts.jetstack.io"
-  name = "cert-manager"
-  namespace = "cert-manager"
+  chart            = "cert-manager"
+  repository       = "https://charts.jetstack.io"
+  name             = "cert-manager"
+  namespace        = "cert-manager"
   create_namespace = true
-  atomic = true
-  cleanup_on_fail = true
-  version = "1.3.1"
+  atomic           = true
+  cleanup_on_fail  = true
+  version          = "1.3.1"
   values = [
     yamlencode({
-      installCRDs: true
+      installCRDs : true
     })
   ]
 }

--- a/config/tf_modules/k8s-base/external_dns.tf
+++ b/config/tf_modules/k8s-base/external_dns.tf
@@ -1,11 +1,11 @@
 data "aws_iam_policy_document" "external_dns" {
   statement {
-    sid = "ChangeResourceRecordSets"
+    sid       = "ChangeResourceRecordSets"
     resources = ["arn:aws:route53:::hostedzone/*"]
-    actions = ["route53:ChangeResourceRecordSets"]
+    actions   = ["route53:ChangeResourceRecordSets"]
   }
   statement {
-    sid = "DescribeRoute53"
+    sid       = "DescribeRoute53"
     resources = ["*"]
     actions = [
       "route53:ListHostedZones",
@@ -15,7 +15,7 @@ data "aws_iam_policy_document" "external_dns" {
 }
 
 resource "aws_iam_policy" "external_dns" {
-  name = "opta-${var.env_name}-external-dns"
+  name   = "opta-${var.env_name}-external-dns"
   policy = data.aws_iam_policy_document.external_dns.json
 }
 
@@ -23,48 +23,48 @@ data "aws_iam_policy_document" "external_dns_trust" {
   statement {
     actions = ["sts:AssumeRoleWithWebIdentity"]
     condition {
-      test = "StringEquals"
-      values = ["system:serviceaccount:external-dns:external-dns"]
+      test     = "StringEquals"
+      values   = ["system:serviceaccount:external-dns:external-dns"]
       variable = "${replace(var.openid_provider_url, "https://", "")}:sub"
     }
     principals {
       identifiers = [var.openid_provider_arn]
-      type = "Federated"
+      type        = "Federated"
     }
   }
 }
 
 resource "aws_iam_role" "external_dns" {
-  name = "opta-${var.env_name}-external-dns"
+  name               = "opta-${var.env_name}-external-dns"
   assume_role_policy = data.aws_iam_policy_document.external_dns_trust.json
 }
 
 resource "aws_iam_role_policy_attachment" "external_dns" {
   policy_arn = aws_iam_policy.external_dns.arn
-  role = aws_iam_role.external_dns.name
+  role       = aws_iam_role.external_dns.name
 }
 
 resource "helm_release" "external-dns" {
-  count = var.domain == "" ? 0 : 1
-  chart = "external-dns"
-  name = "external-dns"
-  repository = "https://charts.bitnami.com/bitnami"
-  namespace = "external-dns"
+  count            = var.domain == "" ? 0 : 1
+  chart            = "external-dns"
+  name             = "external-dns"
+  repository       = "https://charts.bitnami.com/bitnami"
+  namespace        = "external-dns"
   create_namespace = true
-  atomic = true
-  cleanup_on_fail = true
-  version = "3.7.0"
+  atomic           = true
+  cleanup_on_fail  = true
+  version          = "3.7.0"
   values = [
     yamlencode({
-      provider: "aws"
-      aws: {
-        zoneType: "public"
+      provider : "aws"
+      aws : {
+        zoneType : "public"
       }
-      domainFilters: [var.domain]
-      serviceAccount: {
-        name: "external-dns"
-        annotations: {
-          "eks.amazonaws.com/role-arn": aws_iam_role.external_dns.arn
+      domainFilters : [var.domain]
+      serviceAccount : {
+        name : "external-dns"
+        annotations : {
+          "eks.amazonaws.com/role-arn" : aws_iam_role.external_dns.arn
         }
       }
     })

--- a/config/tf_modules/k8s-base/ingress_nginx.tf
+++ b/config/tf_modules/k8s-base/ingress_nginx.tf
@@ -1,74 +1,74 @@
 // NOTE: following this solution for http -> https redirect: https://github.com/kubernetes/ingress-nginx/issues/2724#issuecomment-593769295
 resource "helm_release" "ingress-nginx" {
-  chart = "ingress-nginx"
-  name = "ingress-nginx"
-  repository = "https://kubernetes.github.io/ingress-nginx"
-  version = "3.27.0"
-  namespace = "ingress-nginx"
+  chart            = "ingress-nginx"
+  name             = "ingress-nginx"
+  repository       = "https://kubernetes.github.io/ingress-nginx"
+  version          = "3.27.0"
+  namespace        = "ingress-nginx"
   create_namespace = true
-  atomic = true
-  cleanup_on_fail = true
+  atomic           = true
+  cleanup_on_fail  = true
   values = [
     yamlencode({
-      controller: {
-        config: local.config
-        podAnnotations: {
-          "linkerd.io/inject": "enabled"
+      controller : {
+        config : local.config
+        podAnnotations : {
+          "linkerd.io/inject" : "enabled"
         }
-        resources: {
-          requests: {
-            cpu: "200m"
-            memory: "250Mi"
+        resources : {
+          requests : {
+            cpu : "200m"
+            memory : "250Mi"
           }
         }
-        autoscaling: {
-          enabled: var.high_availability ? true : false
-          minReplicas: var.high_availability ? 3 : 1
+        autoscaling : {
+          enabled : var.high_availability ? true : false
+          minReplicas : var.high_availability ? 3 : 1
         }
-        affinity: {
-          podAntiAffinity: {
-            preferredDuringSchedulingIgnoredDuringExecution: [
+        affinity : {
+          podAntiAffinity : {
+            preferredDuringSchedulingIgnoredDuringExecution : [
               {
-                weight: 50
-                podAffinityTerm: {
-                  labelSelector: {
-                    matchExpressions: [
+                weight : 50
+                podAffinityTerm : {
+                  labelSelector : {
+                    matchExpressions : [
                       {
-                        key: "app.kubernetes.io/name"
-                        operator: "In"
-                        values: ["ingress-nginx"]
+                        key : "app.kubernetes.io/name"
+                        operator : "In"
+                        values : ["ingress-nginx"]
                       },
                       {
-                        key: "app.kubernetes.io/instance"
-                        operator: "In"
-                        values: ["ingress-nginx"]
+                        key : "app.kubernetes.io/instance"
+                        operator : "In"
+                        values : ["ingress-nginx"]
                       },
                       {
-                        key: "app.kubernetes.io/component"
-                        operator: "In"
-                        values: ["controller"]
+                        key : "app.kubernetes.io/component"
+                        operator : "In"
+                        values : ["controller"]
                       }
                     ]
                   }
-                  topologyKey: "topology.kubernetes.io/zone"
+                  topologyKey : "topology.kubernetes.io/zone"
                 }
               }
             ]
           }
         }
-        containerPort: local.container_ports
-        service: {
-          loadBalancerSourceRanges: ["0.0.0.0/0"]
-          externalTrafficPolicy: "Local"
-          enableHttps: var.cert_arn == "" ? false : true
-          targetPorts: local.target_ports
-          annotations: {
-            "service.beta.kubernetes.io/aws-load-balancer-backend-protocol": "ssl"
-            "service.beta.kubernetes.io/aws-load-balancer-proxy-protocol": "*"
-            "service.beta.kubernetes.io/aws-load-balancer-type": "nlb"
-            "service.beta.kubernetes.io/aws-load-balancer-ssl-ports": var.cert_arn == "" ? "" : "https"
-            "service.beta.kubernetes.io/aws-load-balancer-ssl-cert": var.cert_arn
-            "external-dns.alpha.kubernetes.io/hostname": var.domain == "" ? "" : join(",", [var.domain, "*.${var.domain}"])
+        containerPort : local.container_ports
+        service : {
+          loadBalancerSourceRanges : ["0.0.0.0/0"]
+          externalTrafficPolicy : "Local"
+          enableHttps : var.cert_arn == "" ? false : true
+          targetPorts : local.target_ports
+          annotations : {
+            "service.beta.kubernetes.io/aws-load-balancer-backend-protocol" : "ssl"
+            "service.beta.kubernetes.io/aws-load-balancer-proxy-protocol" : "*"
+            "service.beta.kubernetes.io/aws-load-balancer-type" : "nlb"
+            "service.beta.kubernetes.io/aws-load-balancer-ssl-ports" : var.cert_arn == "" ? "" : "https"
+            "service.beta.kubernetes.io/aws-load-balancer-ssl-cert" : var.cert_arn
+            "external-dns.alpha.kubernetes.io/hostname" : var.domain == "" ? "" : join(",", [var.domain, "*.${var.domain}"])
           }
         }
       }

--- a/config/tf_modules/k8s-base/linkerd.tf
+++ b/config/tf_modules/k8s-base/linkerd.tf
@@ -55,8 +55,8 @@ resource "tls_locally_signed_cert" "issuer_cert" {
 
 
 resource "helm_release" "linkerd" {
-  chart = "linkerd2"
-  name = "linkerd"
+  chart      = "linkerd2"
+  name       = "linkerd"
   repository = "https://helm.linkerd.io/stable"
   # Version 2.10.0 is not backwards compatible.
   version = "2.9.4"
@@ -81,7 +81,7 @@ resource "helm_release" "linkerd" {
     value = tls_private_key.issuer_key.private_key_pem
   }
 
-  values = var.high_availability ?  [
+  values = var.high_availability ? [
     file("${path.module}/values-ha.yaml") # Adding the high-availability default values.
   ] : []
 }

--- a/config/tf_modules/k8s-base/metrics_server.tf
+++ b/config/tf_modules/k8s-base/metrics_server.tf
@@ -1,21 +1,21 @@
 resource "helm_release" "metrics_server" {
-  chart = "metrics-server"
-  name = "metrics-server"
-  repository = "https://charts.bitnami.com/bitnami"
-  namespace = "kube-system"
-  version = "5.3.3"
-  atomic = true
+  chart           = "metrics-server"
+  name            = "metrics-server"
+  repository      = "https://charts.bitnami.com/bitnami"
+  namespace       = "kube-system"
+  version         = "5.3.3"
+  atomic          = true
   cleanup_on_fail = true
   values = [
     yamlencode({
-      rbac: {
-        create: true
+      rbac : {
+        create : true
       }
-      serviceAccount: {
-        create: true
+      serviceAccount : {
+        create : true
       }
-      apiService: {
-        create: true
+      apiService : {
+        create : true
       }
     })
   ]

--- a/config/tf_modules/k8s-base/opta_base.tf
+++ b/config/tf_modules/k8s-base/opta_base.tf
@@ -1,10 +1,10 @@
 resource "helm_release" "opta_base" {
-  chart = "${path.module}/opta-base"
-  name = "opta-base"
+  chart     = "${path.module}/opta-base"
+  name      = "opta-base"
   namespace = "default"
   values = [
     yamlencode({
-      adminArns: var.admin_arns
+      adminArns : var.admin_arns
     })
   ]
   depends_on = [

--- a/config/tf_modules/k8s-base/variables.tf
+++ b/config/tf_modules/k8s-base/variables.tf
@@ -1,11 +1,11 @@
 data "aws_region" "current" {}
 
 locals {
-  target_ports = var.cert_arn == "" ? { http: "http" } : { http: "http", https: "https" }
-  container_ports = var.cert_arn == "" ? { http: 80, https: 443 } : { http: 80, https: 443 }
-  config = var.cert_arn == "" ? { ssl-redirect: false } : {
-    ssl-redirect: false
-    server-snippet: <<EOF
+  target_ports    = var.cert_arn == "" ? { http : "http" } : { http : "http", https : "https" }
+  container_ports = var.cert_arn == "" ? { http : 80, https : 443 } : { http : 80, https : 443 }
+  config = var.cert_arn == "" ? { ssl-redirect : false } : {
+    ssl-redirect : false
+    server-snippet : <<EOF
           if ( $server_port = 80 ) {
              return 308 https://$host$request_uri;
           }
@@ -19,7 +19,7 @@ variable "eks_cluster_name" {
 
 variable "env_name" {
   description = "Env name"
-  type = string
+  type        = string
 }
 
 variable "layer_name" {
@@ -29,16 +29,16 @@ variable "layer_name" {
 
 variable "module_name" {
   description = "Module name"
-  type = string
+  type        = string
 }
 
 variable "domain" {
-  type = string
+  type    = string
   default = ""
 }
 
 variable "cert_arn" {
-  type = string
+  type    = string
   default = ""
 }
 
@@ -51,11 +51,11 @@ variable "openid_provider_arn" {
 }
 
 variable "high_availability" {
-  type = bool
+  type    = bool
   default = true
 }
 
 variable "admin_arns" {
-  type = list(string)
+  type    = list(string)
   default = []
 }

--- a/config/tf_modules/k8s-service/ecr.tf
+++ b/config/tf_modules/k8s-service/ecr.tf
@@ -1,13 +1,13 @@
 resource "aws_ecr_repository" "repo" {
   count = var.image == "AUTO" ? 1 : 0
-  name = "opta-${var.layer_name}-${var.module_name}"
+  name  = "opta-${var.layer_name}-${var.module_name}"
   tags = {
     terraform = "true"
   }
 }
 
 data "aws_ecr_image" "service_image" {
-  count =  var.image == "AUTO" && var.tag != "" && var.tag != null? 1 : 0
+  count           = var.image == "AUTO" && var.tag != "" && var.tag != null ? 1 : 0
   repository_name = aws_ecr_repository.repo[0].name
   image_tag       = var.tag
 }
@@ -28,13 +28,13 @@ data "aws_iam_policy_document" "repo_policy" {
 }
 
 resource "aws_ecr_repository_policy" "repo_policy" {
-  count = var.image == "AUTO" ? 1 : 0
+  count      = var.image == "AUTO" ? 1 : 0
   policy     = data.aws_iam_policy_document.repo_policy.json
   repository = aws_ecr_repository.repo[0].name
 }
 
 resource "aws_ecr_lifecycle_policy" "repo_policy" {
-  count = var.image == "AUTO" ? 1 : 0
+  count      = var.image == "AUTO" ? 1 : 0
   policy     = file("${path.module}/simple_lifecycle_policy.json")
   repository = aws_ecr_repository.repo[0].name
 }

--- a/config/tf_modules/k8s-service/iam.tf
+++ b/config/tf_modules/k8s-service/iam.tf
@@ -1,5 +1,5 @@
 resource "aws_iam_policy" "k8s_service" {
-  name = "${var.env_name}-${var.layer_name}-${var.module_name}"
+  name   = "${var.env_name}-${var.layer_name}-${var.module_name}"
   policy = jsonencode(var.iam_policy)
 }
 
@@ -23,16 +23,16 @@ data "aws_iam_policy_document" "trust_k8s_openid" {
 
 resource "aws_iam_role" "k8s_service" {
   assume_role_policy = data.aws_iam_policy_document.trust_k8s_openid.json
-  name = "${var.env_name}-${var.layer_name}-${var.module_name}"
+  name               = "${var.env_name}-${var.layer_name}-${var.module_name}"
 }
 
 resource "aws_iam_role_policy_attachment" "vanilla_role_attachment" {
   policy_arn = aws_iam_policy.k8s_service.arn
-  role = aws_iam_role.k8s_service.name
+  role       = aws_iam_role.k8s_service.name
 }
 
 resource "aws_iam_role_policy_attachment" "extra_policies_attachment" {
-  count = length(var.additional_iam_policies)
+  count      = length(var.additional_iam_policies)
   policy_arn = var.additional_iam_policies[count.index]
-  role = aws_iam_role.k8s_service.name
+  role       = aws_iam_role.k8s_service.name
 }

--- a/config/tf_modules/k8s-service/main.tf
+++ b/config/tf_modules/k8s-service/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     kubernetes = {
-      source = "hashicorp/kubernetes"
+      source  = "hashicorp/kubernetes"
       version = ">= 1.13.3"
     }
   }
@@ -9,37 +9,37 @@ terraform {
 
 resource "helm_release" "k8s-service" {
   chart = "${path.module}/k8s-service"
-  name = "${var.layer_name}-${var.module_name}"
+  name  = "${var.layer_name}-${var.module_name}"
   values = [
     yamlencode({
-      deployment_timestamp: timestamp()
-      autoscaling: {
-        minReplicas: var.min_containers,
-        maxReplicas: var.min_containers,
-        targetCPUUtilizationPercentage: var.autoscaling_target_cpu_percentage
-        targetMemoryUtilizationPercentage: var.autoscaling_target_mem_percentage
+      deployment_timestamp : timestamp()
+      autoscaling : {
+        minReplicas : var.min_containers,
+        maxReplicas : var.min_containers,
+        targetCPUUtilizationPercentage : var.autoscaling_target_cpu_percentage
+        targetMemoryUtilizationPercentage : var.autoscaling_target_mem_percentage
       },
-      port: var.port,
-      containerResourceLimits: {
-        cpu: "${var.resource_request["cpu"] * 2}m"
-        memory: "${var.resource_request["memory"] * 2}Mi"
+      port : var.port,
+      containerResourceLimits : {
+        cpu : "${var.resource_request["cpu"] * 2}m"
+        memory : "${var.resource_request["memory"] * 2}Mi"
       },
-      containerResourceRequests: {
-        cpu: "${var.resource_request["cpu"]}m"
-        memory: "${var.resource_request["memory"]}Mi"
+      containerResourceRequests : {
+        cpu : "${var.resource_request["cpu"]}m"
+        memory : "${var.resource_request["memory"]}Mi"
       },
-      deployPods: (var.image != "AUTO") || (var.tag != null),
-      image: var.image == "AUTO" ? (var.tag == null ? "": "${aws_ecr_repository.repo[0].repository_url}:${var.tag}") : (var.tag == null ? var.image : "${var.image}:${var.tag}")
-      version: var.tag == null ? "latest" : var.tag
-      livenessProbePath: var.healthcheck_path == null || var.liveness_probe_path != "/healthcheck"? var.liveness_probe_path : var.healthcheck_path,
-      readinessProbePath: var.healthcheck_path == null || var.readiness_probe_path != "/healthcheck"? var.readiness_probe_path : var.healthcheck_path,
-      envVars: var.env_vars,
-      linkSecrets: var.link_secrets,
-      manualSecrets: var.manual_secrets,
-      uriComponents: local.uri_components,
-      layerName: var.layer_name,
-      moduleName: var.module_name
-      iamRoleArn: aws_iam_role.k8s_service.arn
+      deployPods : (var.image != "AUTO") || (var.tag != null),
+      image : var.image == "AUTO" ? (var.tag == null ? "" : "${aws_ecr_repository.repo[0].repository_url}:${var.tag}") : (var.tag == null ? var.image : "${var.image}:${var.tag}")
+      version : var.tag == null ? "latest" : var.tag
+      livenessProbePath : var.healthcheck_path == null || var.liveness_probe_path != "/healthcheck" ? var.liveness_probe_path : var.healthcheck_path,
+      readinessProbePath : var.healthcheck_path == null || var.readiness_probe_path != "/healthcheck" ? var.readiness_probe_path : var.healthcheck_path,
+      envVars : var.env_vars,
+      linkSecrets : var.link_secrets,
+      manualSecrets : var.manual_secrets,
+      uriComponents : local.uri_components,
+      layerName : var.layer_name,
+      moduleName : var.module_name
+      iamRoleArn : aws_iam_role.k8s_service.arn
     })
   ]
   atomic          = true

--- a/config/tf_modules/k8s-service/variables.tf
+++ b/config/tf_modules/k8s-service/variables.tf
@@ -1,9 +1,9 @@
 data "aws_caller_identity" "current" {}
 
 locals {
-  uri_components = [for s in var.public_uri: {
-    domain: split("/", s)[0],
-    pathPrefix: (length(split("/", s)) > 1 ? "/${join("/",slice(split("/", s), 1, length(split("/", s))))}" : "/")
+  uri_components = [for s in var.public_uri : {
+    domain : split("/", s)[0],
+    pathPrefix : (length(split("/", s)) > 1 ? "/${join("/", slice(split("/", s), 1, length(split("/", s))))}" : "/")
   }]
 }
 
@@ -17,7 +17,7 @@ variable "openid_provider_arn" {
 
 variable "env_name" {
   description = "Env name"
-  type = string
+  type        = string
 }
 
 variable "layer_name" {
@@ -27,98 +27,98 @@ variable "layer_name" {
 
 variable "module_name" {
   description = "Module name"
-  type = string
+  type        = string
 }
 
 variable "port" {
   description = "Port to be exposed as :80"
-  type = map(number)
+  type        = map(number)
 }
 
 variable "image" {
   description = "External Image to be deployed"
-  type = string
+  type        = string
 }
 
 variable "tag" {
   description = "Tag of image to be deployed"
-  type = string
-  default = null
+  type        = string
+  default     = null
 }
 
 variable "min_containers" {
   description = "Min value for HPA autoscaling"
-  type = string
-  default = 1
+  type        = string
+  default     = 1
 }
 
 variable "max_containers" {
   description = "Max value for HPA autoscaling"
-  type = string
-  default = 3
+  type        = string
+  default     = 3
 }
 
 variable "autoscaling_target_cpu_percentage" {
   description = "Percentage of requested cpu after which autoscaling kicks in"
-  default = 80
+  default     = 80
 }
 
 variable "autoscaling_target_mem_percentage" {
   description = "Percentage of requested memory after which autoscaling kicks in"
-  default = 80
+  default     = 80
 }
 
 variable "liveness_probe_path" {
   description = "Url path for liveness probe"
-  type = string
-  default = "/healthcheck"
+  type        = string
+  default     = "/healthcheck"
 }
 
 variable "readiness_probe_path" {
   description = "Url path for readiness probe"
-  type = string
-  default = "/healthcheck"
+  type        = string
+  default     = "/healthcheck"
 }
 
 variable "healthcheck_path" {
-  type = string
+  type    = string
   default = null
 }
 
 variable "resource_request" {
-  type = map
+  type = map(any)
   default = {
-    cpu: 100
-    memory: 128
+    cpu : 100
+    memory : 128
   }
 }
 
 variable "env_vars" {
   description = "Environment variables to pass to the container"
   type = list(object({
-    name = string
+    name  = string
     value = string
   }))
   default = []
 }
 
 variable "public_uri" {
-  type = list(string)
+  type    = list(string)
   default = []
 }
 
 variable "domain" {
-  type = string
+  type    = string
   default = ""
 }
 
 variable "link_secrets" {
-  type = list(map(string))
+  type    = list(map(string))
   default = []
 }
 
 variable "manual_secrets" {
-  type = list(string)
+  type    = list(string)
   default = []
 }
 
@@ -126,6 +126,6 @@ variable "iam_policy" {
 }
 
 variable "additional_iam_policies" {
-  type = list(string)
+  type    = list(string)
   default = []
 }


### PR DESCRIPTION
I know this change looks scary but it's not-- just some long overdue dusting. Terraform has an official "format"/"style" that basically says how to add spaces, new lines etc... think python black or go fmt. It's actually part of the terraform cli and can be invoked with the `terraform fmt` command. It's pretty good and definitely makes the files prettier/more readable and I should have done this a long time ago. You can read more about it here: https://www.terraform.io/docs/cli/commands/fmt.html

All this pr does is: I ran it to add the newlines and spaces to make our tf files prettier, and now terraform format runs as part of the ci. That's it.