### PR TITLE
Added docs about postgres backups and upped aws retention from 5->7 days

### DIFF
--- a/config/registry/aws/modules/aws-postgres.md
+++ b/config/registry/aws/modules/aws-postgres.md
@@ -11,6 +11,12 @@ This module creates a postgres Aurora RDS database instance. It is made in the
 private subnets automatically created during environment setup and so can only be accessed in the
 VPC or through some proxy (e.g. VPN).
 
+### Backups
+Opta will provision your database with 5 days of automatic daily backups in the form of 
+[RDS snapshots](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_CreateSnapshot.html). 
+You can find them either programmatically via the aws cli, or through the AWS web console (they will be called
+system snapshots, and they have a different tab than the manual ones).
+
 ### Linking
 
 When linked to a k8s-service, it adds connection credentials to your container's environment variables as:

--- a/config/registry/aws/modules/aws-postgres.md
+++ b/config/registry/aws/modules/aws-postgres.md
@@ -12,7 +12,7 @@ private subnets automatically created during environment setup and so can only b
 VPC or through some proxy (e.g. VPN).
 
 ### Backups
-Opta will provision your database with 5 days of automatic daily backups in the form of 
+Opta will provision your database with 7 days of automatic daily backups in the form of 
 [RDS snapshots](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_CreateSnapshot.html). 
 You can find them either programmatically via the aws cli, or through the AWS web console (they will be called
 system snapshots, and they have a different tab than the manual ones).

--- a/config/registry/azurerm/modules/azure-postgres.md
+++ b/config/registry/azurerm/modules/azure-postgres.md
@@ -9,6 +9,9 @@ description: Creates a postgres database
 This module creates a postgres [Azure Database for PostgreSQL](https://azure.microsoft.com/en-us/services/postgresql/) database. It is made with
 the [private link](https://docs.microsoft.com/en-us/azure/postgresql/concepts-data-access-and-security-private-link), ensuring private communication.
 
+### Backups
+Opta will provision your database with 7 days of [continuous backups](https://docs.microsoft.com/en-us/azure/postgresql/concepts-backup).
+
 ### Linking
 
 When linked to a k8s-service, it adds connection credentials to your container's environment variables as:

--- a/config/registry/google/modules/gcp-mysql.md
+++ b/config/registry/google/modules/gcp-mysql.md
@@ -10,6 +10,12 @@ description: Creates a MySQL database instance
 This module creates a MySQL [GCP Cloud SQL](https://cloud.google.com/sql/docs/introduction) database. It is made with
 the [private service access](https://cloud.google.com/vpc/docs/private-services-access), ensuring private communication.
 
+### Backups
+Opta will provision your database with 7 days of automatic daily backups in the form of
+[Cloud SQL Backups](https://cloud.google.com/sql/docs/postgres/backup-recovery/backups).
+You can find them either programmatically via the gcloud cli, or through the GCP web console inside your db description
+page.
+
 ### Linking
 
 When linked to a k8s-service, it adds connection credentials to your container's environment variables as:

--- a/config/registry/google/modules/gcp-postgres.md
+++ b/config/registry/google/modules/gcp-postgres.md
@@ -10,6 +10,12 @@ description: Creates a postgres (GCP Cloud SQL) database instance
 This module creates a postgres [GCP Cloud SQL](https://cloud.google.com/sql/docs/introduction) database. It is made with
 the [private service access](https://cloud.google.com/vpc/docs/private-services-access), ensuring private communication.
 
+### Backups
+Opta will provision your database with 7 days of automatic daily backups in the form of
+[Cloud SQL Backups](https://cloud.google.com/sql/docs/postgres/backup-recovery/backups).
+You can find them either programmatically via the gcloud cli, or through the GCP web console inside your db description
+page.
+
 ### Linking
 
 When linked to a k8s-service, it adds connection credentials to your container's environment variables as:

--- a/config/tf_modules/aws-postgres/main.tf
+++ b/config/tf_modules/aws-postgres/main.tf
@@ -20,7 +20,7 @@ resource "aws_rds_cluster" "db_cluster" {
   master_username         = "postgres"
   master_password         = random_password.pg_password.result
   vpc_security_group_ids  = [data.aws_security_group.security_group.id]
-  backup_retention_period = 5
+  backup_retention_period = 7
   apply_immediately       = true
   skip_final_snapshot     = true
   storage_encrypted       = true


### PR DESCRIPTION
# Description
Apparently we had 5 days retention for AWS. Increasing to 7 does not cause data loss or downtime (as it just means keep stuff for longer)

# Safety checklist
* [x] This change is backwards compatible and safe to apply by existing users
* [x] This change will NOT lead to data loss
* [x] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
opta applied test aws service
