### PR TITLE
Adding opta labels for our k8s service deployments

### DIFF
--- a/config/tf_modules/gcp-k8s-service/k8s-service/templates/_helpers.tpl
+++ b/config/tf_modules/gcp-k8s-service/k8s-service/templates/_helpers.tpl
@@ -36,6 +36,7 @@ Common labels
 {{- define "k8s-service.labels" -}}
 helm.sh/chart: {{ include "k8s-service.chart" . }}
 {{ include "k8s-service.selectorLabels" . }}
+{{ include "k8s-service.optaLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
@@ -48,6 +49,12 @@ Selector labels
 {{- define "k8s-service.selectorLabels" -}}
 app.kubernetes.io/name: {{ include "k8s-service.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{- define "k8s-service.optaLabels" -}}
+opta.dev/module-name: {{ .Values.moduleName }}
+opta.dev/layer-name: {{ .Values.layerName }}
+opta.dev/environment-name: {{ .Values.environmentName }}
 {{- end }}
 
 {{/*Namespace name*/}}

--- a/config/tf_modules/gcp-k8s-service/k8s-service/templates/deployment.yaml
+++ b/config/tf_modules/gcp-k8s-service/k8s-service/templates/deployment.yaml
@@ -22,6 +22,7 @@ spec:
     metadata:
       labels:
         {{- include "k8s-service.selectorLabels" . | nindent 8 }}
+        {{- include "k8s-service.optaLabels" . | nindent 8 }}
         tags.datadoghq.com/service: {{ include "k8s-service.serviceName" . }}-{{ include "k8s-service.namespaceName" . }}
         tags.datadoghq.com/version: {{ .Values.version | quote }}
       annotations:

--- a/config/tf_modules/gcp-k8s-service/k8s-service/templates/ingress.yaml
+++ b/config/tf_modules/gcp-k8s-service/k8s-service/templates/ingress.yaml
@@ -4,6 +4,8 @@ kind: Ingress
 metadata:
   name:  {{ include "k8s-service.fullname" $ }}-{{ $index }}
   namespace: {{ include "k8s-service.namespaceName" $ }}
+  labels:
+    {{- include "k8s-service.labels" . | nindent 4 }}
   annotations:
     {{- if not (eq $val.pathPrefix "/") }}
     nginx.ingress.kubernetes.io/rewrite-target: /$2

--- a/config/tf_modules/gcp-k8s-service/k8s-service/templates/ingress.yaml
+++ b/config/tf_modules/gcp-k8s-service/k8s-service/templates/ingress.yaml
@@ -5,7 +5,7 @@ metadata:
   name:  {{ include "k8s-service.fullname" $ }}-{{ $index }}
   namespace: {{ include "k8s-service.namespaceName" $ }}
   labels:
-    {{- include "k8s-service.labels" . | nindent 4 }}
+    {{- include "k8s-service.labels" $ | nindent 4 }}
   annotations:
     {{- if not (eq $val.pathPrefix "/") }}
     nginx.ingress.kubernetes.io/rewrite-target: /$2

--- a/config/tf_modules/gcp-k8s-service/k8s-service/templates/namespace.yaml
+++ b/config/tf_modules/gcp-k8s-service/k8s-service/templates/namespace.yaml
@@ -4,6 +4,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: {{ include "k8s-service.namespaceName" . }}
+  labels:
+    {{- include "k8s-service.labels" . | nindent 4 }}
   annotations:
     linkerd.io/inject: enabled
   {{- end }}

--- a/config/tf_modules/gcp-k8s-service/k8s-service/templates/secret.yaml
+++ b/config/tf_modules/gcp-k8s-service/k8s-service/templates/secret.yaml
@@ -3,6 +3,8 @@ kind: Secret
 metadata:
   namespace: {{ include "k8s-service.namespaceName" . }}
   name: secret
+  labels:
+    {{- include "k8s-service.labels" . | nindent 4 }}
 type: Opaque
 data:
   {{- $existing := (lookup "v1" "Secret" ( include "k8s-service.namespaceName" . ) "secret").data -}}

--- a/config/tf_modules/gcp-k8s-service/k8s-service/values.yaml
+++ b/config/tf_modules/gcp-k8s-service/k8s-service/values.yaml
@@ -2,6 +2,9 @@ nameOverride: ""
 fullnameOverride: ""
 uriComponents: []
 googleServiceAccount: ""
+layerName: ""
+moduleName: ""
+environmentName: ""
 envVars: []
 linkSecrets: []
 manualSecrets: []

--- a/config/tf_modules/gcp-k8s-service/main.tf
+++ b/config/tf_modules/gcp-k8s-service/main.tf
@@ -38,7 +38,8 @@ resource "helm_release" "k8s-service" {
       manualSecrets : var.manual_secrets,
       uriComponents : local.uri_components,
       layerName : var.layer_name,
-      moduleName : var.module_name
+      moduleName : var.module_name,
+      environmentName: var.env_name,
       googleServiceAccount : google_service_account.k8s_service.email
     })
   ]

--- a/config/tf_modules/gcp-k8s-service/main.tf
+++ b/config/tf_modules/gcp-k8s-service/main.tf
@@ -39,7 +39,7 @@ resource "helm_release" "k8s-service" {
       uriComponents : local.uri_components,
       layerName : var.layer_name,
       moduleName : var.module_name,
-      environmentName: var.env_name,
+      environmentName : var.env_name,
       googleServiceAccount : google_service_account.k8s_service.email
     })
   ]

