### PR TITLE
Jd/stop infinite cycle

### DIFF
--- a/opta/layer.py
+++ b/opta/layer.py
@@ -142,7 +142,9 @@ class Layer:
                 )
 
     @classmethod
-    def load_from_yaml(cls, config: str, env: Optional[str]) -> Layer:
+    def load_from_yaml(
+        cls, config: str, env: Optional[str], is_parent: bool = False
+    ) -> Layer:
         t = None
         if config.startswith("git@"):
             logger.debug("Loading layer from git...")
@@ -175,7 +177,7 @@ class Layer:
         conf["original_spec"] = config_string
         conf["path"] = config
 
-        layer = cls.load_from_dict(conf, env)
+        layer = cls.load_from_dict(conf, env, is_parent)
         validate_yaml(config_path, layer.cloud)
         if t is not None:
             shutil.rmtree(t)
@@ -189,7 +191,9 @@ class Layer:
         }
 
     @classmethod
-    def load_from_dict(cls, conf: Dict[Any, Any], env: Optional[str]) -> Layer:
+    def load_from_dict(
+        cls, conf: Dict[Any, Any], env: Optional[str], is_parent: bool = False
+    ) -> Layer:
         modules_data = conf.get("modules", [])
         environments = conf.pop("environments", None)
         original_spec = conf.pop("original_spec", "")
@@ -197,6 +201,10 @@ class Layer:
         name = conf.pop("name", None)
         if name is None:
             raise UserErrors("Config must have name")
+        if is_parent and environments is not None:
+            raise UserErrors(
+                f"Layer {name} can not be a parent as it has a parent of its own"
+            )
         org_name = conf.pop("org_name", None)
         providers = conf.pop("providers", {})
         if "aws" in providers:
@@ -211,7 +219,7 @@ class Layer:
                 parent_path: str = env_meta["path"]
                 if not parent_path.startswith("git@") and not parent_path.startswith("/"):
                     parent_path = os.path.join(os.path.dirname(path), env_meta["path"])
-                current_parent = cls.load_from_yaml(parent_path, None)
+                current_parent = cls.load_from_yaml(parent_path, None, is_parent=True)
                 if current_parent.parent is not None:
                     raise UserErrors(
                         "A parent can not have a parent, only one level of parent-child allowed."

--- a/opta/layer.py
+++ b/opta/layer.py
@@ -203,7 +203,8 @@ class Layer:
             raise UserErrors("Config must have name")
         if is_parent and environments is not None:
             raise UserErrors(
-                f"Layer {name} can not be a parent as it has a parent of its own"
+                f"Environment {name} can not have an environment itself (usually this means your file is "
+                "self-referencing as it's own parent)."
             )
         org_name = conf.pop("org_name", None)
         providers = conf.pop("providers", {})

--- a/opta/layer.py
+++ b/opta/layer.py
@@ -229,6 +229,10 @@ class Layer:
                     raise UserErrors(
                         f"Same environment: {current_env} is imported twice as parent"
                     )
+                if current_parent.name == name:
+                    raise UserErrors(
+                        "A service can not have the same name as its environment."
+                    )
                 potential_envs[env_name] = (current_parent, env_meta)
 
             if env is None:

--- a/tests/infinite_loop.yaml
+++ b/tests/infinite_loop.yaml
@@ -1,0 +1,10 @@
+environments:
+  - path: "./infinite_loop.yaml"
+    name: "dummy-env"
+    variables: {}
+name: dummy-config-1
+modules:
+  - name: database
+    type: aws-postgres
+  - name: redis
+    type: aws-redis

--- a/tests/same_name_as_parent.yaml
+++ b/tests/same_name_as_parent.yaml
@@ -1,0 +1,10 @@
+environments:
+  - path: "./module_processors/dummy_config_parent.yaml"
+    name: "dummy-env"
+    variables: {}
+name: dummy-parent
+modules:
+  - name: database
+    type: aws-postgres
+  - name: redis
+    type: aws-redis

--- a/tests/test_layer.py
+++ b/tests/test_layer.py
@@ -2,12 +2,33 @@
 
 import os
 
+import pytest
 from pytest_mock import MockFixture
 
+from opta.exceptions import UserErrors
 from opta.layer import Layer
 
 
 class TestLayer:
+    def test_infinite_loop_prevention(self):
+        with pytest.raises(UserErrors):
+            Layer.load_from_yaml(
+                os.path.join(
+                    os.path.dirname(os.path.dirname(__file__)), "infinite_loop.yaml",
+                ),
+                None,
+            )
+
+    def test_same_name_as_parent(self):
+        with pytest.raises(UserErrors):
+            Layer.load_from_yaml(
+                os.path.join(
+                    os.path.dirname(os.path.dirname(__file__)),
+                    "same_name_as_parent.yaml",
+                ),
+                None,
+            )
+
     def test_parent(self, mocker: MockFixture):
         layer = Layer.load_from_yaml(
             os.path.join(


### PR DESCRIPTION
# Description
* If a env has the same name as a service, it will raise an error
* If a parent has a parent we raise an issue

# Safety checklist
* [x] This change is backwards compatible and safe to apply by existing users
* [x] This change will NOT lead to data loss
* [x] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
I ran opta apply locally against a dummy aws app and there was no problem
