### PR TITLE
Change downloaded file name and add node types to templates

### DIFF
--- a/config/init_templates/environment/aws.yaml
+++ b/config/init_templates/environment/aws.yaml
@@ -11,4 +11,5 @@ modules:
     delegated: false
   - type: k8s-cluster
     max_nodes: 12
+    node_instance_type: t3.medium
   - type: k8s-base

--- a/config/init_templates/environment/azure.yaml
+++ b/config/init_templates/environment/azure.yaml
@@ -8,4 +8,5 @@ providers:
 modules:
   - type: base
   - type: k8s-cluster
+    node_instance_type: Standard_D2_v2
   - type: k8s-base

--- a/config/init_templates/environment/gcp.yaml
+++ b/config/init_templates/environment/gcp.yaml
@@ -11,4 +11,5 @@ modules:
     delegated: false
   - type: k8s-cluster
     max_nodes: 6
+    node_instance_type: n2-highcpu-4
   - type: k8s-base

--- a/opta/commands/init.py
+++ b/opta/commands/init.py
@@ -62,7 +62,6 @@ ENVIRONMENT_TEMPLATES: Dict[str, Template] = {
 @click.option(
     "-f",
     "--file-name",
-    default="env.yml",
     help="The name of the file that this command will output (defaults to opta.yml)",
 )
 def env(cloud_provider: str, file_name: str) -> None:
@@ -80,7 +79,8 @@ Press ^C at any time to quit.
     template = ENVIRONMENT_TEMPLATES[cloud_provider]
     res = template.run()
 
-    _write_result(file_path=file_name, result=res)
+    name = res["name"]
+    _write_result(file_path=f"{name}.yaml", result=res)
 
 
 SERVICE_TEMPLATES: Dict[str, Template] = {
@@ -96,7 +96,6 @@ SERVICE_TEMPLATES: Dict[str, Template] = {
 @click.option(
     "-f",
     "--file-name",
-    default="service.yml",
     help="The name of the file that this command will output (defaults to opta.yml)",
 )
 def service(template_name: str, file_name: str, environment_file: str) -> None:
@@ -126,5 +125,6 @@ Press ^C at any time to quit.
                 }
             ]
 
-    _write_result(file_name, res)
+    name = res["name"]
+    _write_result(file_path=f"{name}.yaml", result=res)
     pass

--- a/tests/commands/test_init.py
+++ b/tests/commands/test_init.py
@@ -35,10 +35,11 @@ class TestInitEnv:
         modules:
         - type: base
         - type: dns
-        domain: my.dns.domain
+          domain: my.dns.domain
         delegated: false
         - type: k8s-cluster
-        max_nodes: 6
+          max_nodes: 6
+          node_instance_type: n2-highcpu-4
         - type: k8s-base
         """
         assert _sanitize(expected_result) in _sanitize(result.output)
@@ -66,6 +67,7 @@ class TestInitEnv:
             modules:
             - type: base
             - type: k8s-cluster
+              node_instance_type: Standard_D2_v2
             - type: k8s-base
         """
         assert _sanitize(expected_result) in _sanitize(result.output)
@@ -93,10 +95,11 @@ class TestInitEnv:
             modules:
             - type: base
             - type: dns
-            domain: my.dns.domain
-            delegated: false
+              domain: my.dns.domain
+              delegated: false
             - type: k8s-cluster
-            max_nodes: 12
+              max_nodes: 12
+              node_instance_type: t3.medium
             - type: k8s-base
         """
         assert _sanitize(expected_result) in _sanitize(result.output)
@@ -124,10 +127,11 @@ class TestInitEnv:
             modules:
             - type: base
             - type: dns
-            domain: my.dns.domain
-            delegated: false
+              domain: my.dns.domain
+              delegated: false
             - type: k8s-cluster
-            max_nodes: 12
+              max_nodes: 12
+              node_instance_type: t3.medium
             - type: k8s-base
         """
         assert _sanitize(expected_result) in _sanitize(result.output)
@@ -155,10 +159,11 @@ class TestInitEnv:
         modules:
         - type: base
         - type: dns
-        domain: my.dns.domain
-        delegated: false
+          domain: my.dns.domain
+          delegated: false
         - type: k8s-cluster
-        max_nodes: 6
+          max_nodes: 6
+          node_instance_type: n2-highcpu-4
         - type: k8s-base
         """
         assert _sanitize(expected_result) in _sanitize(result.output)


### PR DESCRIPTION
# Description
- Adds node types to `opta init` templates
- Changes downloaded file name for `opta init` to the name of the service/env the user is creating

# Safety checklist
* [x] This change is backwards compatible and safe to apply by existing users
* [x] This change will NOT lead to data loss
* [x] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, besides unit tests?
automated testing