### PR TITLE
Allow user to rename db/cache cred envars in the link

### DIFF
--- a/opta/module_processors/gcp_k8s_service.py
+++ b/opta/module_processors/gcp_k8s_service.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, List
+from typing import TYPE_CHECKING, Any, List
 
 from opta.core.kubernetes import create_namespace_if_not_exists, get_manual_secrets
 from opta.exceptions import UserErrors
@@ -82,12 +82,25 @@ class GcpK8sServiceProcessor(GcpK8sModuleProcessor):
         super(GcpK8sServiceProcessor, self).process(module_idx)
 
     def handle_rds_link(
-        self, linked_module: "Module", link_permissions: List[str]
+        self, linked_module: "Module", link_permissions: List[Any]
     ) -> None:
-        for key in ["db_user", "db_name", "db_password", "db_host"]:
+        required_db_vars = ["db_user", "db_name", "db_password", "db_host"]
+        renamed_vars = {}
+        if len(link_permissions) > 0:
+            renamed_vars = link_permissions.pop()
+            if not isinstance(renamed_vars, dict) or set(renamed_vars.keys()) != set(
+                required_db_vars
+            ):
+                raise UserErrors(
+                    f"To rename db variables you must provide aliases for these fields: {required_db_vars}"
+                )
+            if not all(map(lambda x: isinstance(x, str), renamed_vars.values())):
+                raise UserErrors("DB variable rename must be only to another string")
+
+        for key in required_db_vars:
             self.module.data["link_secrets"].append(
                 {
-                    "name": f"{linked_module.name}_{key}",
+                    "name": renamed_vars.get(key, f"{linked_module.name}_{key}"),
                     "value": f"${{{{module.{linked_module.name}.{key}}}}}",
                 }
             )
@@ -101,12 +114,26 @@ class GcpK8sServiceProcessor(GcpK8sModuleProcessor):
             )
 
     def handle_redis_link(
-        self, linked_module: "Module", link_permissions: List[str]
+        self, linked_module: "Module", link_permissions: List[Any]
     ) -> None:
-        for key in ["cache_host", "cache_auth_token"]:
+        required_redis_vars = ["cache_host", "cache_auth_token"]
+        renamed_vars = {}
+
+        if len(link_permissions) > 0:
+            renamed_vars = link_permissions.pop()
+            if not isinstance(renamed_vars, dict) or set(renamed_vars.keys()) != set(
+                required_redis_vars
+            ):
+                raise UserErrors(
+                    f"To rename redis variables you must provide aliases for these fields: {required_redis_vars}"
+                )
+            if not all(map(lambda x: isinstance(x, str), renamed_vars.values())):
+                raise UserErrors("Redis variable rename must be only to another string")
+
+        for key in required_redis_vars:
             self.module.data["link_secrets"].append(
                 {
-                    "name": f"{linked_module.name}_{key}",
+                    "name": renamed_vars.get(key, f"{linked_module.name}_{key}"),
                     "value": f"${{{{module.{linked_module.name}.{key}}}}}",
                 }
             )

--- a/tests/module_processors/dummy_config1.yaml
+++ b/tests/module_processors/dummy_config1.yaml
@@ -27,6 +27,18 @@ modules:
       - database
       - redis
       - docdb
+      - database2:
+          - db_user: DBUSER2
+            db_host: DBHOST2
+            db_name: DBNAME2
+            db_password: BLAH
+      - redis2:
+          - cache_host: CACHEHOST2
+            cache_auth_token: CACHEAUTH2
+      - docdb2:
+          - db_user: DOCDBUSER2
+            db_host: DOCDBHOST2
+            db_password: DOCDBPASSWORD2
       - bucket1:
           - read
       - bucket2:
@@ -61,3 +73,9 @@ modules:
     type: aws-sqs
   - name: topic
     type: aws-sns
+  - name: database2
+    type: postgres
+  - name: redis2
+    type: redis
+  - name: docdb2
+    type: aws-documentdb

--- a/tests/module_processors/gcp_dummy_config.yaml
+++ b/tests/module_processors/gcp_dummy_config.yaml
@@ -24,8 +24,20 @@ modules:
     links:
       - database
       - redis
