### PR TITLE
Nicer stdout for terraform planning

### DIFF
--- a/opta/commands/apply.py
+++ b/opta/commands/apply.py
@@ -241,7 +241,7 @@ def _apply(
                 *targets,
                 quiet=True,
             )
-            PlanDisplayer(layer).display(detailed_plan=detailed_plan)
+            PlanDisplayer.display(detailed_plan=detailed_plan)
 
             if not auto_approve:
                 click.confirm(

--- a/opta/commands/deploy.py
+++ b/opta/commands/deploy.py
@@ -31,8 +31,19 @@ from opta.utils import check_opta_file_exists, fmt_msg, logger
     default=False,
     help="Automatically approve terraform plan.",
 )
+@click.option(
+    "--detailed-plan",
+    is_flag=True,
+    default=False,
+    help="Show full terraform plan in detail, not the opta provided summary",
+)
 def deploy(
-    image: str, config: str, env: Optional[str], tag: Optional[str], auto_approve: bool
+    image: str,
+    config: str,
+    env: Optional[str],
+    tag: Optional[str],
+    auto_approve: bool,
+    detailed_plan: bool,
 ) -> None:
     """Push your new image to the cloud and deploy it in your environment"""
 
@@ -65,20 +76,20 @@ def deploy(
             config=config,
             env=env,
             refresh=False,
-            max_module=None,
             image_tag=None,
             test=False,
             auto_approve=auto_approve,
             stdout_logs=False,
+            detailed_plan=detailed_plan,
         )
     image_digest, image_tag = _push(image=image, config=config, env=env, tag=tag)
     _apply(
         config=config,
         env=env,
         refresh=False,
-        max_module=None,
         image_tag=None,
         test=False,
         auto_approve=auto_approve,
         image_digest=image_digest,
+        detailed_plan=detailed_plan,
     )

--- a/opta/core/plan_displayer.py
+++ b/opta/core/plan_displayer.py
@@ -17,7 +17,7 @@ ACTION_TO_SEVERITY = {
 }
 SEVERITY_COLORS = {
     BENIGN_SEVERITY: fg("green"),
-    MODERATE_SEVERITY: fg("yellow"),
+    MODERATE_SEVERITY: fg("orange_4b"),
     SERIOUS_SEVERITY: fg("magenta"),
 }
 SEVERITY_EXPLANATIONS = {
@@ -94,7 +94,12 @@ class PlanDisplayer:
             "If you want extra help, please feel free to reach out to the Runx team at https://slack.opta.dev.\n"
             "Severity break down by module is as follows:"
         )
