### PR TITLE
Adding sticky sessions thanks to nginx ingress

### DIFF
--- a/config/registry/aws/modules/aws-k8s-service.yaml
+++ b/config/registry/aws/modules/aws-k8s-service.yaml
@@ -105,6 +105,16 @@ inputs:
     validator: str(required=False)
     description: Use if liveness probe != readiness probe
     default: null
+  - name: sticky_session
+    user_facing: true
+    validator: bool(required=False)
+    description: Use [sticky sessions](https://stackoverflow.com/questions/10494431/sticky-and-non-sticky-sessions) via cookies for your service (first request will send you a cookie called opta_cookie which you should add on future requests).
+    default: false
+  - name: sticky_session_max_age
+    user_facing: true
+    validator: int(required=False)
+    description: If the sticky session is enabled, how long should the cookie last?
+    default: 86400
   - name: resource_request
     user_facing: true
     validator: any(required=False)

--- a/config/registry/azurerm/modules/azure-k8s-service.yaml
+++ b/config/registry/azurerm/modules/azure-k8s-service.yaml
@@ -96,6 +96,16 @@ inputs: # (what users see)
     validator: str(required=False)
     description: Use if liveness probe != readiness probe
     default: null
+  - name: sticky_session
+    user_facing: true
+    validator: bool(required=False)
+    description: Use [sticky sessions](https://stackoverflow.com/questions/10494431/sticky-and-non-sticky-sessions) via cookies for your service (first request will send you a cookie called opta_cookie which you should add on future requests).
+    default: false
+  - name: sticky_session_max_age
+    user_facing: true
+    validator: int(required=False)
+    description: If the sticky session is enabled, how long should the cookie last?
+    default: 86400
   - name: resource_request
     user_facing: true
     validator: any(required=False)

--- a/config/registry/google/modules/gcp-k8s-service.yaml
+++ b/config/registry/google/modules/gcp-k8s-service.yaml
@@ -100,6 +100,16 @@ inputs:
     validator: str(required=False)
     description: Use if liveness probe != readiness probe
     default: null
+  - name: sticky_session
+    user_facing: true
+    validator: bool(required=False)
+    description: Use [sticky sessions](https://stackoverflow.com/questions/10494431/sticky-and-non-sticky-sessions) via cookies for your service (first request will send you a cookie called opta_cookie which you should add on future requests).
+    default: false
+  - name: sticky_session_max_age
+    user_facing: true
+    validator: int(required=False)
+    description: If the sticky session is enabled, how long should the cookie last?
+    default: 86400
   - name: resource_request
     user_facing: true
     validator: any(required=False)

--- a/config/tf_modules/azure-k8s-service/k8s-service/templates/ingress.yaml
+++ b/config/tf_modules/azure-k8s-service/k8s-service/templates/ingress.yaml
@@ -7,6 +7,12 @@ metadata:
   labels:
     {{- include "k8s-service.labels" $ | nindent 4 }}
   annotations:
+    {{- if $.Values.stickySession }}
+    nginx.ingress.kubernetes.io/affinity: "cookie"
+    nginx.ingress.kubernetes.io/session-cookie-name: "opta-cookie"
+    nginx.ingress.kubernetes.io/session-cookie-expires: {{ $.Values.stickySessionMaxAge | quote }}
+    nginx.ingress.kubernetes.io/session-cookie-max-age: {{ $.Values.stickySessionMaxAge | quote }}
+    {{- end }}
     {{- if not (eq $val.pathPrefix "/") }}
     nginx.ingress.kubernetes.io/rewrite-target: /$2
     {{- end }}

--- a/config/tf_modules/azure-k8s-service/k8s-service/values.yaml
+++ b/config/tf_modules/azure-k8s-service/k8s-service/values.yaml
@@ -5,6 +5,8 @@ iamRoleArn: ""
 layerName: ""
 moduleName: ""
 environmentName: ""
+stickySession: false
+stickySessionMaxAge: 86400
 envVars: []
 linkSecrets: []
 manualSecrets: []

--- a/config/tf_modules/azure-k8s-service/main.tf
+++ b/config/tf_modules/azure-k8s-service/main.tf
@@ -41,6 +41,8 @@ resource "helm_release" "k8s-service" {
       layerName : var.layer_name,
       moduleName : var.module_name,
       environmentName : var.env_name,
+      stickySession : var.sticky_session
+      stickySessionMaxAge : var.sticky_session_max_age
     })
   ]
   atomic          = true

--- a/config/tf_modules/azure-k8s-service/variables.tf
+++ b/config/tf_modules/azure-k8s-service/variables.tf
@@ -31,6 +31,14 @@ variable "module_name" {
   type        = string
 }
 
+variable "sticky_session" {
+  default = false
+}
+
+variable "sticky_session_max_age" {
+  default = 86400
+}
+
 variable "port" {
   description = "Port to be exposed as :80"
   type        = map(number)

--- a/config/tf_modules/gcp-k8s-service/k8s-service/templates/ingress.yaml
+++ b/config/tf_modules/gcp-k8s-service/k8s-service/templates/ingress.yaml
@@ -7,6 +7,12 @@ metadata:
   labels:
     {{- include "k8s-service.labels" $ | nindent 4 }}
   annotations:
+    {{- if $.Values.stickySession }}
+    nginx.ingress.kubernetes.io/affinity: "cookie"
+    nginx.ingress.kubernetes.io/session-cookie-name: "opta-cookie"
+    nginx.ingress.kubernetes.io/session-cookie-expires: {{ $.Values.stickySessionMaxAge | quote }}
+    nginx.ingress.kubernetes.io/session-cookie-max-age: {{ $.Values.stickySessionMaxAge | quote }}
+    {{- end }}
     {{- if not (eq $val.pathPrefix "/") }}
     nginx.ingress.kubernetes.io/rewrite-target: /$2
     {{- end }}

--- a/config/tf_modules/gcp-k8s-service/k8s-service/values.yaml
+++ b/config/tf_modules/gcp-k8s-service/k8s-service/values.yaml
@@ -5,6 +5,8 @@ googleServiceAccount: ""
 layerName: ""
 moduleName: ""
 environmentName: ""
+stickySession: false
+stickySessionMaxAge: 86400
 envVars: []
 linkSecrets: []
 manualSecrets: []

--- a/config/tf_modules/gcp-k8s-service/main.tf
+++ b/config/tf_modules/gcp-k8s-service/main.tf
@@ -41,6 +41,8 @@ resource "helm_release" "k8s-service" {
       moduleName : var.module_name,
       environmentName : var.env_name,
       googleServiceAccount : google_service_account.k8s_service.email
+      stickySession : var.sticky_session
+      stickySessionMaxAge : var.sticky_session_max_age
     })
   ]
   atomic          = true

