### PR TITLE
Simplify airflow example

### DIFF
--- a/examples/airflow/opta.yml
+++ b/examples/airflow/opta.yml
@@ -24,6 +24,11 @@ modules:
         enabled: false
       statsd:
         enabled: false
+      flower:
+        enabled: false
+      extraEnv: |-
+        - name: AIRFLOW__CORE__LOAD_EXAMPLES
+          value: "true"
       data:
         metadataConnection:
           host: "${{module.db.db_host}}"
@@ -34,16 +39,10 @@ modules:
       airflow:
         config:
           AIRFLOW__WEBSERVER__BASE_URL: "http://airflow.{parent.domain}"
-          AIRFLOW__CELERY__FLOWER_URL_PREFIX: "/flower"
       ingress:
         enabled: true
         web:
           path: ""
-          host: "airflow.{parent.domain}"
-          annotations:
-            kubernetes.io/ingress.class: "nginx"
-        flower:
-          path: "/flower"
           host: "airflow.{parent.domain}"
           annotations:
             kubernetes.io/ingress.class: "nginx"

--- a/examples/airflow/opta.yml
+++ b/examples/airflow/opta.yml
@@ -26,9 +26,12 @@ modules:
         enabled: false
       flower:
         enabled: false
+      # Remove extraEnv if you don't want to load the example DAGs
       extraEnv: |-
         - name: AIRFLOW__CORE__LOAD_EXAMPLES
           value: "true"
+      workers:
+        replicas: 1 # Change this if you want more workers
       data:
         metadataConnection:
           host: "${{module.db.db_host}}"


### PR DESCRIPTION
- Remove flower (which is a monitoring tool)
- Enable example dags (this way you can try something from the UI)
- Show worker replicas option