-        for module_name, module_change in module_changes.items():
+        module_changes_list = sorted(
+            [(k, v) for k, v in module_changes.items()],
+            key=lambda x: x[1]["severity"],
+            reverse=True,
+        )
+        for module_name, module_change in module_changes_list:
             current_severity = module_change["severity"]
             logger.info(
                 f"Module name: {module_name}. Severity: {SEVERITY_COLORS[current_severity]}{current_severity}{attr(0)}."
@@ -102,7 +107,12 @@ class PlanDisplayer:
             # No need to be verbose with benign changes
             if current_severity == BENIGN_SEVERITY:
                 continue
-            for resource_name, resource_change in module_change["resources"].items():
+            resource_changes_list = sorted(
+                [(k, v) for k, v in module_change["resources"].items()],
+                key=lambda x: x[1]["severity"],
+                reverse=True,
+            )
+            for resource_name, resource_change in resource_changes_list:
                 current_severity = resource_change["severity"]
                 logger.info(
                     f"  Resource name: {resource_name}. Action: {resource_change['action']}. "

--- a/opta/core/plan_displayer.py
+++ b/opta/core/plan_displayer.py
@@ -1,13 +1,8 @@
-from typing import TYPE_CHECKING
-
 from colored import attr, fg
 
 from opta.constants import TF_PLAN_PATH
 from opta.core.terraform import Terraform
 from opta.utils import logger
-
-if TYPE_CHECKING:
-    from opta.layer import Layer
 
 BENIGN_SEVERITY = "BENIGN"
 MODERATE_SEVERITY = "MODERATE"
@@ -53,10 +48,8 @@ def _max_severity(severity_1: str, severity_2: str) -> str:
 
 
 class PlanDisplayer:
-    def __init__(self, layer: "Layer"):
-        self.layer = layer
-
-    def display(self, detailed_plan: bool = False) -> None:
+    @staticmethod
+    def display(detailed_plan: bool = False) -> None:
         if detailed_plan:
             Terraform.show(TF_PLAN_PATH)
             return

--- a/opta/core/plan_displayer.py
+++ b/opta/core/plan_displayer.py
@@ -1,0 +1,123 @@
+from typing import TYPE_CHECKING
+
+from colored import attr, fg
+
+from opta.constants import TF_PLAN_PATH
+from opta.core.terraform import Terraform
+from opta.utils import logger
+
+if TYPE_CHECKING:
+    from opta.layer import Layer
+
+BENIGN_SEVERITY = "BENIGN"
+MODERATE_SEVERITY = "MODERATE"
+SERIOUS_SEVERITY = "SERIOUS"
+PLAN_SEVERITIES = {BENIGN_SEVERITY, MODERATE_SEVERITY, SERIOUS_SEVERITY}
+ACTION_TO_SEVERITY = {
+    "create": BENIGN_SEVERITY,
+    "read": BENIGN_SEVERITY,
+    "delete": SERIOUS_SEVERITY,
+    "update": MODERATE_SEVERITY,
+    "replace": SERIOUS_SEVERITY,
+}
+SEVERITY_COLORS = {
+    BENIGN_SEVERITY: fg("green"),
+    MODERATE_SEVERITY: fg("yellow"),
+    SERIOUS_SEVERITY: fg("magenta"),
+}
+SEVERITY_EXPLANATIONS = {
+    BENIGN_SEVERITY: (
+        "This is the lowest level of severity and it typically means that you are adding or refreshing "
+        "things instead of changing and deleting things. You should feel very confident in these changes "
+        "without knowing anything further."
+    ),
+    MODERATE_SEVERITY: (
+        "This is the medium level of severity, meaning that something have been updates, but not destroyed or forced "
+        "to replace (destroy and recreate). Typically, this means you updated some minor fields the yaml or updated "
+        "to a new pta version and we're doing some backwards compatible changes."
+    ),
+    SERIOUS_SEVERITY: (
+        "This is the highest level of severity and this means that either you are destroying something or made a big "
+        "change which forced something to recreate (destroy and create itself). Please tread carefully and know what "
+        "you are doing."
+    ),
+}
+
+
+def _max_severity(severity_1: str, severity_2: str) -> str:
+    if SERIOUS_SEVERITY in [severity_1, severity_2]:
+        return SERIOUS_SEVERITY
+    if MODERATE_SEVERITY in [severity_1, severity_2]:
+        return MODERATE_SEVERITY
+    return BENIGN_SEVERITY
+
+
+class PlanDisplayer:
+    def __init__(self, layer: "Layer"):
+        self.layer = layer
+
+    def display(self, detailed_plan: bool = False) -> None:
+        if detailed_plan:
+            Terraform.show(TF_PLAN_PATH)
+            return
+        plan_dict = Terraform.show_plan()
+        plan_severity = BENIGN_SEVERITY
+        module_changes: dict = {}
+        resource_change: dict
+        for resource_change in plan_dict.get("resource_changes", []):
+            if resource_change.get("change", {}).get("actions", ["no-op"]) == ["no-op"]:
+                continue
+            address: str = resource_change["address"]
+
+            if not address.startswith("module."):
+                logger.warn(
+                    f"Unable to determine severity of changes to resource {address}. "
+                    "Please run in detailed plan mode for more info"
+                )
+            module_name = address.split(".")[1]
+            module_changes[module_name] = module_changes.get(
+                module_name, {"severity": BENIGN_SEVERITY, "resources": {}}
+            )
+            resource_name = ".".join(address.split(".")[2:])
+            actions = resource_change.get("change", {}).get("actions", [])
+            if "create" in actions and "delete" in actions:
+                actions = ["replace"]
+            action = actions[0]
+            current_severity = ACTION_TO_SEVERITY[action]
+            action_reason = resource_change.get("action_reason", "N/A")
+            module_changes[module_name]["resources"][resource_name] = {
+                "action": action,
+                "reason": action_reason,
+                "severity": current_severity,
+            }
+            module_changes[module_name]["severity"] = _max_severity(
+                module_changes[module_name]["severity"], current_severity
+            )
+            plan_severity = _max_severity(plan_severity, current_severity)
+
+        logger.info(
+            f"Identified total severity of {SEVERITY_COLORS[plan_severity]}{plan_severity}{attr(0)}.\n"
+            f"{SEVERITY_EXPLANATIONS[plan_severity]}\n"
+            "If you want extra help, please feel free to reach out to the Runx team at slack.opta.dev.\n"
+            "Severity break down by module is as follows:"
+        )
+        for module_name, module_change in module_changes.items():
+            current_severity = module_change["severity"]
+            logger.info(
+                f"Module name: {module_name}. Severity: {SEVERITY_COLORS[current_severity]}{current_severity}{attr(0)}."
+            )
+            # No need to be verbose with benign changes
+            if current_severity == BENIGN_SEVERITY:
+                continue
+            for resource_name, resource_change in module_change["resources"].items():
+                current_severity = resource_change["severity"]
+                logger.info(
+                    f"  Resource name: {resource_name}. Action: {resource_change['action']}. "
+                    f"Reason: {resource_change['reason']}. Severity: {SEVERITY_COLORS[current_severity]}{current_severity}{attr(0)}"
+                )
+        if len(module_changes) == 0:
+            logger.info("No changes found.")
+        logger.info(
+            "This concludes the plan summary. For more detail, please pass the --detailed-plan flag to your opta "
+            "command!"
+        )

--- a/opta/core/plan_displayer.py
+++ b/opta/core/plan_displayer.py
@@ -98,7 +98,7 @@ class PlanDisplayer:
         logger.info(
             f"Identified total severity of {SEVERITY_COLORS[plan_severity]}{plan_severity}{attr(0)}.\n"
             f"{SEVERITY_EXPLANATIONS[plan_severity]}\n"
-            "If you want extra help, please feel free to reach out to the Runx team at slack.opta.dev.\n"
+            "If you want extra help, please feel free to reach out to the Runx team at https://slack.opta.dev.\n"
             "Severity break down by module is as follows:"
         )
         for module_name, module_change in module_changes.items():

--- a/tests/commands/test_apply.py
+++ b/tests/commands/test_apply.py
@@ -19,6 +19,7 @@ def basic_mocks(mocker: MockFixture) -> None:
     mocker.patch("opta.commands.apply.is_tool", return_value=True)
     mocker.patch("opta.commands.apply.amplitude_client.send_event")
     mocker.patch("opta.commands.apply.gen_opta_resource_tags")
+    mocker.patch("opta.commands.apply.PlanDisplayer")
 
     # Mock remote state
     mocker.patch(
@@ -65,7 +66,6 @@ def test_apply(mocker: MockFixture, mocked_layer: Any, basic_mocks: Any) -> None
     mocker.patch("opta.commands.apply.Terraform.download_state")
     tf_apply = mocker.patch("opta.commands.apply.Terraform.apply")
     tf_plan = mocker.patch("opta.commands.apply.Terraform.plan")
-    tf_show = mocker.patch("opta.commands.apply.Terraform.show")
     tf_create_storage = mocker.patch("opta.commands.apply.Terraform.create_state_storage")
     mocked_thread = mocker.patch("opta.commands.apply.Thread")
     mocked_layer.get_module_by_type.return_value = [mocker.Mock()]
@@ -94,7 +94,6 @@ def test_apply(mocker: MockFixture, mocked_layer: Any, basic_mocks: Any) -> None
         "The above are the planned changes for your opta run. Do you approve?",
         abort=True,
     )
-    tf_show.assert_called_once_with(TF_PLAN_PATH)
     mocked_layer.get_module_by_type.assert_has_calls(
         [mocker.call("k8s-service"), mocker.call("k8s-service", 0)]
     )
@@ -129,7 +128,6 @@ def test_auto_approve(mocker: MockFixture, mocked_layer: Any, basic_mocks: Any) 
     mocker.patch("opta.commands.apply.get_cluster_name")
     tf_apply = mocker.patch("opta.commands.apply.Terraform.apply")
     tf_plan = mocker.patch("opta.commands.apply.Terraform.plan")
-    tf_show = mocker.patch("opta.commands.apply.Terraform.show")
     tf_create_storage = mocker.patch("opta.commands.apply.Terraform.create_state_storage")
     mocked_thread = mocker.patch("opta.commands.apply.Thread")
     mocked_layer.get_module_by_type.return_value = [mocker.Mock()]
@@ -155,7 +153,6 @@ def test_auto_approve(mocker: MockFixture, mocked_layer: Any, basic_mocks: Any) 
         quiet=True,
     )
     mocked_click.confirm.assert_not_called()
-    tf_show.assert_called_once_with(TF_PLAN_PATH)
     mocked_layer.get_module_by_type.assert_has_calls(
         [mocker.call("k8s-service"), mocker.call("k8s-service", 0)]
     )

--- a/tests/commands/test_deploy.py
+++ b/tests/commands/test_deploy.py
@@ -38,11 +38,11 @@ def test_deploy_basic(mocker: MockFixture) -> None:
         config="opta.yml",
         env=None,
         refresh=False,
-        max_module=None,
         image_tag=None,
         test=False,
         auto_approve=False,
         image_digest="local_digest",
+        detailed_plan=False,
     )
     mock_terraform_outputs.assert_called_once_with(mocker.ANY)
 