--- a/config/tf_modules/gcp-k8s-service/variables.tf
+++ b/config/tf_modules/gcp-k8s-service/variables.tf
@@ -29,6 +29,14 @@ variable "module_name" {
   type        = string
 }
 
+variable "sticky_session" {
+  default = false
+}
+
+variable "sticky_session_max_age" {
+  default = 86400
+}
+
 variable "port" {
   description = "Port to be exposed as :80"
   type        = map(number)

--- a/config/tf_modules/k8s-service/k8s-service/templates/ingress.yaml
+++ b/config/tf_modules/k8s-service/k8s-service/templates/ingress.yaml
@@ -7,6 +7,12 @@ metadata:
   labels:
     {{- include "k8s-service.labels" $ | nindent 4 }}
   annotations:
+    {{- if $.Values.stickySession }}
+    nginx.ingress.kubernetes.io/affinity: "cookie"
+    nginx.ingress.kubernetes.io/session-cookie-name: "opta-cookie"
+    nginx.ingress.kubernetes.io/session-cookie-expires: {{ $.Values.stickySessionMaxAge | quote }}
+    nginx.ingress.kubernetes.io/session-cookie-max-age: {{ $.Values.stickySessionMaxAge | quote }}
+    {{- end }}
     {{- if not (eq $val.pathPrefix "/") }}
     nginx.ingress.kubernetes.io/rewrite-target: /$2
     {{- end }}

--- a/config/tf_modules/k8s-service/k8s-service/values.yaml
+++ b/config/tf_modules/k8s-service/k8s-service/values.yaml
@@ -5,6 +5,8 @@ iamRoleArn: ""
 layerName: ""
 moduleName: ""
 environmentName: ""
+stickySession: false
+stickySessionMaxAge: 86400
 envVars: []
 linkSecrets: []
 manualSecrets: []

--- a/config/tf_modules/k8s-service/main.tf
+++ b/config/tf_modules/k8s-service/main.tf
@@ -42,6 +42,8 @@ resource "helm_release" "k8s-service" {
       moduleName : var.module_name,
       environmentName : var.env_name,
       iamRoleArn : aws_iam_role.k8s_service.arn
+      stickySession : var.sticky_session
+      stickySessionMaxAge : var.sticky_session_max_age
     })
   ]
   atomic          = true

--- a/config/tf_modules/k8s-service/variables.tf
+++ b/config/tf_modules/k8s-service/variables.tf
@@ -30,6 +30,14 @@ variable "module_name" {
   type        = string
 }
 
+variable "sticky_session" {
+  default = false
+}
+
+variable "sticky_session_max_age" {
+  default = 86400
+}
+
 variable "port" {
   description = "Port to be exposed as :80"
   type        = map(number)

--- a/examples/http-service/opta.yml
+++ b/examples/http-service/opta.yml
@@ -20,9 +20,10 @@ modules:
     max_containers: "{vars.max_containers}"
     liveness_probe_path: "/get"
     readiness_probe_path: "/get"
+    sticky_session: true
     port:
       http: 80
     env_vars:
-      A: B
+      GUNICORN_CMD_ARGS: "--bind=0.0.0.0:8000 --workers=3 --capture-output --error-logfile - --access-logfile - --access-logformat '%(h)s %(t)s %(r)s %(s)s Content-Type: %({Content-Type}i)s'"
     public_uri: "http-example.{parent.domain}"
 

--- a/opta/module_processors/aws_eks.py
+++ b/opta/module_processors/aws_eks.py
@@ -1,3 +1,4 @@
+from time import sleep
 from typing import TYPE_CHECKING, Dict, List, Optional
 
 import boto3
@@ -45,6 +46,13 @@ class AwsEksProcessor(ModuleProcessor):
             f"Found dangling cloudwatch log group {log_group_name}. Deleting it now"
         )
         client.delete_log_group(logGroupName=log_group_name)
+        sleep(3)
+        log_groups = client.describe_log_groups(logGroupNamePrefix=log_group_name)
+        if len(log_groups["logGroups"]) != 0:
+            logger.warning(
+                f"Cloudwatch Log group {log_group_name} has recreated itself. Not stopping the destroy, but you will "
+                "wanna check this out."
+            )
 
     def cleanup_dangling_enis(self, region: str) -> None:
         client: EC2Client = boto3.client("ec2", config=Config(region_name=region))


### PR DESCRIPTION
A k8s-service module spec now has 2 new fields to specify whether to have sticky sessions and how long should the session's cookies last.