### PR TITLE
SOC 2 and PCI Compliance with azure thanks to fugue

### DIFF
--- a/config/config.rego
+++ b/config/config.rego
@@ -37,19 +37,4 @@ rules[rule] {
     "rule_id": "FG_R00275",
     "status": "DISABLED"
   }
-} {  # The following rules are disabled until the PR to cleanup the soc2 on each respective cloud
-  rule := {
-    "rule_id": "FG_R00227",
-    "status": "DISABLED"
-  }
-} {
-  rule := {
-    "rule_id": "FG_R00286",
-    "status": "DISABLED"
-  }
-} {
-  rule := {
-    "rule_id": "FG_R00344",
-    "status": "DISABLED"
-  }
 }

--- a/config/tf_modules/azure-aks/aks.tf
+++ b/config/tf_modules/azure-aks/aks.tf
@@ -24,28 +24,28 @@ resource "azurerm_role_assignment" "opta" {
   scope                = data.azurerm_resource_group.opta.id
   role_definition_name = "Network Contributor"
   principal_id         = azurerm_user_assigned_identity.opta.principal_id
-  lifecycle {ignore_changes = [scope]}
+  lifecycle { ignore_changes = [scope] }
 }
 
 resource "azurerm_role_assignment" "k8s_assign_identities" {
   scope                = data.azurerm_resource_group.opta.id
   role_definition_name = "Managed Identity Operator"
   principal_id         = azurerm_user_assigned_identity.opta.principal_id
-  lifecycle {ignore_changes = [scope]}
+  lifecycle { ignore_changes = [scope] }
 }
 
 resource "azurerm_role_assignment" "azurerm_container_registry" {
   scope                = data.azurerm_resource_group.opta.id
   role_definition_name = "AcrPull"
   principal_id         = azurerm_user_assigned_identity.opta.principal_id
-  lifecycle {ignore_changes = [scope]}
+  lifecycle { ignore_changes = [scope] }
 }
 
 resource "azurerm_role_assignment" "azurerm_container_registry_agent_pool" {
   scope                = data.azurerm_resource_group.opta.id
   role_definition_name = "AcrPull"
   principal_id         = azurerm_user_assigned_identity.agent_pool.principal_id
-  lifecycle {ignore_changes = [scope]}
+  lifecycle { ignore_changes = [scope] }
 }
 
 

--- a/config/tf_modules/azure-aks/aks.tf
+++ b/config/tf_modules/azure-aks/aks.tf
@@ -24,24 +24,28 @@ resource "azurerm_role_assignment" "opta" {
   scope                = data.azurerm_resource_group.opta.id
   role_definition_name = "Network Contributor"
   principal_id         = azurerm_user_assigned_identity.opta.principal_id
+  lifecycle {ignore_changes = [scope]}
 }
 
 resource "azurerm_role_assignment" "k8s_assign_identities" {
   scope                = data.azurerm_resource_group.opta.id
   role_definition_name = "Managed Identity Operator"
   principal_id         = azurerm_user_assigned_identity.opta.principal_id
+  lifecycle {ignore_changes = [scope]}
 }
 
 resource "azurerm_role_assignment" "azurerm_container_registry" {
   scope                = data.azurerm_resource_group.opta.id
   role_definition_name = "AcrPull"
   principal_id         = azurerm_user_assigned_identity.opta.principal_id
+  lifecycle {ignore_changes = [scope]}
 }
 
 resource "azurerm_role_assignment" "azurerm_container_registry_agent_pool" {
   scope                = data.azurerm_resource_group.opta.id
   role_definition_name = "AcrPull"
   principal_id         = azurerm_user_assigned_identity.agent_pool.principal_id
+  lifecycle {ignore_changes = [scope]}
 }
 
 

