### PR TITLE
Added retention limit & snapshot window.

### DIFF
--- a/config/registry/aws/modules/aws-redis.yaml
+++ b/config/registry/aws/modules/aws-redis.yaml
@@ -32,7 +32,7 @@ inputs:
     user_facing: true
     validator: str(required=False)
     description: Window during which the snapshot would be taken.
-    default: ""
+    default: "04:00-05:00"
 outputs:
   - name: cache_host
     export: true

--- a/config/registry/aws/modules/aws-redis.yaml
+++ b/config/registry/aws/modules/aws-redis.yaml
@@ -23,6 +23,16 @@ inputs:
     validator: str(required=False)
     description: the redis version to use for this instance
     default: "6.x"
+  - name: snapshot_retention_limit
+    user_facing: true
+    validator: int(required=False)
+    description: Retentions days for which the snapshot will be retained.
+    default: 0
+  - name: snapshot_window
+    user_facing: true
+    validator: str(required=False)
+    description: Window during which the snapshot would be taken.
+    default: ""
 outputs:
   - name: cache_host
     export: true

--- a/config/tf_modules/aws-redis/main.tf
+++ b/config/tf_modules/aws-redis/main.tf
@@ -28,6 +28,8 @@ resource "aws_elasticache_replication_group" "redis_cluster" {
   transit_encryption_enabled    = true
   at_rest_encryption_enabled    = true
   kms_key_id                    = data.aws_kms_key.main.arn
+  snapshot_window               = var.snapshot_window
+  snapshot_retention_limit      = var.snapshot_retention_limit
   lifecycle {
     ignore_changes = [engine_version]
   }

--- a/config/tf_modules/aws-redis/variables.tf
+++ b/config/tf_modules/aws-redis/variables.tf
@@ -22,3 +22,15 @@ variable "redis_version" {
   type    = string
   default = "6.x"
 }
+
+variable "snapshot_window" {
+  description = "When should the Snapshot for redis cache be done. UTC Time. Snapshot Retention Limit should be set to more than 0."
+  type        = string
+  default     = "04:00-05:00"
+}
+
+variable "snapshot_retention_limit" {
+  description = "Days for which the Snapshot should be retained."
+  type        = number
+  default     = 0
+}


### PR DESCRIPTION
# Description
Added an option for the user to add the retention limit and a snapshot window for the users to customise the Redis Cache.
`Note: Snapshot window by itself doesn't do anything. It needs retention limit to be set for it to work.`

# Safety checklist
* [X] This change is backwards compatible and safe to apply by existing users
* [X] This change will NOT lead to data loss
* [X] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
Tested Manually by applying the changes multiple times. Neither was the data lost nor was the pod killed.
