### PR TITLE
Adding a keep path prefix flag for k8s services

### DIFF
--- a/config/registry/aws/modules/aws-k8s-service.yaml
+++ b/config/registry/aws/modules/aws-k8s-service.yaml
@@ -139,6 +139,11 @@ inputs:
     description: |
       The full domain to expose your app under as well as path prefix. Must be the full parent domain or a subdomain referencing the parent as such: "dummy.{parent[domain]}/my/path/prefix"
     default: []
+  - name: keep_path_prefix
+    user_facing: true
+    validator: bool(required=False)
+    description: Should we keep the prefix path which you set in the public uri when forwarding requests to your service?
+    default: false
   - name: additional_iam_policies
     user_facing: true
     validator: any(required=False)

--- a/config/registry/azurerm/modules/azure-k8s-service.yaml
+++ b/config/registry/azurerm/modules/azure-k8s-service.yaml
@@ -130,6 +130,11 @@ inputs: # (what users see)
     description: |
       The full domain to expose your app under as well as path prefix. Must be the full parent domain or a subdomain referencing the parent as such: "dummy.{parent[domain]}/my/path/prefix"
     default: []
+  - name: keep_path_prefix
+    user_facing: true
+    validator: bool(required=False)
+    description: Should we keep the prefix path which you set in the public uri when forwarding requests to your service?
+    default: false
   - name: links
     user_facing: true
     validator: list(any(str(), map()), required=False)

--- a/config/registry/google/modules/gcp-k8s-service.yaml
+++ b/config/registry/google/modules/gcp-k8s-service.yaml
@@ -134,6 +134,11 @@ inputs:
     description: |
       The full domain to expose your app under as well as path prefix. Must be the full parent domain or a subdomain referencing the parent as such: "dummy.{parent[domain]}/my/path/prefix"
     default: []
+  - name: keep_path_prefix
+    user_facing: true
+    validator: bool(required=False)
+    description: Should we keep the prefix path which you set in the public uri when forwarding requests to your service?
+    default: false
   - name: links
     user_facing: true
     validator: list(any(str(), map()), required=False)

--- a/config/tf_modules/azure-k8s-service/k8s-service/templates/ingress.yaml
+++ b/config/tf_modules/azure-k8s-service/k8s-service/templates/ingress.yaml
@@ -16,8 +16,11 @@ metadata:
     {{- if $.Values.consistentHash }}
     nginx.ingress.kubernetes.io/upstream-hash-by: {{ $.Values.consistentHash }}
     {{- end }}
-    {{- if not (eq $val.pathPrefix "/") }}
-    nginx.ingress.kubernetes.io/rewrite-target: /$2
+    {{- if and ( ne $val.pathPrefix "/") (not $.Values.keepPathPrefix) }}
+    nginx.ingress.kubernetes.io/rewrite-target: "/$2"
+    {{- end }}
+    {{- if and ( ne $val.pathPrefix "/") $.Values.keepPathPrefix }}
+    nginx.ingress.kubernetes.io/rewrite-target: "{{ $val.pathPrefix }}$1$2"
     {{- end }}
     {{ if hasKey $.Values.port "grpc" }}
     nginx.ingress.kubernetes.io/backend-protocol: "GRPC"

--- a/config/tf_modules/azure-k8s-service/k8s-service/values.yaml
+++ b/config/tf_modules/azure-k8s-service/k8s-service/values.yaml
@@ -11,6 +11,7 @@ envVars: []
 linkSecrets: []
 manualSecrets: []
 port: {}
+keepPathPrefix: false
 
 serviceAccount:
   # The name of the service account to use.

--- a/config/tf_modules/azure-k8s-service/main.tf
+++ b/config/tf_modules/azure-k8s-service/main.tf
@@ -44,6 +44,7 @@ resource "helm_release" "k8s-service" {
       stickySession : var.sticky_session
       stickySessionMaxAge : var.sticky_session_max_age
       consistentHash : var.consistent_hash
+      keepPathPrefix: var.keep_path_prefix
     })
   ]
   atomic          = true