@@ -76,11 +76,11 @@ def test_deploy_auto_approve(mocker: MockFixture) -> None:
         config="opta.yml",
         env=None,
         refresh=False,
-        max_module=None,
         image_tag=None,
         test=False,
         auto_approve=True,
         image_digest="local_digest",
+        detailed_plan=False,
     )
     mock_terraform_outputs.assert_called_once_with(mocker.ANY)
 
@@ -125,11 +125,11 @@ def test_deploy_all_flags(mocker: MockFixture) -> None:
         config="app/opta.yml",
         env="staging",
         refresh=False,
-        max_module=None,
         image_tag=None,
         test=False,
         auto_approve=False,
         image_digest="local_digest",
+        detailed_plan=False,
     )
 
 
@@ -174,21 +174,21 @@ def test_deploy_ecr_apply(mocker: MockFixture) -> None:
                 config="app/opta.yml",
                 env="staging",
                 refresh=False,
-                max_module=None,
                 image_tag=None,
                 test=False,
                 auto_approve=False,
                 stdout_logs=False,
+                detailed_plan=False,
             ),
             mocker.call(
                 config="app/opta.yml",
                 env="staging",
                 refresh=False,
-                max_module=None,
                 image_tag=None,
                 test=False,
                 auto_approve=False,
                 image_digest="local_digest",
+                detailed_plan=False,
             ),
         ]
     )

