### PR TITLE
Send org name and layer name to amplitude

### DIFF
--- a/opta/commands/apply.py
+++ b/opta/commands/apply.py
@@ -102,9 +102,7 @@ def _apply(
 ) -> None:
     _check_terraform_version()
     layer = Layer.load_from_yaml(config, env)
-    import pdb
 
-    pdb.set_trace()
     amplitude_client.send_event(
         amplitude_client.START_GEN_EVENT,
         event_properties={"org_name": layer.org_name, "layer_name": layer.name},

--- a/opta/commands/apply.py
+++ b/opta/commands/apply.py
@@ -101,8 +101,14 @@ def _apply(
     auto_approve: bool,
 ) -> None:
     _check_terraform_version()
-    amplitude_client.send_event(amplitude_client.START_GEN_EVENT)
     layer = Layer.load_from_yaml(config, env)
+    import pdb
+
+    pdb.set_trace()
+    amplitude_client.send_event(
+        amplitude_client.START_GEN_EVENT,
+        event_properties={"org_name": layer.org_name, "layer_name": layer.name},
+    )
 
     # We need a region with at least 3 AZs for leader election during failover.
     # Also EKS historically had problems with regions that have fewer than 3 AZs.
@@ -180,7 +186,12 @@ def _apply(
             print("Plan ran successfully, not applying since this is a test.")
         else:
             amplitude_client.send_event(
-                amplitude_client.APPLY_EVENT, event_properties={"module_idx": module_idx}
+                amplitude_client.APPLY_EVENT,
+                event_properties={
+                    "module_idx": module_idx,
+                    "org_name": layer.org_name,
+                    "layer_name": layer.name,
+                },
             )
             logger.info("Planning your changes (might take a minute)")
             Terraform.plan(

--- a/tests/commands/test_apply.py
+++ b/tests/commands/test_apply.py
@@ -38,6 +38,7 @@ def mocked_layer(mocker: MockFixture) -> Any:
     mocked_layer = mocker.Mock(spec=Layer)
     mocked_layer.variables = {}
     mocked_layer.name = "blah"
+    mocked_layer.org_name = "blahorg"
     mocked_layer.cloud = "aws"
     mocked_layer.gen_providers = lambda x: {"provider": {"aws": {"region": "us-east-1"}}}
     mocked_layer_class.load_from_yaml.return_value = mocked_layer


### PR DESCRIPTION
- This will help us measure applies/week and distinct-orgs/week
- Also let's start using org=runx for all of our environments? so we can exclude them in metrics