### PR TITLE
Preemptive GCP instances.

### DIFF
--- a/config/registry/google/modules/gcp-gke.yaml
+++ b/config/registry/google/modules/gcp-gke.yaml
@@ -54,6 +54,17 @@ inputs:
     validator: str(required=False)
     description: The GKE K8s [release channel](https://cloud.google.com/kubernetes-engine/docs/concepts/release-channels) to bind the cluster too. Gives you automatic K8s version management for the lcuster and node pools.
     default: REGULAR
+  - name: preemptible
+    user_facing: true
+    validator: bool(required=False)
+    description: |
+      A boolean specifying whether to use [preemptible instances](https://cloud.google.com/compute/docs/instances/preemptible)
+      for the default nodegroup or not. The preemptible instances will be configured to have the max price equal to the on-demand
+      price (so no danger of overcharging). _WARNING_: By using preemptible instances you must accept the real risk of frequent abrupt
+      node terminations and possibly (although extremely rarely) even full blackouts (all nodes die). The former is a small
+      risk as containers of Opta services will be automatically restarted on surviving nodes. So just make sure to specify
+      a minimum of more than 1 containers -- Opta by default attempts to spread them out amongst many nodes.
+    default: false
 outputs:
   - name: k8s_endpoint
     export: true

--- a/config/tf_modules/gcp-gke/default_node_group.tf
+++ b/config/tf_modules/gcp-gke/default_node_group.tf
@@ -15,7 +15,7 @@ resource "google_container_node_pool" "default" {
   }
 
   node_config {
-    preemptible  = false
+    preemptible  = var.preemptible
     machine_type = var.node_instance_type
     disk_size_gb = var.node_disk_size
     tags         = ["opta-${var.layer_name}-nodes"]

--- a/config/tf_modules/gcp-gke/variables.tf
+++ b/config/tf_modules/gcp-gke/variables.tf
@@ -69,3 +69,8 @@ variable "node_instance_type" {
   type    = string
   default = "n2-highcpu-4"
 }
+
+variable "preemptible" {
+  type    = bool
+  default = false
+}


### PR DESCRIPTION
# Description
Adding support for Preemptive Instances in GCP

# Safety checklist
* [ ] This change is backwards compatible and safe to apply by existing users
* [ ] This change will NOT lead to data loss
* [ ] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
Manually tested by changing the GCP Opta Configuration.

## Observations
Using the Regular Configuration, following is the state of the VM Instance.
<img width="224" alt="Screenshot 2021-10-01 at 3 09 09 AM" src="https://user-images.githubusercontent.com/20905988/135533759-d46c9ed2-69ef-4144-9b01-198a861835f8.png">
<img width="1792" alt="Screenshot 2021-10-01 at 2 54 35 AM" src="https://user-images.githubusercontent.com/20905988/135533857-8d38bbf0-b0ea-4831-804b-5bb707366ae7.png">

Using Preemptive Configuration, following is the state of the VM Instance.
<img width="246" alt="Screenshot 2021-10-01 at 3 12 04 AM" src="https://user-images.githubusercontent.com/20905988/135534067-425aff9d-30da-4147-b84a-46a211a0a39f.png">
<img width="1792" alt="Screenshot 2021-10-01 at 2 40 46 AM" src="https://user-images.githubusercontent.com/20905988/135534104-c2c3f35f-e35a-4eda-bc18-5ce45ce49e0d.png">