--- a/tests/core/dummy_changes.yaml
+++ b/tests/core/dummy_changes.yaml
@@ -1,0 +1,399 @@
+resource_changes:
+  - action_reason: replace_because_cannot_update
+    address: module.base.aws_ebs_default_kms_key.default
+    change:
+      actions:
+        - create
+        - delete
+      after:
+        key_arn: arn:aws:kms:us-east-1:445935066876:key/aaac2f57-1f39-405e-95fe-2cfbd24744d2
+      after_sensitive: {}
+      after_unknown:
+        id: true
+      before:
+        id: arn:aws:kms:us-east-1:445935066876:key/aaac2f57-1f39-405e-95fe-2cfbd24744d2
+        key_arn: arn:aws:kms:us-east-1:445935066876:key/7da1bd98-6dce-4cba-8b7b-a37b5c475101
+      before_sensitive: {}
+      replace_paths:
+        - - key_arn
+    mode: managed
+    module_address: module.base
+    name: default
+    provider_name: registry.terraform.io/hashicorp/aws
+    type: aws_ebs_default_kms_key
+  - address: module.base.aws_ebs_encryption_by_default.default
+    change:
+      actions:
+        - no-op
+      after:
+        enabled: true
+        id: terraform-20210802213104524500000001
+      after_sensitive: {}
+      after_unknown: {}
+      before:
+        enabled: true
+        id: terraform-20210802213104524500000001
+      before_sensitive: {}
+    mode: managed
+    module_address: module.base
+    name: default
+    provider_name: registry.terraform.io/hashicorp/aws
+    type: aws_ebs_encryption_by_default
+  - address: module.dns.aws_route53_zone.public
+    change:
+      actions:
+        - no-op
+      after:
+        comment: Managed by Terraform
+        delegation_set_id: ''
+        force_destroy: true
+        id: Z0590875IJFAYVYAZJ5G
+        name: baloney.runx.dev
+        name_servers:
+          - ns-115.awsdns-14.com
+          - ns-1482.awsdns-57.org
+          - ns-1731.awsdns-24.co.uk
+          - ns-689.awsdns-22.net
+        tags:
+          Name: opta-live-example-dev
+          layer: live-example-dev
+          opta: 'true'
+          opta-environment: live-example-dev
+          tf_address: module.dns.aws_route53_zone.public
+        tags_all:
+          Name: opta-live-example-dev
+          layer: live-example-dev
+          opta: 'true'
+          opta-environment: live-example-dev
+          tf_address: module.dns.aws_route53_zone.public
+        vpc: []
+        zone_id: Z0590875IJFAYVYAZJ5G
+      after_sensitive:
+        name_servers:
+          - false
+          - false
+          - false
+          - false
+        tags: {}
+        tags_all: {}
+        vpc: []
+      after_unknown: {}
+      before:
+        comment: Managed by Terraform
+        delegation_set_id: ''
+        force_destroy: true
+        id: Z0590875IJFAYVYAZJ5G
+        name: baloney.runx.dev
+        name_servers:
+          - ns-115.awsdns-14.com
+          - ns-1482.awsdns-57.org
+          - ns-1731.awsdns-24.co.uk
+          - ns-689.awsdns-22.net
+        tags:
+          Name: opta-live-example-dev
+          layer: live-example-dev
+          opta: 'true'
+          opta-environment: live-example-dev
+          tf_address: module.dns.aws_route53_zone.public
+        tags_all:
+          Name: opta-live-example-dev
+          layer: live-example-dev
+          opta: 'true'
+          opta-environment: live-example-dev
+          tf_address: module.dns.aws_route53_zone.public
+        vpc: []
+        zone_id: Z0590875IJFAYVYAZJ5G
+      before_sensitive:
+        name_servers:
+          - false
+          - false
+          - false
+          - false
+        tags: {}
+        tags_all: {}
+        vpc: []
+    mode: managed
+    module_address: module.dns
+    name: public
+    provider_name: registry.terraform.io/hashicorp/aws
+    type: aws_route53_zone
+  - address: module.k8sbase.aws_iam_policy.autoscaler
+    change:
+      actions:
+        - update
+      after:
+        arn: arn:aws:iam::445935066876:policy/opta-live-example-dev-k8s-autoscaler
+        description: ''
+        id: arn:aws:iam::445935066876:policy/opta-live-example-dev-k8s-autoscaler
+        name: opta-live-example-dev-k8s-autoscaler
+        name_prefix: null
+        path: /
+        policy_id: ANPAWPU6ND36FUKZQPWQO
+        tags:
+          layer: live-example-dev
+          opta: 'true'
+          tf_address: module.k8sbase.aws_iam_policy.autoscaler
+        tags_all:
+          layer: live-example-dev
+          opta: 'true'
+          tf_address: module.k8sbase.aws_iam_policy.autoscaler
+      after_sensitive:
+        tags: {}
+        tags_all: {}
+      after_unknown:
+        policy: true
+        tags: {}
+        tags_all: {}
+      before:
+        arn: arn:aws:iam::445935066876:policy/opta-live-example-dev-k8s-autoscaler
+        description: ''
+        id: arn:aws:iam::445935066876:policy/opta-live-example-dev-k8s-autoscaler
+        name: opta-live-example-dev-k8s-autoscaler
+        name_prefix: null
+        path: /
+        policy: "{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n    \
+        \  \"Sid\": \"autoscaling\",\n      \"Effect\": \"Allow\",\n      \"Action\"\
+        : [\n        \"ec2:DescribeLaunchTemplateVersions\",\n        \"autoscaling:TerminateInstanceInAutoScalingGroup\"\
+        ,\n        \"autoscaling:SetDesiredCapacity\",\n        \"autoscaling:DescribeTags\"\
+        ,\n        \"autoscaling:DescribeLaunchConfigurations\",\n        \"autoscaling:DescribeAutoScalingInstances\"\
+        ,\n        \"autoscaling:DescribeAutoScalingGroups\"\n      ],\n      \"Resource\"\
+        : \"*\"\n    }\n  ]\n}"
+        policy_id: ANPAWPU6ND36FUKZQPWQO
+        tags:
+          layer: live-example-dev
+          opta: 'true'
+          tf_address: module.k8sbase.aws_iam_policy.autoscaler
+        tags_all:
+          layer: live-example-dev
+          opta: 'true'
+          tf_address: module.k8sbase.aws_iam_policy.autoscaler
+      before_sensitive:
+        tags: {}
+        tags_all: {}
+    mode: managed
+    module_address: module.k8sbase
+    name: autoscaler
+    provider_name: registry.terraform.io/hashicorp/aws
+    type: aws_iam_policy
+  - address: module.k8sbase.aws_iam_policy.external_dns
+    change:
+      actions:
+        - update
+      after:
+        arn: arn:aws:iam::445935066876:policy/opta-live-example-dev-external-dns
+        description: ''
+        id: arn:aws:iam::445935066876:policy/opta-live-example-dev-external-dns
+        name: opta-live-example-dev-external-dns
+        name_prefix: null
+        path: /
+        policy_id: ANPAWPU6ND36PM3UUIVZV
+        tags:
+          layer: live-example-dev
+          opta: 'true'
+          tf_address: module.k8sbase.aws_iam_policy.external_dns
+        tags_all:
+          layer: live-example-dev
+          opta: 'true'
+          tf_address: module.k8sbase.aws_iam_policy.external_dns
+      after_sensitive:
+        tags: {}
+        tags_all: {}
+      after_unknown:
+        policy: true
+        tags: {}
+        tags_all: {}
+      before:
+        arn: arn:aws:iam::445935066876:policy/opta-live-example-dev-external-dns
+        description: ''
+        id: arn:aws:iam::445935066876:policy/opta-live-example-dev-external-dns
+        name: opta-live-example-dev-external-dns
+        name_prefix: null
+        path: /
+        policy: "{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n    \
+        \  \"Sid\": \"ChangeResourceRecordSets\",\n      \"Effect\": \"Allow\",\n\
+        \      \"Action\": \"route53:ChangeResourceRecordSets\",\n      \"Resource\"\
+        : \"arn:aws:route53:::hostedzone/*\"\n    },\n    {\n      \"Sid\": \"DescribeRoute53\"\
+        ,\n      \"Effect\": \"Allow\",\n      \"Action\": [\n        \"route53:ListResourceRecordSets\"\
+        ,\n        \"route53:ListHostedZones\"\n      ],\n      \"Resource\": \"*\"\
+        \n    }\n  ]\n}"
+        policy_id: ANPAWPU6ND36PM3UUIVZV
+        tags:
+          layer: live-example-dev
+          opta: 'true'
+          tf_address: module.k8sbase.aws_iam_policy.external_dns
+        tags_all:
+          layer: live-example-dev
+          opta: 'true'
+          tf_address: module.k8sbase.aws_iam_policy.external_dns
+      before_sensitive:
+        tags: {}
+        tags_all: {}
+    mode: managed
+    module_address: module.k8sbase
+    name: external_dns
+    provider_name: registry.terraform.io/hashicorp/aws
+    type: aws_iam_policy
+  - address: module.k8sbase.aws_iam_role.autoscaler
+    change:
+      actions:
+        - update
+      after:
+        arn: arn:aws:iam::445935066876:role/opta-live-example-dev-k8s-autoscaler
+        create_date: '2021-08-02T20:10:43Z'
+        description: ''
+        force_detach_policies: false
+        id: opta-live-example-dev-k8s-autoscaler
+        inline_policy:
+          - name: ''
+            policy: ''
+        managed_policy_arns:
+          - arn:aws:iam::445935066876:policy/opta-live-example-dev-k8s-autoscaler
+        max_session_duration: 3600
+        name: opta-live-example-dev-k8s-autoscaler
+        name_prefix: null
+        path: /
+        permissions_boundary: null
+        tags:
+          layer: live-example-dev
+          opta: 'true'
+          tf_address: module.k8sbase.aws_iam_role.autoscaler
+        tags_all:
+          layer: live-example-dev
+          opta: 'true'
+          tf_address: module.k8sbase.aws_iam_role.autoscaler
+        unique_id: AROAWPU6ND36AL3CHVO3G
+      after_sensitive:
+        inline_policy:
+          - {}
+        managed_policy_arns:
+          - false
+        tags: {}
+        tags_all: {}
+      after_unknown:
+        assume_role_policy: true
+        inline_policy:
+          - {}
+        managed_policy_arns:
+          - false
+        tags: {}
+        tags_all: {}
+      before:
+        arn: arn:aws:iam::445935066876:role/opta-live-example-dev-k8s-autoscaler
+        assume_role_policy: '{"Version":"2012-10-17","Statement":[{"Sid":"","Effect":"Allow","Principal":{"Federated":"arn:aws:iam::445935066876:oidc-provider/oidc.eks.us-east-1.amazonaws.com/id/CD680652372A21B639AF8970AA7A4816"},"Action":"sts:AssumeRoleWithWebIdentity","Condition":{"StringEquals":{"oidc.eks.us-east-1.amazonaws.com/id/CD680652372A21B639AF8970AA7A4816:sub":"system:serviceaccount:autoscaler:autoscaler"}}}]}'
+        create_date: '2021-08-02T20:10:43Z'
+        description: ''
+        force_detach_policies: false
+        id: opta-live-example-dev-k8s-autoscaler
+        inline_policy:
+          - name: ''
+            policy: ''
+        managed_policy_arns:
+          - arn:aws:iam::445935066876:policy/opta-live-example-dev-k8s-autoscaler
+        max_session_duration: 3600
+        name: opta-live-example-dev-k8s-autoscaler
+        name_prefix: null
+        path: /
+        permissions_boundary: null
+        tags:
+          layer: live-example-dev
+          opta: 'true'
+          tf_address: module.k8sbase.aws_iam_role.autoscaler
+        tags_all:
+          layer: live-example-dev
+          opta: 'true'
+          tf_address: module.k8sbase.aws_iam_role.autoscaler
+        unique_id: AROAWPU6ND36AL3CHVO3G
+      before_sensitive:
+        inline_policy:
+          - {}
+        managed_policy_arns:
+          - false
+        tags: {}
+        tags_all: {}
+    mode: managed
+    module_address: module.k8sbase
+    name: autoscaler
+    provider_name: registry.terraform.io/hashicorp/aws
+    type: aws_iam_role
+  - address: module.k8sbase.aws_iam_role.external_dns
+    change:
+      actions:
+        - update
+      after:
+        arn: arn:aws:iam::445935066876:role/opta-live-example-dev-external-dns
+        create_date: '2021-08-02T20:10:43Z'
+        description: ''
+        force_detach_policies: false
+        id: opta-live-example-dev-external-dns
+        inline_policy:
+          - name: ''
+            policy: ''
+        managed_policy_arns:
+          - arn:aws:iam::445935066876:policy/opta-live-example-dev-external-dns
+        max_session_duration: 3600
+        name: opta-live-example-dev-external-dns
+        name_prefix: null
+        path: /
+        permissions_boundary: null
+        tags:
+          layer: live-example-dev
+          opta: 'true'
+          tf_address: module.k8sbase.aws_iam_role.external_dns
+        tags_all:
+          layer: live-example-dev
+          opta: 'true'
+          tf_address: module.k8sbase.aws_iam_role.external_dns
+        unique_id: AROAWPU6ND36OQ7WB5YYV
+      after_sensitive:
+        inline_policy:
+          - {}
+        managed_policy_arns:
+          - false
+        tags: {}
+        tags_all: {}
+      after_unknown:
+        assume_role_policy: true
+        inline_policy:
+          - {}
+        managed_policy_arns:
+          - false
+        tags: {}
+        tags_all: {}
+      before:
+        arn: arn:aws:iam::445935066876:role/opta-live-example-dev-external-dns
+        assume_role_policy: '{"Version":"2012-10-17","Statement":[{"Sid":"","Effect":"Allow","Principal":{"Federated":"arn:aws:iam::445935066876:oidc-provider/oidc.eks.us-east-1.amazonaws.com/id/CD680652372A21B639AF8970AA7A4816"},"Action":"sts:AssumeRoleWithWebIdentity","Condition":{"StringEquals":{"oidc.eks.us-east-1.amazonaws.com/id/CD680652372A21B639AF8970AA7A4816:sub":"system:serviceaccount:external-dns:external-dns"}}}]}'
+        create_date: '2021-08-02T20:10:43Z'
+        description: ''
+        force_detach_policies: false
+        id: opta-live-example-dev-external-dns
+        inline_policy:
+          - name: ''
+            policy: ''
+        managed_policy_arns:
+          - arn:aws:iam::445935066876:policy/opta-live-example-dev-external-dns
+        max_session_duration: 3600
+        name: opta-live-example-dev-external-dns
+        name_prefix: null
+        path: /
+        permissions_boundary: null
+        tags:
+          layer: live-example-dev
+          opta: 'true'
+          tf_address: module.k8sbase.aws_iam_role.external_dns
+        tags_all:
+          layer: live-example-dev
+          opta: 'true'
+          tf_address: module.k8sbase.aws_iam_role.external_dns
+        unique_id: AROAWPU6ND36OQ7WB5YYV
+      before_sensitive:
+        inline_policy:
+          - {}
+        managed_policy_arns:
+          - false
+        tags: {}
+        tags_all: {}
+    mode: managed
+    module_address: module.k8sbase
+    name: external_dns
+    provider_name: registry.terraform.io/hashicorp/aws
+    type: aws_iam_role

