### PR TITLE
Replace AWS process command with Boto for STS get identity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, dev]
   pull_request:
-    branches: [main]
+    branches: [main, dev]
 
 jobs:
   lint:

--- a/opta/commands/deploy.py
+++ b/opta/commands/deploy.py
@@ -6,6 +6,7 @@ from opta.amplitude import amplitude_client
 from opta.commands.apply import _apply
 from opta.commands.push import _push, is_service_config
 from opta.core.terraform import Terraform
+from opta.error_constants import USER_ERROR_TF_LOCK
 from opta.exceptions import MissingState, UserErrors
 from opta.layer import Layer
 from opta.utils import check_opta_file_exists, fmt_msg, logger
@@ -62,18 +63,16 @@ def deploy(
         )
 
     layer = Layer.load_from_yaml(config, env)
-    tf_lock_exists, _ = Terraform.tf_lock_details(layer)
-    if tf_lock_exists:
-        raise UserErrors(
-            "Terraform Lock exists on the given configuration."
-            "\nEither wait for sometime for the Terraform to release lock."
-            "\nOr use force-unlock command to release the lock."
-        )
     amplitude_client.send_event(
         amplitude_client.DEPLOY_EVENT,
         event_properties={"org_name": layer.org_name, "layer_name": layer.name},
     )
     layer.verify_cloud_credentials()
+    if Terraform.download_state(layer):
+        tf_lock_exists, _ = Terraform.tf_lock_details(layer)
+        if tf_lock_exists:
+            raise UserErrors(USER_ERROR_TF_LOCK)
+
     try:
         outputs = Terraform.get_outputs(layer)
     except MissingState:

--- a/opta/commands/destroy.py
+++ b/opta/commands/destroy.py
@@ -13,6 +13,7 @@ from opta.core.azure import Azure
 from opta.core.gcp import GCP
 from opta.core.generator import gen_all
 from opta.core.terraform import Terraform
+from opta.error_constants import USER_ERROR_TF_LOCK
 from opta.exceptions import UserErrors
 from opta.layer import Layer
 from opta.utils import check_opta_file_exists, fmt_msg, logger
@@ -34,13 +35,6 @@ def destroy(config: str, env: Optional[str], auto_approve: bool) -> None:
 
     check_opta_file_exists(config)
     layer = Layer.load_from_yaml(config, env)
-    tf_lock_exists, _ = Terraform.tf_lock_details(layer)
-    if tf_lock_exists:
-        raise UserErrors(
-            "Terraform Lock exists on the given configuration."
-            "\nEither wait for sometime for the Terraform to release lock."
-            "\nOr use force-unlock command to release the lock."
-        )
     amplitude_client.send_event(
         amplitude_client.DESTROY_EVENT,
         event_properties={"org_name": layer.org_name, "layer_name": layer.name},
@@ -51,6 +45,10 @@ def destroy(config: str, env: Optional[str], auto_approve: bool) -> None:
             "The opta state could not be found. This may happen if destroy ran successfully before."
         )
         return
+
+    tf_lock_exists, _ = Terraform.tf_lock_details(layer)
+    if tf_lock_exists:
+        raise UserErrors(USER_ERROR_TF_LOCK)
 
     # Any child layers should be destroyed first before the current layer.
     children_layers = _fetch_children_layers(layer)

--- a/opta/commands/rollback.py
+++ b/opta/commands/rollback.py
@@ -4,9 +4,10 @@ import click
 
 from opta.core.generator import gen_all
 from opta.core.terraform import Terraform
+from opta.error_constants import USER_ERROR_TF_LOCK
 from opta.exceptions import UserErrors
 from opta.layer import Layer
-from opta.utils import check_opta_file_exists
+from opta.utils import check_opta_file_exists, logger
 
 
 # Rollback automatically runs when terraform apply fails.
@@ -21,13 +22,14 @@ def rollback(config: str, env: Optional[str]) -> None:
 
     check_opta_file_exists(config)
     layer = Layer.load_from_yaml(config, env)
+    layer.verify_cloud_credentials()
+    if not Terraform.download_state(layer):
+        logger.info(
+            "The opta state could not be found. This may happen if destroy ran successfully before."
+        )
+        return
     tf_lock_exists, _ = Terraform.tf_lock_details(layer)
     if tf_lock_exists:
