### PR TITLE
Due to version being a reserved input, the version field in the helm ...

### DIFF
--- a/config/registry/common/modules/helm-chart.yaml
+++ b/config/registry/common/modules/helm-chart.yaml
@@ -46,10 +46,10 @@ inputs:
     validator: bool(required=False)
     description: Allow deletion of new resources created in this upgrade when upgrade fails
     default: true
-  - name: version
+  - name: chart_version
     user_facing: true
     validator: str(required=False)
-    description: The version of the helm chart to install
+    description: User side of the version of the helm chart to install
     default: null
   - name: values_file
     user_facing: true

--- a/opta/module_processors/helm_chart.py
+++ b/opta/module_processors/helm_chart.py
@@ -20,9 +20,7 @@ class HelmChartProcessor(ModuleProcessor):
         super(HelmChartProcessor, self).__init__(module, layer)
 
     def process(self, module_idx: int) -> None:
-        if "version" in self.module.data:
-            self.module.data["chart_version"] = self.module.data["version"]
-        if "repository" in self.module.data and "version" not in self.module.data:
+        if "repository" in self.module.data and "chart_version" not in self.module.data:
             raise UserErrors(
                 "If you specify a remote repository you must give a version."
             )


### PR DESCRIPTION
chart  is being  renamed to chart_version. This is a breaking change for the helm-chart module if you were using the version field (just rename it to chart_version and you should be all good).