### PR TITLE
Custom terraform module for opta

### DIFF
--- a/config/registry.yaml
+++ b/config/registry.yaml
@@ -285,6 +285,12 @@ modules:
             host: "${{{module_source}.k8s_endpoint}}"
             token: "${{data.aws_eks_cluster_auth.k8s.token}}"
             cluster_ca_certificate: "${{base64decode({module_source}.k8s_ca_data)}}"
+  custom-terraform:
+    cloud: any
+    location: custom-terraform
+    halt: true
+    variables:
+      path_to_module: str
   datadog:
     cloud: any
     location: datadog

--- a/opta/layer.py
+++ b/opta/layer.py
@@ -40,6 +40,7 @@ from opta.module_processors.azure_base import AzureBaseProcessor
 from opta.module_processors.azure_k8s_base import AzureK8sBaseProcessor
 from opta.module_processors.azure_k8s_service import AzureK8sServiceProcessor
 from opta.module_processors.base import ModuleProcessor
+from opta.module_processors.custom_terraform import CustomTerraformProcessor
 from opta.module_processors.datadog import DatadogProcessor
 from opta.module_processors.external_ssl_cert import ExternalSSLCert
 from opta.module_processors.gcp_dns import GCPDnsProcessor
@@ -81,6 +82,7 @@ class Layer:
         "external-ssl-cert": ExternalSSLCert,
         "aws-s3": AwsS3Processor,
         "gcp-dns": GCPDnsProcessor,
+        "custom-terraform": CustomTerraformProcessor,
     }
 
     def __init__(

--- a/opta/module.py
+++ b/opta/module.py
@@ -26,7 +26,7 @@ class Module:
             raise UserErrors(f"{self.type} is not a valid module type")
         self.aliased_type: Optional[str] = None
         self.layer_name = layer.name
-        self.desc = REGISTRY["modules"][self.type]
+        self.desc = REGISTRY["modules"][self.type].copy()
         if "alias" in self.desc:
             cloud = layer.cloud
             if cloud not in self.desc["alias"]:

--- a/opta/module_processors/custom_terraform.py
+++ b/opta/module_processors/custom_terraform.py
@@ -1,0 +1,23 @@
+import os
+from typing import TYPE_CHECKING
+
+from opta.module_processors.base import ModuleProcessor
+
+if TYPE_CHECKING:
+    from opta.layer import Layer
+    from opta.module import Module
+
+
+class CustomTerraformProcessor(ModuleProcessor):
+    def __init__(self, module: "Module", layer: "Layer"):
+        super(CustomTerraformProcessor, self).__init__(module, layer)
+
+    def process(self, module_idx: int) -> None:
+        current_desc = self.module.desc
+        self.module.module_dir_path = os.path.join(
+            os.path.dirname(self.layer.path), self.module.data["path_to_module"]
+        )
+        current_desc["variables"] = {
+            x: "optional" for x in self.module.data.get("terraform_inputs", {}).keys()
+        }
+        self.module.data.update(self.module.data.get("terraform_inputs", {}))


### PR DESCRIPTION
Use it like this:

```yaml
name: live-example-dev
org_name: runx
providers:
  aws:
    region: us-east-1
    account_id: 445935066876
modules:
  - type: base
  - type: custom-terraform
    path_to_module: "../blah_module"
    terraform_inputs:
      a: "${{module.base.vpc_id}}"
```
