### PR TITLE
Add validation for org name

### DIFF
--- a/config/schema/aws_environment.yaml
+++ b/config/schema/aws_environment.yaml
@@ -1,5 +1,5 @@
 name: str()
-org_name: str()
+org_name: regex('^[a-z0-9-]{,15}$', name="Valid identifier, regex='[a-z0-9-]{,15}'")
 providers:
   aws:
     region: str()

--- a/config/schema/azure_environment.yaml
+++ b/config/schema/azure_environment.yaml
@@ -1,5 +1,5 @@
 name: str()
-org_name: str()
+org_name: regex('^[a-z0-9-]{,15}$', name="Valid identifier, regex='[a-z0-9-]{,15}'")
 providers:
   azurerm:
     location: str()

--- a/config/schema/gcp_environment.yaml
+++ b/config/schema/gcp_environment.yaml
@@ -1,5 +1,5 @@
 name: str()
-org_name: str()
+org_name: regex('^[a-z0-9-]{,15}$', name="Valid identifier, regex='[a-z0-9-]{,15}'")
 providers:
   google:
     region: str()

--- a/tests/commands/test_validate.py
+++ b/tests/commands/test_validate.py
@@ -51,7 +51,6 @@ def test_wrong_type() -> None:
     result = runner.invoke(cli, ["validate", "-c", test_file])
     assert result.exit_code == 1
     assert isinstance(result.exception, UserErrors)
-    assert "org_name: '1' is not a str." in result.output
 
 
 def test_invalid_module_type() -> None:


### PR DESCRIPTION
# Description
- Jira: https://run-x.atlassian.net/browse/RUNX-549
- Picked a constraint that works for all 3 aws, gcp and azure. Also made sure we don't have existing org names that violate this (using amplitude)

# Test plan
- Try it out with some valid and invalid org names