-        raise UserErrors(
-            "Terraform Lock exists on the given configuration."
-            "\nEither wait for sometime for the Terraform to release lock."
-            "\nOr use force-unlock command to release the lock."
-        )
-    layer.verify_cloud_credentials()
+        raise UserErrors(USER_ERROR_TF_LOCK)
     gen_all(layer)
     Terraform.rollback(layer)

--- a/opta/error_constants.py
+++ b/opta/error_constants.py
@@ -1,0 +1,5 @@
+USER_ERROR_TF_LOCK = (
+    "Terraform lock exists on the given configuration. "
+    "This means that another opta command is being run on this file. "
+    "If that’s not the case, please run opta force-unlock command to remove the lock"
+)

--- a/tests/commands/test_apply.py
+++ b/tests/commands/test_apply.py
@@ -186,9 +186,11 @@ def test_auto_approve(mocker: MockFixture, mocked_layer: Any, basic_mocks: Any) 
 def test_fail_on_2_azs(mocker: MockFixture, mocked_layer: Any) -> None:
     mocked_os_path_exists = mocker.patch("opta.utils.os.path.exists")
     mocked_os_path_exists.return_value = True
+    mock_tf_download_state = mocker.patch(
+        "opta.commands.apply.Terraform.download_state", return_value=True
+    )
     mocker.patch(
-        "opta.commands.apply.Terraform.tf_lock_details",
-        return_value=(False, "mock_lock_id"),
+        "opta.commands.apply.Terraform.tf_lock_details", return_value=(False, ""),
     )
 
     # Opta needs a region with at least 3 AZs, fewer should fail.
@@ -198,6 +200,7 @@ def test_fail_on_2_azs(mocker: MockFixture, mocked_layer: Any) -> None:
     )
     runner = CliRunner()
     result = runner.invoke(apply)
+    mock_tf_download_state.assert_called_once_with(mocked_layer)
     assert "Opta requires a region with at least *3* availability zones." in str(
         result.exception
     )

--- a/tests/commands/test_deploy.py
+++ b/tests/commands/test_deploy.py
@@ -14,9 +14,11 @@ def mock_is_service_config(module_mocker: MockFixture) -> None:
 def test_deploy_basic(mocker: MockFixture) -> None:
     mocked_os_path_exists = mocker.patch("opta.utils.os.path.exists")
     mocked_os_path_exists.return_value = True