--- a/config/tf_modules/azure-k8s-service/main.tf
+++ b/config/tf_modules/azure-k8s-service/main.tf
@@ -44,7 +44,7 @@ resource "helm_release" "k8s-service" {
       stickySession : var.sticky_session
       stickySessionMaxAge : var.sticky_session_max_age
       consistentHash : var.consistent_hash
-      keepPathPrefix: var.keep_path_prefix
+      keepPathPrefix : var.keep_path_prefix
     })
   ]
   atomic          = true

--- a/config/tf_modules/azure-k8s-service/variables.tf
+++ b/config/tf_modules/azure-k8s-service/variables.tf
@@ -150,6 +150,6 @@ variable "acr_registry_name" {
 }
 
 variable "keep_path_prefix" {
-  type = bool
+  type    = bool
   default = false
 }

--- a/config/tf_modules/azure-k8s-service/variables.tf
+++ b/config/tf_modules/azure-k8s-service/variables.tf
@@ -148,3 +148,8 @@ variable "manual_secrets" {
 variable "acr_registry_name" {
   type = string
 }
+
+variable "keep_path_prefix" {
+  type = bool
+  default = false
+}

--- a/config/tf_modules/gcp-k8s-service/k8s-service/templates/ingress.yaml
+++ b/config/tf_modules/gcp-k8s-service/k8s-service/templates/ingress.yaml
@@ -16,8 +16,11 @@ metadata:
     {{- if $.Values.consistentHash }}
     nginx.ingress.kubernetes.io/upstream-hash-by: {{ $.Values.consistentHash }}
     {{- end }}
-    {{- if not (eq $val.pathPrefix "/") }}
-    nginx.ingress.kubernetes.io/rewrite-target: /$2
+    {{- if and ( ne $val.pathPrefix "/") (not $.Values.keepPathPrefix) }}
+    nginx.ingress.kubernetes.io/rewrite-target: "/$2"
+    {{- end }}
+    {{- if and ( ne $val.pathPrefix "/") $.Values.keepPathPrefix }}
+    nginx.ingress.kubernetes.io/rewrite-target: "{{ $val.pathPrefix }}$1$2"
     {{- end }}
     {{ if hasKey $.Values.port "grpc" }}
     nginx.ingress.kubernetes.io/backend-protocol: "GRPC"

--- a/config/tf_modules/gcp-k8s-service/k8s-service/values.yaml
+++ b/config/tf_modules/gcp-k8s-service/k8s-service/values.yaml
@@ -11,6 +11,7 @@ envVars: []
 linkSecrets: []
 manualSecrets: []
 port: {}
+keepPathPrefix: false
 serviceAccount:
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template

--- a/config/tf_modules/gcp-k8s-service/main.tf
+++ b/config/tf_modules/gcp-k8s-service/main.tf
@@ -44,6 +44,7 @@ resource "helm_release" "k8s-service" {
       stickySession : var.sticky_session
       stickySessionMaxAge : var.sticky_session_max_age
       consistentHash : var.consistent_hash
+      keepPathPrefix: var.keep_path_prefix
     })
   ]
   atomic          = true

--- a/config/tf_modules/gcp-k8s-service/main.tf
+++ b/config/tf_modules/gcp-k8s-service/main.tf
@@ -44,7 +44,7 @@ resource "helm_release" "k8s-service" {
       stickySession : var.sticky_session
       stickySessionMaxAge : var.sticky_session_max_age
       consistentHash : var.consistent_hash
-      keepPathPrefix: var.keep_path_prefix
+      keepPathPrefix : var.keep_path_prefix
     })
   ]
   atomic          = true

--- a/config/tf_modules/gcp-k8s-service/variables.tf
+++ b/config/tf_modules/gcp-k8s-service/variables.tf
@@ -152,3 +152,8 @@ variable "write_buckets" {
   type    = list(string)
   default = []
 }
