### PR TITLE
Making sure order does not matter for gcp dns in k8s base

### DIFF
--- a/config/registry/google/modules/gcp-k8s-base.yaml
+++ b/config/registry/google/modules/gcp-k8s-base.yaml
@@ -19,7 +19,7 @@ inputs:
     default: false
   - name: hosted_zone_name
     user_facing: false
-    description: Name of hostezed zone to setup the ingress with
+    description: Name of hosted zone to setup the ingress with
     default: ""
   - name: domain
     user_facing: false

--- a/config/registry/google/modules/gcp-k8s-base.yaml
+++ b/config/registry/google/modules/gcp-k8s-base.yaml
@@ -19,6 +19,10 @@ inputs:
     default: false
   - name: hosted_zone_name
     user_facing: false
+    description: Name of hostezed zone to setup the ingress with
+    default: ""
+  - name: domain
+    user_facing: false
     description: Domain to setup the ingress with
     default: ""
   - name: cert_self_link

--- a/config/tf_modules/gcp-k8s-base/load_balancer.tf
+++ b/config/tf_modules/gcp-k8s-base/load_balancer.tf
@@ -91,23 +91,18 @@ resource "google_compute_global_forwarding_rule" "https" {
 
 resource "google_dns_record_set" "default" {
   count        = var.hosted_zone_name == null ? 0 : 1
-  name         = data.google_dns_managed_zone.public[0].dns_name
+  name         = "${var.domain}."
   type         = "A"
   ttl          = 3600
-  managed_zone = data.google_dns_managed_zone.public[0].name
+  managed_zone = var.hosted_zone_name
   rrdatas      = [google_compute_global_address.load_balancer.address]
 }
 
 resource "google_dns_record_set" "wildcard" {
   count        = var.hosted_zone_name == null ? 0 : 1
-  name         = "*.${data.google_dns_managed_zone.public[0].dns_name}"
+  name         = "*.${var.domain}."
   type         = "A"
   ttl          = 3600
-  managed_zone = data.google_dns_managed_zone.public[0].name
+  managed_zone = var.hosted_zone_name
   rrdatas      = [google_compute_global_address.load_balancer.address]
-}
-
-data "google_dns_managed_zone" "public" {
-  count = var.hosted_zone_name == null ? 0 : 1
-  name  = var.hosted_zone_name
 }

--- a/config/tf_modules/gcp-k8s-base/variables.tf
+++ b/config/tf_modules/gcp-k8s-base/variables.tf
@@ -61,6 +61,11 @@ variable "hosted_zone_name" {
   default = null
 }
 
+variable "domain" {
+  type    = string
+  default = null
+}
+
 variable "zone_names" {
   type    = list(string)
   default = []

--- a/opta/module_processors/gcp_k8s_base.py
+++ b/opta/module_processors/gcp_k8s_base.py
@@ -33,15 +33,15 @@ class GcpK8sBaseProcessor(GcpK8sModuleProcessor):
                 "certificate_chain"
             ] = f"${{{{module.{byo_cert_module.name}.certificate_chain}}}}"
 
+        gcp_dns_modules = self.layer.get_module_by_type("gcp-dns", module_idx)
         gcp_dns_module = None
-        for module in self.layer.modules:
-            if (module.aliased_type or module.type) == "gcp-dns":
-                gcp_dns_module = module
-                break
+        if len(gcp_dns_modules) > 0:
+            gcp_dns_module = gcp_dns_modules[0]
         if gcp_dns_module is not None:
             self.module.data[
                 "hosted_zone_name"
             ] = f"${{{{module.{gcp_dns_module.name}.zone_name}}}}"
+            self.module.data["domain"] = f"${{{{module.{gcp_dns_module.name}.domain}}}}"
             self.module.data[
                 "cert_self_link"
             ] = f"${{{{module.{gcp_dns_module.name}.cert_self_link}}}}"


### PR DESCRIPTION
Tried locally once, now destroying and recreating to confirm consistency, but ready for review