+      - database2:
+          - db_user: DBUSER2
+            db_host: DBHOST2
+            db_name: DBNAME2
+            db_password: BLAH
+      - redis2:
+          - cache_host: CACHEHOST2
+            cache_auth_token: CACHEAUTH2
       - bucket1:
           - read
       - bucket2:
           - write
       - bucket3
+  - name: database2
+    type: postgres
+  - name: redis2
+    type: redis

--- a/tests/module_processors/test_gcp_k8s_service.py
+++ b/tests/module_processors/test_gcp_k8s_service.py
@@ -18,12 +18,13 @@ class TestGCPK8sServiceProcessor:
             ),
             None,
         )
-        app_module = layer.get_module("app", 6)
+        idx = len(layer.modules)
+        app_module = layer.get_module("app", idx)
         mocked_process = mocker.patch(
             "opta.module_processors.gcp_k8s_service.GcpK8sModuleProcessor.process"
         )
-        GcpK8sServiceProcessor(app_module, layer).process(5)
-        mocked_process.assert_called_once_with(5)
+        GcpK8sServiceProcessor(app_module, layer).process(idx)
+        mocked_process.assert_called_once_with(idx)
         assert app_module.data["link_secrets"] == [
             {"name": "database_db_user", "value": "${{module.database.db_user}}"},
             {"name": "database_db_name", "value": "${{module.database.db_name}}"},
@@ -34,6 +35,12 @@ class TestGCPK8sServiceProcessor:
                 "name": "redis_cache_auth_token",
                 "value": "${{module.redis.cache_auth_token}}",
             },
+            {"name": "DBUSER2", "value": "${{module.database2.db_user}}"},
+            {"name": "DBNAME2", "value": "${{module.database2.db_name}}"},
+            {"name": "BLAH", "value": "${{module.database2.db_password}}"},
+            {"name": "DBHOST2", "value": "${{module.database2.db_host}}"},
+            {"name": "CACHEHOST2", "value": "${{module.redis2.cache_host}}"},
+            {"name": "CACHEAUTH2", "value": "${{module.redis2.cache_auth_token}}"},
         ]
         assert app_module.data["manual_secrets"] == [
             "BALONEY",
@@ -53,11 +60,12 @@ class TestGCPK8sServiceProcessor:
             ),
             None,
         )
-        app_module = layer.get_module("app", 6)
+        idx = len(layer.modules)
+        app_module = layer.get_module("app", idx)
         app_module.data["links"] = []
         app_module.data["links"].append({"database": "read"})
         with pytest.raises(Exception):
-            GcpK8sServiceProcessor(app_module, layer).process(5)
+            GcpK8sServiceProcessor(app_module, layer).process(idx)
 
     def test_bad_redis_permission(self):
         layer = Layer.load_from_yaml(
@@ -68,11 +76,12 @@ class TestGCPK8sServiceProcessor:
             ),
             None,
         )
-        app_module = layer.get_module("app", 6)
+        idx = len(layer.modules)
+        app_module = layer.get_module("app", idx)
         app_module.data["links"] = []
         app_module.data["links"].append({"redis": "read"})
         with pytest.raises(Exception):
-            GcpK8sServiceProcessor(app_module, layer).process(5)
+            GcpK8sServiceProcessor(app_module, layer).process(idx)
 
     def test_bad_gcs_permission(self):
         layer = Layer.load_from_yaml(
@@ -83,8 +92,9 @@ class TestGCPK8sServiceProcessor:
             ),
             None,
         )
-        app_module = layer.get_module("app", 6)
+        idx = len(layer.modules)
+        app_module = layer.get_module("app", idx)
         app_module.data["links"] = []
         app_module.data["links"].append({"bucket1": "blah"})
         with pytest.raises(Exception):
-            GcpK8sServiceProcessor(app_module, layer).process(6)
+            GcpK8sServiceProcessor(app_module, layer).process(idx)

--- a/tests/module_processors/test_k8s_service.py
+++ b/tests/module_processors/test_k8s_service.py
@@ -18,12 +18,13 @@ class TestK8sServiceProcessor:
             ),
             None,
         )