+
+variable "keep_path_prefix" {
+  type = bool
+  default = false
+}

--- a/config/tf_modules/gcp-k8s-service/variables.tf
+++ b/config/tf_modules/gcp-k8s-service/variables.tf
@@ -154,6 +154,6 @@ variable "write_buckets" {
 }
 
 variable "keep_path_prefix" {
-  type = bool
+  type    = bool
   default = false
 }

--- a/config/tf_modules/k8s-service/k8s-service/templates/ingress.yaml
+++ b/config/tf_modules/k8s-service/k8s-service/templates/ingress.yaml
@@ -16,8 +16,11 @@ metadata:
     {{- if $.Values.consistentHash }}
     nginx.ingress.kubernetes.io/upstream-hash-by: {{ $.Values.consistentHash }}
     {{- end }}
-    {{- if not (eq $val.pathPrefix "/") }}
-    nginx.ingress.kubernetes.io/rewrite-target: /$2
+    {{- if and ( ne $val.pathPrefix "/") (not $.Values.keepPathPrefix) }}
+    nginx.ingress.kubernetes.io/rewrite-target: "/$2"
+    {{- end }}
+    {{- if and ( ne $val.pathPrefix "/") $.Values.keepPathPrefix }}
+    nginx.ingress.kubernetes.io/rewrite-target: "{{ $val.pathPrefix }}$1$2"
     {{- end }}
     {{ if hasKey $.Values.port "grpc" }}
     nginx.ingress.kubernetes.io/backend-protocol: "GRPC"

--- a/config/tf_modules/k8s-service/k8s-service/values.yaml
+++ b/config/tf_modules/k8s-service/k8s-service/values.yaml
@@ -11,6 +11,7 @@ envVars: []
 linkSecrets: []
 manualSecrets: []
 port: {}
+keepPathPrefix: false
 
 serviceAccount:
   # The name of the service account to use.

--- a/config/tf_modules/k8s-service/main.tf
+++ b/config/tf_modules/k8s-service/main.tf
@@ -45,6 +45,7 @@ resource "helm_release" "k8s-service" {
       stickySession : var.sticky_session
       stickySessionMaxAge : var.sticky_session_max_age
       consistentHash : var.consistent_hash
+      keepPathPrefix: var.keep_path_prefix
     })
   ]
   atomic          = true

--- a/config/tf_modules/k8s-service/main.tf
+++ b/config/tf_modules/k8s-service/main.tf
@@ -45,7 +45,7 @@ resource "helm_release" "k8s-service" {
       stickySession : var.sticky_session
       stickySessionMaxAge : var.sticky_session_max_age
       consistentHash : var.consistent_hash
-      keepPathPrefix: var.keep_path_prefix
+      keepPathPrefix : var.keep_path_prefix
     })
   ]
   atomic          = true

--- a/config/tf_modules/k8s-service/variables.tf
+++ b/config/tf_modules/k8s-service/variables.tf
@@ -153,6 +153,6 @@ variable "additional_iam_policies" {
 }
 
 variable "keep_path_prefix" {
-  type = bool
+  type    = bool
   default = false
 }

--- a/config/tf_modules/k8s-service/variables.tf
+++ b/config/tf_modules/k8s-service/variables.tf
@@ -151,3 +151,8 @@ variable "additional_iam_policies" {
   type    = list(string)
   default = []
 }
+
+variable "keep_path_prefix" {
+  type = bool
+  default = false
+}


### PR DESCRIPTION
# Description
If set to true, then the prefix path in the public uri is kept when we forward the request to your service

# Safety checklist
* [x] This change is backwards compatible and safe to apply by existing users
* [x] This change will NOT lead to data loss
* [x] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
I used the example http service with an aws environment. I went back and forth between toggling the flag and not and thanks to httpbin's [anything](https://httpbin.org/anything) endpoint I could look at the path which the server saw. Took a while to get it right but ultimately worked exactly as plan.
