### PR TITLE
Nicer plan displayer

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -58,6 +58,8 @@ pyOpenSSL = ">=20.0.1,<20.1"
 semver = "~=2.13.0"
 dnspython = "2.1.0"
 docker = "5.0.0"
+tabulate = "0.8.9"
+types-tabulate = "0.8.2"
 [requires]
 python_version = "3.8"
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "58683d027061be60bfddcb98e55167e1b6da57a5380891f7075b1f9037c27f41"
+            "sha256": "a5377dd10cc62c093e98b999ec88bf431bfd4ce6da21cb58d32adbdb00368b5d"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -1154,6 +1154,14 @@
             "markers": "python_version >= '3.5'",
             "version": "==4.0.0"
         },
+        "tabulate": {
+            "hashes": [
+                "sha256:d7c013fe7abbc5e491394e10fa845f8f32fe54f8dc60c6622c6cf482d25d47e4",
+                "sha256:eb1d13f25760052e8931f2ef80aaf6045a6cceb47514db8beab24cded16f13a7"
+            ],
+            "index": "pypi",
+            "version": "==0.8.9"
+        },
         "testtools": {
             "hashes": [
                 "sha256:57c13433d94f9ffde3be6534177d10fb0c1507cc499319128958ca91a65cb23f",
@@ -1231,6 +1239,14 @@
             "index": "pypi",
             "version": "==2.25.9"
         },
+        "types-tabulate": {
+            "hashes": [
+                "sha256:456c8066f1ae8ae445a0484aaff9f30d6293e1cb84e8b15e3ad939047c8508bf",
+                "sha256:6dbad23ccb92562fcc420c4402799fbb14dfc1cb288bffa84f389d0b12120ba6"
+            ],
+            "index": "pypi",
+            "version": "==0.8.2"
+        },
         "typing-extensions": {
             "hashes": [
                 "sha256:49f75d16ff11f1cd258e1b988ccff82a3ca5570217d7ad8c5f48205dd99a677e",
@@ -1261,7 +1277,7 @@
                 "sha256:4987c65554f7a2dbf30c18fd48778ef124af6fab771a377103da0585e2336ece",
                 "sha256:c4fdf4019605b6e5423637e01bc9fe4daef873709a7973e195ceba0a62bbc844"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_full_version < '4.0.0'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
             "version": "==1.26.7"
         },
         "wcwidth": {
@@ -2032,7 +2048,7 @@
                 "sha256:4987c65554f7a2dbf30c18fd48778ef124af6fab771a377103da0585e2336ece",
                 "sha256:c4fdf4019605b6e5423637e01bc9fe4daef873709a7973e195ceba0a62bbc844"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_full_version < '4.0.0'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
             "version": "==1.26.7"
         },
         "vistir": {

--- a/opta/core/plan_displayer.py
+++ b/opta/core/plan_displayer.py
@@ -172,7 +172,7 @@ class PlanDisplayer:
                 current_risk = resource_change["risk"]
                 table.append(
                     [
-                        module_name,
+                        f"{fg('blue')}{module_name}{attr(0)}",
                         resource_name,
                         resource_change["action"],
                         f"{RISK_COLORS[current_risk]}{current_risk}{attr(0)}",

--- a/opta/core/plan_displayer.py
+++ b/opta/core/plan_displayer.py
@@ -1,60 +1,111 @@
+from typing import Any, Dict, Tuple
+
 from colored import attr, fg
+from tabulate import tabulate
 
 from opta.constants import TF_PLAN_PATH
 from opta.core.terraform import Terraform
 from opta.utils import logger
 
-BENIGN_SEVERITY = "BENIGN"
-MODERATE_SEVERITY = "MODERATE"
-SERIOUS_SEVERITY = "SERIOUS"
-PLAN_SEVERITIES = {BENIGN_SEVERITY, MODERATE_SEVERITY, SERIOUS_SEVERITY}
-ACTION_TO_SEVERITY = {
-    "create": BENIGN_SEVERITY,
-    "read": BENIGN_SEVERITY,
-    "delete": SERIOUS_SEVERITY,
-    "update": MODERATE_SEVERITY,
-    "replace": SERIOUS_SEVERITY,
+LOW_RISK = "LOW"
+HIGH_RISK = "HIGH"
+PLAN_SEVERITIES = {LOW_RISK, HIGH_RISK}
+ACTION_TO_RISK = {
+    "create": LOW_RISK,
+    "read": LOW_RISK,
+    "delete": HIGH_RISK,
+    "update": LOW_RISK,
+    "replace": HIGH_RISK,
 }
-SEVERITY_COLORS = {
-    BENIGN_SEVERITY: fg("green"),
-    MODERATE_SEVERITY: fg("orange_4b"),
-    SERIOUS_SEVERITY: fg("magenta"),
+RISK_COLORS = {
+    LOW_RISK: fg("green"),
+    HIGH_RISK: fg("magenta"),
 }
-SEVERITY_EXPLANATIONS = {
-    BENIGN_SEVERITY: (
-        "This is the lowest level of severity and it typically means that you are adding or refreshing "
-        "things instead of changing and deleting things. You should feel very confident in these changes "
-        "without knowing anything further."
+RISK_EXPLANATIONS = {
+    LOW_RISK: (
+        "This is the safe level of risk. For these changes there is no expected downtime or dataloss of any sort. "
+        "You should feel confident in the changes listed here."
     ),
-    MODERATE_SEVERITY: (
-        "This is the medium level of severity, meaning that something have been updates, but not destroyed or forced "
-        "to replace (destroy and recreate). Typically, this means you updated some minor fields the yaml or updated "
-        "to a new pta version and we're doing some backwards compatible changes."
-    ),
-    SERIOUS_SEVERITY: (
-        "This is the highest level of severity and this means that either you are destroying something or made a big "
-        "change which forced something to recreate (destroy and create itself). Please tread carefully and know what "
-        "you are doing."
+    HIGH_RISK: (
+        "This is the high level of risk. For these changes there MAY (but not guaranteed) be some donwtime "
+        "and / or dataloss."
     ),
 }
 
+LOW_RISK_FIELDS = {
+    "aws_elasticache_replication_group": ["snapshot_window", "tags", "tags_all"],
+    "helm_release": ["values", "timeout"],
+    "aws_rds_cluster": ["backup_retention_period", "tags", "tags_all"],
+    "aws_rds_cluster_instance": ["instance_class", "tags", "tags_all"],
+}
 
-def _max_severity(severity_1: str, severity_2: str) -> str:
-    if SERIOUS_SEVERITY in [severity_1, severity_2]:
-        return SERIOUS_SEVERITY
-    if MODERATE_SEVERITY in [severity_1, severity_2]:
-        return MODERATE_SEVERITY
-    return BENIGN_SEVERITY
+
+def _max_risk(risk_1: str, risk_2: str) -> str:
+    if HIGH_RISK in [risk_1, risk_2]:
+        return HIGH_RISK
+    return LOW_RISK
+
+
+def dict_diffs(dict1: Dict, dict2: dict) -> Dict[Any, Tuple[Any, Any]]:
+    diff_dict: Dict[Any, Tuple[Any, Any]] = {}
+    for key in dict1.keys():
+        if key not in dict2:
+            diff_dict[key] = (dict1[key], None)
+        if dict1[key] != dict2[key]:
+            diff_dict[key] = (dict1[key], dict2[key])
+    for key in dict2.keys():
+        if key not in dict1:
+            diff_dict[key] = (None, dict2[key])
+
+    return diff_dict
 
 
 class PlanDisplayer:
+    @staticmethod
+    def handle_update(resource_change: Dict) -> Tuple[str, str]:
+
+        if resource_change.get("change", {}).get("resource_change", {}) != {}:
+            return LOW_RISK, "refreshing data"
+        if (
+            resource_change["type"] == "helm_release"
+            and resource_change["name"] == "k8s-service"
+        ):
+            return LOW_RISK, "deploying new version of app"
+
+        diff_dict = dict_diffs(
+            resource_change["change"]["before"], resource_change["change"]["after"]
+        )
+        high_risk_change_keys = []
+
+        for key in diff_dict.keys():
+            if key not in LOW_RISK_FIELDS.get(
+                resource_change["type"], ["tags", "tags_all", "labels", "resource_labels"]
+            ):
+                high_risk_change_keys.append(key)
+
+        if len(high_risk_change_keys) == 0:
+            return LOW_RISK, "updating low risk fields"
+
+        if len(high_risk_change_keys) <= 3:
+            prefix = (
+                "updating fields:"
+                if len(high_risk_change_keys) > 1
+                else "updating field:"
+            )
+            return HIGH_RISK, f"{prefix} {', '.join(high_risk_change_keys)}"
+
+        return (
+            HIGH_RISK,
+            f"updating fields {', '.join(high_risk_change_keys[:3])}, etc...",
+        )
+
     @staticmethod
     def display(detailed_plan: bool = False) -> None:
         if detailed_plan:
             Terraform.show(TF_PLAN_PATH)
             return
         plan_dict = Terraform.show_plan()
-        plan_severity = BENIGN_SEVERITY
+        plan_risk = LOW_RISK
         module_changes: dict = {}
         resource_change: dict
         for resource_change in plan_dict.get("resource_changes", []):
@@ -64,62 +115,80 @@ class PlanDisplayer:
 
             if not address.startswith("module."):
                 logger.warn(
-                    f"Unable to determine severity of changes to resource {address}. "
+                    f"Unable to determine risk of changes to resource {address}. "
                     "Please run in detailed plan mode for more info"
                 )
             module_name = address.split(".")[1]
             module_changes[module_name] = module_changes.get(
-                module_name, {"severity": BENIGN_SEVERITY, "resources": {}}
+                module_name, {"risk": LOW_RISK, "resources": {}}
             )
             resource_name = ".".join(address.split(".")[2:])
             actions = resource_change.get("change", {}).get("actions", [])
             if "create" in actions and "delete" in actions:
                 actions = ["replace"]
             action = actions[0]
-            current_severity = ACTION_TO_SEVERITY[action]
-            action_reason = resource_change.get("action_reason", "N/A")
+            if action in ["read", "create"]:
+                current_risk = LOW_RISK
+                action_reason = (
+                    "data_refresh" if action == "read" else "ground_up_creation"
+                )
+            elif action in ["replace", "destroy"]:
+                current_risk = HIGH_RISK
+                action_reason = resource_change.get("action_reason", "N/A")
+            elif action in ["update"]:
+                current_risk, action_reason = PlanDisplayer.handle_update(resource_change)
+            else:
+                raise Exception(f"Do not know how to handle planned action: {action}")
+
             module_changes[module_name]["resources"][resource_name] = {
                 "action": action,
                 "reason": action_reason,
-                "severity": current_severity,
+                "risk": current_risk,
             }
-            module_changes[module_name]["severity"] = _max_severity(
-                module_changes[module_name]["severity"], current_severity
+            module_changes[module_name]["risk"] = _max_risk(
+                module_changes[module_name]["risk"], current_risk
             )
-            plan_severity = _max_severity(plan_severity, current_severity)
+            plan_risk = _max_risk(plan_risk, current_risk)
 
         logger.info(
-            f"Identified total severity of {SEVERITY_COLORS[plan_severity]}{plan_severity}{attr(0)}.\n"
-            f"{SEVERITY_EXPLANATIONS[plan_severity]}\n"
+            f"Identified total risk of {RISK_COLORS[plan_risk]}{plan_risk}{attr(0)}.\n"
+            f"{RISK_EXPLANATIONS[plan_risk]}\n"
             "If you want extra help, please feel free to reach out to the Runx team at https://slack.opta.dev.\n"
             "Severity break down by module is as follows:"
         )
         module_changes_list = sorted(
             [(k, v) for k, v in module_changes.items()],
-            key=lambda x: x[1]["severity"],
+            key=lambda x: x[1]["risk"],
             reverse=True,
         )
+        table = []
         for module_name, module_change in module_changes_list:
-            current_severity = module_change["severity"]
-            logger.info(
-                f"Module name: {module_name}. Severity: {SEVERITY_COLORS[current_severity]}{current_severity}{attr(0)}."
-            )
-            # No need to be verbose with benign changes
-            if current_severity == BENIGN_SEVERITY:
-                continue
             resource_changes_list = sorted(
                 [(k, v) for k, v in module_change["resources"].items()],
-                key=lambda x: x[1]["severity"],
+                key=lambda x: x[1]["risk"],
                 reverse=True,
             )
             for resource_name, resource_change in resource_changes_list:
-                current_severity = resource_change["severity"]
-                logger.info(
-                    f"  Resource name: {resource_name}. Action: {resource_change['action']}. "
-                    f"Reason: {resource_change['reason']}. Severity: {SEVERITY_COLORS[current_severity]}{current_severity}{attr(0)}"
+                current_risk = resource_change["risk"]
+                table.append(
+                    [
+                        module_name,
+                        resource_name,
+                        resource_change["action"],
+                        f"{RISK_COLORS[current_risk]}{current_risk}{attr(0)}",
+                        resource_change["reason"].replace("_", " "),
+                    ]
                 )
         if len(module_changes) == 0:
             logger.info("No changes found.")
+        else:
+            print(
+                tabulate(
+                    table,
+                    ["module", "resource", "action", "risk", "reason"],
+                    tablefmt="fancy_grid",
+                )
+            )
         logger.info(
             "This concludes the plan summary. For more detail, please pass the --detailed-plan flag to your opta "
             "command!"

--- a/opta/core/plan_displayer.py
+++ b/opta/core/plan_displayer.py
@@ -22,14 +22,8 @@ RISK_COLORS = {
     HIGH_RISK: fg("magenta"),
 }
 RISK_EXPLANATIONS = {
-    LOW_RISK: (
-        "This is the safe level of risk. For these changes there is no expected downtime or dataloss of any sort. "
-        "You should feel confident in the changes listed here."
-    ),
-    HIGH_RISK: (
-        "This is the high level of risk. For these changes there MAY (but not guaranteed) be some donwtime "
-        "and / or dataloss."
-    ),
+    LOW_RISK: "Low risk change.",
+    HIGH_RISK: "High risk change. May lead to significant downtime and/or data loss.",
 }
 
 LOW_RISK_FIELDS = {
@@ -153,8 +147,7 @@ class PlanDisplayer:
         logger.info(
             f"Identified total risk of {RISK_COLORS[plan_risk]}{plan_risk}{attr(0)}.\n"
             f"{RISK_EXPLANATIONS[plan_risk]}\n"
-            "If you want extra help, please feel free to reach out to the Runx team at https://slack.opta.dev.\n"
-            "Severity break down by module is as follows:"
+            "For additional help, please reach out to the RunX team at https://slack.opta.dev/"
         )
         module_changes_list = sorted(
             [(k, v) for k, v in module_changes.items()],
@@ -190,6 +183,5 @@ class PlanDisplayer:
                 )
             )
         logger.info(
-            "This concludes the plan summary. For more detail, please pass the --detailed-plan flag to your opta "
-            "command!"
+            "For more details, please rerun the command with the —detailed-plan flag."
         )

--- a/opta/core/plan_displayer.py
+++ b/opta/core/plan_displayer.py
@@ -51,7 +51,7 @@ def dict_diffs(dict1: Dict, dict2: dict) -> Dict[Any, Tuple[Any, Any]]:
     for key in dict1.keys():
         if key not in dict2:
             diff_dict[key] = (dict1[key], None)
-        if dict1[key] != dict2[key]:
+        elif dict1[key] != dict2[key]:
             diff_dict[key] = (dict1[key], dict2[key])
     for key in dict2.keys():
         if key not in dict1:

--- a/opta/core/plan_displayer.py
+++ b/opta/core/plan_displayer.py
@@ -138,9 +138,7 @@ class PlanDisplayer:
             action = actions[0]
             if action in ["read", "create"]:
                 current_risk = LOW_RISK
-                action_reason = (
-                    "data_refresh" if action == "read" else "ground_up_creation"
-                )
+                action_reason = "data_refresh" if action == "read" else "creation"
             elif action in ["replace", "destroy"]:
                 current_risk = HIGH_RISK
                 action_reason = resource_change.get("action_reason", "N/A")


### PR DESCRIPTION
# Description
1. Using tables to show data about changes
2. Only 2 security levels "LOW RISK" and "HIGH RISK". Low risk represents no expected dataloss and minimal, recoverable downtime

# Safety checklist
* [x] This change is backwards compatible and safe to apply by existing users
* [x] This change will NOT lead to data loss
* [x] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
I ran it a series of times locally against opta yaml in different states

Here is what a new run looks like
<img width="1290" alt="Screen Shot 2021-09-29 at 5 13 58 PM" src="https://user-images.githubusercontent.com/10430635/135366006-6e5b5612-0d85-4441-b24c-362ef2754ec9.png">

Here is what no changes looks like
<img width="1279" alt="Screen Shot 2021-09-29 at 5 12 35 PM" src="https://user-images.githubusercontent.com/10430635/135366012-40b7f2c2-3011-45cc-a566-f83047725e23.png">

Here is what it looks like when I modified the max node count (also called the lb to update itself)
<img width="1143" alt="Screen Shot 2021-09-29 at 5 09 42 PM" src="https://user-images.githubusercontent.com/10430635/135366013-d80ae362-fbe7-4804-83be-36400203ab30.png">

Here is when I did a normal deploy for an app and also a risky change for a helm chart
<img width="995" alt="Screen Shot 2021-09-29 at 5 00 51 PM" src="https://user-images.githubusercontent.com/10430635/135366015-2343b094-2b12-44e0-9e4e-1ecdc076e66a.png">