--- a/config/tf_modules/k8s-service/k8s-service/templates/_helpers.tpl
+++ b/config/tf_modules/k8s-service/k8s-service/templates/_helpers.tpl
@@ -36,6 +36,7 @@ Common labels
 {{- define "k8s-service.labels" -}}
 helm.sh/chart: {{ include "k8s-service.chart" . }}
 {{ include "k8s-service.selectorLabels" . }}
+{{ include "k8s-service.optaLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
@@ -48,6 +49,12 @@ Selector labels
 {{- define "k8s-service.selectorLabels" -}}
 app.kubernetes.io/name: {{ include "k8s-service.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{- define "k8s-service.optaLabels" -}}
+opta.dev/module-name: {{ .Values.moduleName }}
+opta.dev/layer-name: {{ .Values.layerName }}
+opta.dev/environment-name: {{ .Values.environmentName }}
 {{- end }}
 
 {{/*Namespace name*/}}

--- a/config/tf_modules/k8s-service/k8s-service/templates/deployment.yaml
+++ b/config/tf_modules/k8s-service/k8s-service/templates/deployment.yaml
@@ -22,6 +22,7 @@ spec:
     metadata:
       labels:
         {{- include "k8s-service.selectorLabels" . | nindent 8 }}
+        {{- include "k8s-service.optaLabels" . | nindent 8 }}
         tags.datadoghq.com/service: {{ include "k8s-service.serviceName" . }}-{{ include "k8s-service.namespaceName" . }}
         tags.datadoghq.com/version: {{ .Values.version | quote }}
       annotations:

--- a/config/tf_modules/k8s-service/k8s-service/templates/ingress.yaml
+++ b/config/tf_modules/k8s-service/k8s-service/templates/ingress.yaml
@@ -4,6 +4,8 @@ kind: Ingress
 metadata:
   name:  {{ include "k8s-service.fullname" $ }}-{{ $index }}
   namespace: {{ include "k8s-service.namespaceName" $ }}
+  labels:
+    {{- include "k8s-service.labels" . | nindent 4 }}
   annotations:
     {{- if not (eq $val.pathPrefix "/") }}
     nginx.ingress.kubernetes.io/rewrite-target: /$2

--- a/config/tf_modules/k8s-service/k8s-service/templates/ingress.yaml
+++ b/config/tf_modules/k8s-service/k8s-service/templates/ingress.yaml
@@ -5,7 +5,7 @@ metadata:
   name:  {{ include "k8s-service.fullname" $ }}-{{ $index }}
   namespace: {{ include "k8s-service.namespaceName" $ }}
   labels:
-    {{- include "k8s-service.labels" . | nindent 4 }}
+    {{- include "k8s-service.labels" $ | nindent 4 }}
   annotations:
     {{- if not (eq $val.pathPrefix "/") }}
     nginx.ingress.kubernetes.io/rewrite-target: /$2

--- a/config/tf_modules/k8s-service/k8s-service/templates/namespace.yaml
+++ b/config/tf_modules/k8s-service/k8s-service/templates/namespace.yaml
@@ -4,6 +4,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: {{ include "k8s-service.namespaceName" . }}
+  labels:
+    {{- include "k8s-service.labels" . | nindent 4 }}
   annotations:
     linkerd.io/inject: enabled
 {{- end }}

--- a/config/tf_modules/k8s-service/k8s-service/templates/secret.yaml
+++ b/config/tf_modules/k8s-service/k8s-service/templates/secret.yaml
@@ -3,6 +3,8 @@ kind: Secret
 metadata:
   namespace: {{ include "k8s-service.namespaceName" . }}
   name: secret
+  labels:
+    {{- include "k8s-service.labels" . | nindent 4 }}
 type: Opaque
 data:
   {{- $existing := (lookup "v1" "Secret" ( include "k8s-service.namespaceName" . ) "secret").data -}}

--- a/config/tf_modules/k8s-service/k8s-service/values.yaml
+++ b/config/tf_modules/k8s-service/k8s-service/values.yaml
@@ -2,6 +2,9 @@ nameOverride: ""
 fullnameOverride: ""
 uriComponents: []
 iamRoleArn: ""
+layerName: ""
+moduleName: ""
+environmentName: ""
 envVars: []
 linkSecrets: []
 manualSecrets: []

--- a/config/tf_modules/k8s-service/main.tf
+++ b/config/tf_modules/k8s-service/main.tf
@@ -38,7 +38,8 @@ resource "helm_release" "k8s-service" {
       manualSecrets : var.manual_secrets,
       uriComponents : local.uri_components,
       layerName : var.layer_name,
-      moduleName : var.module_name
+      moduleName : var.module_name,
+      environmentName: var.env_name,
       iamRoleArn : aws_iam_role.k8s_service.arn
     })
   ]

--- a/config/tf_modules/k8s-service/main.tf
+++ b/config/tf_modules/k8s-service/main.tf
@@ -39,7 +39,7 @@ resource "helm_release" "k8s-service" {
       uriComponents : local.uri_components,
       layerName : var.layer_name,
       moduleName : var.module_name,
-      environmentName: var.env_name,
+      environmentName : var.env_name,
       iamRoleArn : aws_iam_role.k8s_service.arn
     })
   ]


### PR DESCRIPTION
For our opta ui
All opta service resources will now have the following labels:
```
opta.dev/module-name: {{ .Values.moduleName }}
opta.dev/layer-name: {{ .Values.layerName }}
opta.dev/environment-name: {{ .Values.environmentName }}
```