--- a/tests/core/test_plan_displayer.py
+++ b/tests/core/test_plan_displayer.py
@@ -1,0 +1,19 @@
+# type: ignore
+import os
+
+from pytest_mock import MockFixture
+from ruamel import yaml
+
+from opta.core.plan_displayer import PlanDisplayer
+
+
+class TestPlanDisplayer:
+    def test_run(self, mocker: MockFixture):
+        path = os.path.join(
+            os.path.dirname(os.path.dirname(__file__)), "core", "dummy_changes.yaml",
+        )
+        with open(path) as f:
+            plan_dict = yaml.load(f)
+        mocked_terraform = mocker.patch("opta.core.plan_displayer.Terraform")
+        mocked_terraform.show_plan.return_value = plan_dict
+        PlanDisplayer.display()


### PR DESCRIPTION
1. Replaced default opta apply/deploy's plan showing to use our new compressed and color-coded change summary. Old behavior can still be invoked by adding the `--detailed-plan flag`
2. Opta INFO level logs will now not be prefixed by their level except in debug mode.
3. The `terraform init` output is now silenced

Below are some sample stdouts.

<img width="1093" alt="Screen Shot 2021-09-07 at 3 08 32 PM" src="https://user-images.githubusercontent.com/10430635/132419470-fb2b89fc-572b-434a-b827-cff90b463ac9.png">
<img width="1792" alt="Screen Shot 2021-09-07 at 3 28 00 PM" src="https://user-images.githubusercontent.com/10430635/132419464-b1504270-f7db-4b50-b067-591ea67d7cec.png">
<img width="1792" alt="Screen Shot 2021-09-07 at 3 24 24 PM" src="https://user-images.githubusercontent.com/10430635/132419467-2ffc38da-f425-4523-ad40-acf9689ff404.png">
<img width="1792" alt="Screen Shot 2021-09-07 at 3 21 47 PM" src="https://user-images.githubusercontent.com/10430635/132419468-bf47c541-f7d6-4ed6-8f24-fcec8cdbc589.png">