-        app_module = layer.get_module("app", 6)
+        idx = len(layer.modules)
+        app_module = layer.get_module("app", idx)
         mocked_process = mocker.patch(
             "opta.module_processors.aws_k8s_service.AWSK8sModuleProcessor.process"
         )
-        AwsK8sServiceProcessor(app_module, layer).process(10)
-        mocked_process.assert_called_once_with(10)
+        AwsK8sServiceProcessor(app_module, layer).process(idx)
+        mocked_process.assert_called_once_with(idx)
         assert app_module.data["link_secrets"] == [
             {"name": "database_db_user", "value": "${{module.database.db_user}}"},
             {"name": "database_db_name", "value": "${{module.database.db_name}}"},
@@ -37,6 +38,15 @@ class TestK8sServiceProcessor:
             {"name": "docdb_db_user", "value": "${{module.docdb.db_user}}"},
             {"name": "docdb_db_host", "value": "${{module.docdb.db_host}}"},
             {"name": "docdb_db_password", "value": "${{module.docdb.db_password}}"},
+            {"name": "DBUSER2", "value": "${{module.database2.db_user}}"},
+            {"name": "DBNAME2", "value": "${{module.database2.db_name}}"},
+            {"name": "BLAH", "value": "${{module.database2.db_password}}"},
+            {"name": "DBHOST2", "value": "${{module.database2.db_host}}"},
+            {"name": "CACHEHOST2", "value": "${{module.redis2.cache_host}}"},
+            {"name": "CACHEAUTH2", "value": "${{module.redis2.cache_auth_token}}"},
+            {"name": "DOCDBUSER2", "value": "${{module.docdb2.db_user}}"},
+            {"name": "DOCDBHOST2", "value": "${{module.docdb2.db_host}}"},
+            {"name": "DOCDBPASSWORD2", "value": "${{module.docdb2.db_password}}"},
         ]
         assert app_module.data["manual_secrets"] == [
             "BALONEY",
@@ -128,7 +138,8 @@ class TestK8sServiceProcessor:
             ),
             None,
         )
-        app_module = layer.get_module("app", 6)
+        idx = len(layer.modules)
+        app_module = layer.get_module("app", idx)
         app_module.data["links"] = []
         app_module.data["links"].append({"database": "read"})
         with pytest.raises(Exception):
@@ -143,7 +154,8 @@ class TestK8sServiceProcessor:
             ),
             None,
         )
-        app_module = layer.get_module("app", 6)
+        idx = len(layer.modules)
+        app_module = layer.get_module("app", idx)
         app_module.data["links"] = []
         app_module.data["links"].append({"redis": "read"})
         with pytest.raises(Exception):
@@ -158,11 +170,12 @@ class TestK8sServiceProcessor:
             ),
             None,
         )
-        app_module = layer.get_module("app", 6)
+        idx = len(layer.modules)
+        app_module = layer.get_module("app", idx)
         app_module.data["links"] = []
         app_module.data["links"].append({"docdb": "read"})
         with pytest.raises(Exception):
-            AwsK8sServiceProcessor(app_module, layer).process(6)
+            AwsK8sServiceProcessor(app_module, layer).process(idx)
 
     def test_bad_s3_permission(self):
         layer = Layer.load_from_yaml(
@@ -173,8 +186,9 @@ class TestK8sServiceProcessor:
             ),
             None,
         )
-        app_module = layer.get_module("app", 6)
+        idx = len(layer.modules)
+        app_module = layer.get_module("app", idx)
         app_module.data["links"] = []
         app_module.data["links"].append({"bucket1": "blah"})
         with pytest.raises(Exception):
-            AwsK8sServiceProcessor(app_module, layer).process(6)
+            AwsK8sServiceProcessor(app_module, layer).process(idx)

--- a/tests/test_layer.py
+++ b/tests/test_layer.py
@@ -110,83 +110,83 @@ class TestLayer:
         assert layer.name == "dummy-config-1"
         assert layer.parent is not None
         assert layer.parent == layer.root()