+    mock_tf_download_state = mocker.patch(
+        "opta.commands.deploy.Terraform.download_state", return_value=True
+    )
     mocker.patch(
-        "opta.commands.apply.Terraform.tf_lock_details",
-        return_value=(False, "mock_lock_id"),
+        "opta.commands.deploy.Terraform.tf_lock_details", return_value=(False, ""),
     )
 
     mock_push = mocker.patch(
@@ -36,6 +38,7 @@ def test_deploy_basic(mocker: MockFixture) -> None:
     result = runner.invoke(cli, ["deploy", "-i", "local_image:local_tag"])
 
     assert result.exit_code == 0
+    mock_tf_download_state.assert_called_once_with(mocked_layer)
     mock_push.assert_called_once_with(
         image="local_image:local_tag", config="opta.yml", env=None, tag=None
     )
@@ -56,9 +59,11 @@ def test_deploy_basic(mocker: MockFixture) -> None:
 def test_deploy_auto_approve(mocker: MockFixture) -> None:
     mocked_os_path_exists = mocker.patch("opta.utils.os.path.exists")
     mocked_os_path_exists.return_value = True
+    mock_tf_download_state = mocker.patch(
+        "opta.commands.deploy.Terraform.download_state", return_value=True
+    )
     mocker.patch(
-        "opta.commands.apply.Terraform.tf_lock_details",
-        return_value=(False, "mock_lock_id"),
+        "opta.commands.deploy.Terraform.tf_lock_details", return_value=(False, ""),
     )
 
     mock_push = mocker.patch(
@@ -80,6 +85,7 @@ def test_deploy_auto_approve(mocker: MockFixture) -> None:
     )
 
     assert result.exit_code == 0
+    mock_tf_download_state.assert_called_once_with(mocked_layer)
     mock_push.assert_called_once_with(
         image="local_image:local_tag", config="opta.yml", env=None, tag=None
     )
@@ -100,9 +106,11 @@ def test_deploy_auto_approve(mocker: MockFixture) -> None:
 def test_deploy_all_flags(mocker: MockFixture) -> None:
     mocked_os_path_exists = mocker.patch("opta.utils.os.path.exists")
     mocked_os_path_exists.return_value = True
+    mock_tf_download_state = mocker.patch(
+        "opta.commands.deploy.Terraform.download_state", return_value=True
+    )
     mocker.patch(
-        "opta.commands.apply.Terraform.tf_lock_details",
-        return_value=(False, "mock_lock_id"),
+        "opta.commands.deploy.Terraform.tf_lock_details", return_value=(False, ""),
     )
 
     mock_push = mocker.patch(
@@ -135,6 +143,7 @@ def test_deploy_all_flags(mocker: MockFixture) -> None:
     )
 
     assert result.exit_code == 0
+    mock_tf_download_state.assert_called_once_with(mocked_layer)
     mock_push.assert_called_once_with(
         image="local_image:local_tag", config="app/opta.yml", env="staging", tag="latest"
     )
@@ -154,9 +163,11 @@ def test_deploy_all_flags(mocker: MockFixture) -> None:
 def test_deploy_ecr_apply(mocker: MockFixture) -> None:
     mocked_os_path_exists = mocker.patch("opta.utils.os.path.exists")
     mocked_os_path_exists.return_value = True
+    mock_tf_download_state = mocker.patch(
+        "opta.commands.deploy.Terraform.download_state", return_value=True
+    )
     mocker.patch(
-        "opta.commands.apply.Terraform.tf_lock_details",
-        return_value=(False, "mock_lock_id"),
+        "opta.commands.deploy.Terraform.tf_lock_details", return_value=(False, ""),
     )
 
     mock_push = mocker.patch(
@@ -188,6 +199,7 @@ def test_deploy_ecr_apply(mocker: MockFixture) -> None:
     )
 
     assert result.exit_code == 0
+    mock_tf_download_state.assert_called_once_with(mocked_layer)
     mock_push.assert_called_once_with(
         image="local_image:local_tag", config="app/opta.yml", env="staging", tag="latest"
     )

--- a/tests/commands/test_destroy.py
+++ b/tests/commands/test_destroy.py
@@ -25,8 +25,7 @@ FAKE_SERVICE_CONFIG_MULTIPLE_ENV = os.path.join(
 
 def test_destroy_env_with_children(mocker: MockFixture) -> None:
     mocker.patch(
-        "opta.commands.apply.Terraform.tf_lock_details",
-        return_value=(False, "mock_lock_id"),
+        "opta.commands.destroy.Terraform.tf_lock_details", return_value=(False, ""),
     )
     mocker.patch("opta.commands.destroy.amplitude_client.send_event")
     mocker.patch("opta.commands.destroy.Terraform.init")
@@ -49,8 +48,7 @@ def test_destroy_env_with_children(mocker: MockFixture) -> None:
 
 def test_destroy_env_without_children(mocker: MockFixture) -> None:
     mocker.patch(
-        "opta.commands.apply.Terraform.tf_lock_details",
-        return_value=(False, "mock_lock_id"),
+        "opta.commands.destroy.Terraform.tf_lock_details", return_value=(False, ""),
     )
     mocker.patch("opta.commands.destroy.amplitude_client.send_event")
     mocker.patch("opta.commands.destroy.Terraform.init")
@@ -77,8 +75,7 @@ def test_destroy_env_without_children(mocker: MockFixture) -> None:
 
 def test_destroy_service(mocker: MockFixture) -> None:
     mocker.patch(
-        "opta.commands.apply.Terraform.tf_lock_details",
-        return_value=(False, "mock_lock_id"),
+        "opta.commands.destroy.Terraform.tf_lock_details", return_value=(False, ""),
     )
     mocker.patch("opta.commands.destroy.amplitude_client.send_event")
     mocker.patch("opta.commands.destroy.Terraform.init")


### PR DESCRIPTION
# Description


# Safety checklist
* [X] This change is backwards compatible and safe to apply by existing users
* [X] This change will NOT lead to data loss
* [X] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
Manually tested for the Details on the STS client method.