--- a/config/tf_modules/azure-base/encryption.tf
+++ b/config/tf_modules/azure-base/encryption.tf
@@ -13,6 +13,7 @@ resource "azurerm_key_vault" "opta" {
   enabled_for_deployment          = true
   enabled_for_template_deployment = true
   purge_protection_enabled        = true
+  soft_delete_enabled = true
   lifecycle {
     ignore_changes = [location]
   }

--- a/config/tf_modules/azure-base/encryption.tf
+++ b/config/tf_modules/azure-base/encryption.tf
@@ -13,7 +13,7 @@ resource "azurerm_key_vault" "opta" {
   enabled_for_deployment          = true
   enabled_for_template_deployment = true
   purge_protection_enabled        = true
-  soft_delete_enabled = true
+  soft_delete_enabled             = true
   lifecycle {
     ignore_changes = [location]
   }

--- a/config/tf_modules/azure-base/logging.tf
+++ b/config/tf_modules/azure-base/logging.tf
@@ -1,0 +1,75 @@
+resource "random_id" "logging_suffix" {
+  byte_length = 4
+}
+
+resource "azurerm_storage_account" "infra_logging" {
+  name                            = "optainfralogs${random_id.logging_suffix.hex}"
+  location                        = data.azurerm_resource_group.opta.location
+  resource_group_name             = data.azurerm_resource_group.opta.name
+  account_replication_type = "LRS"
+  account_tier = "Standard"
+  enable_https_traffic_only = true
+  network_rules {
+    default_action = "Deny"
+    bypass = ["AzureServices"]
+  }
+}
+
+resource "azurerm_monitor_diagnostic_setting" "infra_logging" {
+  name               = "opta-${var.env_name}"
+  target_resource_id = azurerm_key_vault.opta.id
+  storage_account_id = azurerm_storage_account.infra_logging.id
+
+  log {
+    category = "AuditEvent"
+    enabled  = true
+
+    retention_policy {
+      enabled = true
+      days = 180
+    }
+  }
+
+  metric {
+    category = "AllMetrics"
+
+    retention_policy {
+      enabled = false
+    }
+  }
+}
+
+data "azurerm_network_watcher" "default" {
+  name = "NetworkWatcher_${data.azurerm_resource_group.opta.location}"
+  resource_group_name = "NetworkWatcherRG"
+  depends_on = [azurerm_virtual_network.opta]
+}
+
+resource "azurerm_log_analytics_workspace" "watcher" {
+  name                = "opta-${var.env_name}"
+  location            = data.azurerm_resource_group.opta.location
+  resource_group_name = data.azurerm_resource_group.opta.name
+  sku                 = "PerGB2018"
+}
+
+resource "azurerm_network_watcher_flow_log" "vpc_flow_log" {
+  network_watcher_name = data.azurerm_network_watcher.default.name
+  resource_group_name = "NetworkWatcherRG"
+
+  network_security_group_id = azurerm_network_security_group.opta.id
+  storage_account_id        = azurerm_storage_account.infra_logging.id
+  enabled                   = true
+
+  retention_policy {
+    enabled = true
+    days    = 90
+  }
+
+  traffic_analytics {
+    enabled               = true
+    workspace_id          = azurerm_log_analytics_workspace.watcher.workspace_id
+    workspace_region      = azurerm_log_analytics_workspace.watcher.location
+    workspace_resource_id = azurerm_log_analytics_workspace.watcher.id
+    interval_in_minutes   = 10
+  }
+}

--- a/config/tf_modules/azure-base/logging.tf
+++ b/config/tf_modules/azure-base/logging.tf
@@ -3,15 +3,15 @@ resource "random_id" "logging_suffix" {
 }
 
 resource "azurerm_storage_account" "infra_logging" {
-  name                            = "optainfralogs${random_id.logging_suffix.hex}"
-  location                        = data.azurerm_resource_group.opta.location
-  resource_group_name             = data.azurerm_resource_group.opta.name
-  account_replication_type = "LRS"
-  account_tier = "Standard"
+  name                      = "optainfralogs${random_id.logging_suffix.hex}"
+  location                  = data.azurerm_resource_group.opta.location
+  resource_group_name       = data.azurerm_resource_group.opta.name
+  account_replication_type  = "LRS"
+  account_tier              = "Standard"
   enable_https_traffic_only = true
   network_rules {
     default_action = "Deny"
-    bypass = ["AzureServices"]
+    bypass         = ["AzureServices"]
   }
 }
 
@@ -26,7 +26,7 @@ resource "azurerm_monitor_diagnostic_setting" "infra_logging" {
 
     retention_policy {
       enabled = true
-      days = 180
+      days    = 180
     }
   }
 
@@ -40,9 +40,9 @@ resource "azurerm_monitor_diagnostic_setting" "infra_logging" {
 }
 
 data "azurerm_network_watcher" "default" {
-  name = "NetworkWatcher_${data.azurerm_resource_group.opta.location}"
+  name                = "NetworkWatcher_${data.azurerm_resource_group.opta.location}"
   resource_group_name = "NetworkWatcherRG"
-  depends_on = [azurerm_virtual_network.opta]
+  depends_on          = [azurerm_virtual_network.opta]
 }
 
 resource "azurerm_log_analytics_workspace" "watcher" {
@@ -54,7 +54,7 @@ resource "azurerm_log_analytics_workspace" "watcher" {
 
 resource "azurerm_network_watcher_flow_log" "vpc_flow_log" {
   network_watcher_name = data.azurerm_network_watcher.default.name
-  resource_group_name = "NetworkWatcherRG"
+  resource_group_name  = "NetworkWatcherRG"
 
   network_security_group_id = azurerm_network_security_group.opta.id
   storage_account_id        = azurerm_storage_account.infra_logging.id

--- a/config/tf_modules/azure-postgres/main.tf
+++ b/config/tf_modules/azure-postgres/main.tf
@@ -58,3 +58,26 @@ resource "azurerm_postgresql_database" "opta" {
   charset             = "UTF8"
   collation           = "English_United States.1252"
 }
+
+resource "azurerm_postgresql_configuration" "log_disconnections" {
+  name                = "log_disconnections"
+  resource_group_name = data.azurerm_resource_group.main.name
+  server_name         = azurerm_postgresql_server.opta.name
+  value               = "on"
+}
+
+
+resource "azurerm_postgresql_configuration" "log_duration" {
+  name                = "log_duration"
+  resource_group_name = data.azurerm_resource_group.main.name
+  server_name         = azurerm_postgresql_server.opta.name
+  value               = "on"
+}
+
+
+resource "azurerm_postgresql_configuration" "log_retention_days" {
+  name                = "log_retention_days"
+  resource_group_name = data.azurerm_resource_group.main.name
+  server_name         = azurerm_postgresql_server.opta.name
+  value               = "5"
+}

--- a/examples/aws-resources/opta.yml
+++ b/examples/aws-resources/opta.yml
@@ -28,9 +28,31 @@ modules:
       - SECRET_1
   - name: db
     type: aws-postgres
+    multi_az: true
   - name: s3
     type: aws-s3
+    same_region_replication: true
     bucket_name: "{parent_name}-{layer_name}"
+    bucket_policy: {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Sid": "denyInsecureTransport",
+          "Effect": "Deny",
+          "Principal": "*",
+          "Action": "s3:*",
+          "Resource": [
+              "arn:aws:s3:::{parent_name}-{layer_name}/*",
+              "arn:aws:s3:::{parent_name}-{layer_name}"
+          ],
+          "Condition": {
+            "Bool": {
+              "aws:SecureTransport": "false"
+            }
+          }
+        }
+      ]
+    }
   - name: redis
     type: aws-redis
   - name: queue

--- a/examples/http-service/opta.yml
+++ b/examples/http-service/opta.yml
@@ -23,8 +23,7 @@ modules:
     port:
       http: 80
     env_vars:
-      - name: A
-        value: B
+      A: B
     public_uri: "subdomain1.{parent.domain}"
     links:
       - redis

--- a/opta/layer.py
+++ b/opta/layer.py
@@ -361,7 +361,7 @@ class Layer:
             aws = AWS(self)
             region = aws.region
         elif self.cloud == "azurerm":
-            region = self.providers["azurerm"]["location"]
+            region = self.root().providers["azurerm"]["location"]
         hydration = self.metadata_hydration()
         providers = self.providers
         if self.parent is not None:


### PR DESCRIPTION
This pull request should complete the work to make opta infrastructure created on Azure close to SOC2 and PCI compliant, with compliance being complete by the following user actions:

1. Enable flow logs for the [agent pool security group](https://docs.microsoft.com/en-us/security/benchmark/azure/baselines/aks-security-baseline#12-monitor-and-log-the-configuration-and-traffic-of-virtual-networks-subnets-and-nics)

That's it