-        assert len(layer.modules) == 11
-        assert layer.pre_hook(10) is None
-        assert layer.post_hook(10, None) is None
+        assert len(layer.modules) == 14
+        assert layer.pre_hook(13) is None
+        assert layer.post_hook(13, None) is None
 
         mocked_k8s_service_processor.assert_has_calls(
             [
                 mocker.call(mocker.ANY, layer),
-                mocker.call().pre_hook(10),
+                mocker.call().pre_hook(13),
                 mocker.call(mocker.ANY, layer),
-                mocker.call().post_hook(10, None),
+                mocker.call().post_hook(13, None),
             ]
         )
         mocked_base_processor.assert_has_calls(
             [
                 mocker.call(mocker.ANY, layer),
-                mocker.call().pre_hook(10),
+                mocker.call().pre_hook(13),
                 mocker.call(mocker.ANY, layer),
-                mocker.call().pre_hook(10),
+                mocker.call().pre_hook(13),
                 mocker.call(mocker.ANY, layer),
-                mocker.call().pre_hook(10),
+                mocker.call().pre_hook(13),
                 mocker.call(mocker.ANY, layer),
-                mocker.call().pre_hook(10),
+                mocker.call().pre_hook(13),
                 mocker.call(mocker.ANY, layer),
-                mocker.call().pre_hook(10),
+                mocker.call().pre_hook(13),
                 mocker.call(mocker.ANY, layer),
-                mocker.call().pre_hook(10),
+                mocker.call().pre_hook(13),
                 mocker.call(mocker.ANY, layer),
-                mocker.call().post_hook(10, None),
+                mocker.call().post_hook(13, None),
                 mocker.call(mocker.ANY, layer),
-                mocker.call().post_hook(10, None),
+                mocker.call().post_hook(13, None),
                 mocker.call(mocker.ANY, layer),
-                mocker.call().post_hook(10, None),
+                mocker.call().post_hook(13, None),
                 mocker.call(mocker.ANY, layer),
-                mocker.call().post_hook(10, None),
+                mocker.call().post_hook(13, None),
                 mocker.call(mocker.ANY, layer),
-                mocker.call().post_hook(10, None),
+                mocker.call().post_hook(13, None),
                 mocker.call(mocker.ANY, layer),
-                mocker.call().post_hook(10, None),
+                mocker.call().post_hook(13, None),
             ]
         )
         mocked_aws_iam_role_processor.assert_has_calls(
             [
                 mocker.call(mocker.ANY, layer),
-                mocker.call().pre_hook(10),
+                mocker.call().pre_hook(13),
                 mocker.call(mocker.ANY, layer),
-                mocker.call().post_hook(10, None),
+                mocker.call().post_hook(13, None),
             ]
         )
         mocked_aws_iam_user_processor.assert_has_calls(
             [
                 mocker.call(mocker.ANY, layer),
-                mocker.call().pre_hook(10),
+                mocker.call().pre_hook(13),
                 mocker.call(mocker.ANY, layer),
-                mocker.call().post_hook(10, None),
+                mocker.call().post_hook(13, None),
             ]
         )
         mocked_aws_sns_processor.assert_has_calls(
             [
                 mocker.call(mocker.ANY, layer),
-                mocker.call().pre_hook(10),
+                mocker.call().pre_hook(13),
                 mocker.call(mocker.ANY, layer),
-                mocker.call().post_hook(10, None),
+                mocker.call().post_hook(13, None),
             ]
         )
         mocked_aws_sqs_processor.assert_has_calls(
             [
                 mocker.call(mocker.ANY, layer),
-                mocker.call().pre_hook(10),
+                mocker.call().pre_hook(13),
                 mocker.call(mocker.ANY, layer),
-                mocker.call().post_hook(10, None),
+                mocker.call().post_hook(13, None),
             ]
         )
         mocked_runx_processor.assert_has_calls(
             [
                 mocker.call(mocker.ANY, layer),
-                mocker.call().pre_hook(10),
+                mocker.call().pre_hook(13),
                 mocker.call(mocker.ANY, layer),
-                mocker.call().post_hook(10, None),
+                mocker.call().post_hook(13, None),
             ]
         )


### PR DESCRIPTION
Did it for redis, postgres, and docdb in AWS and redis, postgres, and mysql in GCP
