### PR TITLE
Modify docs script for prettier formatting

### DIFF
--- a/config/registry/aws/index.md
+++ b/config/registry/aws/index.md
@@ -1,10 +1,8 @@
 ---
-title: "aws"
-linkTitle: "aws"
+title: "AWS"
+linkTitle: "AWS"
 date: 2021-07-21
 draft: false
 weight: 1
 description: AWS provider
 ---
-
-# Opta AWS Provider

--- a/config/registry/aws/modules/aws-nodegroup.yaml
+++ b/config/registry/aws/modules/aws-nodegroup.yaml
@@ -15,7 +15,7 @@ inputs:
     default: None
   - name: labels
     user_facing: true
-    validator:  map(str(), str(), required=False)
+    validator: map(str(), str(), required=False)
     description: labels for the kubernetes nodes
     default: {}
   - name: max_nodes
@@ -36,7 +36,7 @@ inputs:
   - name: node_instance_type
     user_facing: true
     validator: str(required=False)
-    description: he [ec2 instance type](https://aws.amazon.com/ec2/instance-types/) for the nodes.
+    description: The [ec2 instance type](https://aws.amazon.com/ec2/instance-types/) for the nodes.
     default: "t3.medium"
   - name: use_gpu
     user_facing: true
@@ -56,6 +56,6 @@ inputs:
       is a graver concern which can be addressed by having multiple node groups of different instance types (see aws
       nodegroup module) and ideally at least one non-spot.
     default: false
-outputs: { }
-output_providers: { }
-output_data: { }
+outputs: {}
+output_providers: {}
+output_data: {}

--- a/config/registry/aws/modules/aws-sns.yaml
+++ b/config/registry/aws/modules/aws-sns.yaml
@@ -31,9 +31,9 @@ inputs:
 outputs:
   - name: topic_arn
     export: true
-    description: Arn of the topic jsut created
+    description: Arn of the topic just created
   - name: kms_arn
     export: false
     description: Arn of the kms key created to encrypt this topi
-output_providers: { }
-output_data: { }
+output_providers: {}
+output_data: {}

--- a/config/registry/aws/modules/aws-sqs.yaml
+++ b/config/registry/aws/modules/aws-sqs.yaml
@@ -41,15 +41,15 @@ inputs:
 outputs:
   - name: queue_arn
     export: true
-    description: Arn of the queue jsut created
+    description: Arn of the queue just created
   - name: queue_name
     export: true
-    description: Name of the queue jsut created
+    description: Name of the queue just created
   - name: queue_id
     export: true
-    description: ID of the queue jsut created
+    description: ID of the queue just created
   - name: kms_arn
     export: false
     description: Arn of the kms key created to encrypt this queue
-output_providers: { }
-output_data: { }
+output_providers: {}
+output_data: {}

--- a/config/registry/azurerm/index.md
+++ b/config/registry/azurerm/index.md
@@ -1,10 +1,8 @@
 ---
-title: "azure"
-linkTitle: "azure"
+title: "Azure"
+linkTitle: "Azure"
 date: 2021-07-21
 draft: false
 weight: 1
 description: Azure provider
 ---
-
-# Opta Azure Provider

--- a/config/registry/google/index.md
+++ b/config/registry/google/index.md
@@ -1,10 +1,8 @@
 ---
-title: "google"
-linkTitle: "google"
+title: "GCP"
+linkTitle: "GCP"
 date: 2021-07-21
 draft: false
 weight: 1
 description: GCP provider
 ---
-
-# Opta GCP Provider

--- a/opta/registry.py
+++ b/opta/registry.py
@@ -14,7 +14,6 @@ linkTitle: "Service"
 weight: 1
 description: This section provides the list of module types for the user to use in a service Opta yaml for this cloud, along with their inputs and outputs.
 ---
-This section provides the list of module types for the user to use in a service Opta yaml for this cloud, along with their inputs and outputs.
 """
 
 ENVIRONMENT_MODULE_INDEX = """---
@@ -23,7 +22,6 @@ linkTitle: "Environment"
 weight: 1
 description: This section provides the list of module types for the user to use in a environment Opta yaml for this cloud, along with their inputs and outputs.
 ---
-This section provides the list of module types for the user to use in a environment Opta yaml for this cloud, along with their inputs and outputs.
 """
 
 
@@ -53,32 +51,48 @@ def make_registry_dict() -> Dict[Any, Any]:
     return registry_dict
 
 
+INPUTS_TABLE_HEADING = """
+| Name      | Description | Default | Required |
+| ----------- | ----------- | ------- | -------- |
+"""
+
+OUTPUTS_TABLE_HEADING = """
+| Name      | Description |
+| ----------- | ----------- |
+"""
+
+
 def _make_module_docs(vanilla_text: str, module_dict: Dict[Any, Any]) -> str:
     input_lines: List[str] = []
     output_lines: List[str] = []
-    input: Dict[str, Any]
-    for input in module_dict["inputs"]:
-        if not input["user_facing"]:
+    inputs: Dict[str, Any]
+    for inputs in module_dict["inputs"]:
+        if not inputs["user_facing"]:
             continue
-        required = "required=True" in input["validator"]
-        name = input["name"]
-        default = input["default"]
-        description = input["description"]
-        if required:
-            input_lines.append(f"- `{name}` - Required. {description}")
-        else:
-            input_lines.append(f"- `{name}` - Optional. {description} Default {default}")
+        name = inputs["name"]
+        default = inputs["default"]
+        description = inputs["description"].replace("\n", " ")
+        required = "required=True" in inputs["validator"]
+        table_row = f"| `{name}` | {description} | `{default}` | {required} |"
+        input_lines.append(table_row)
 
     output: Dict[str, Any]
     for output in module_dict["outputs"]:
         if not output["export"]:
             continue
         name = output["name"]
-        description = output["description"]
-        output_lines.append(f"- {name} - {description}")
-    input_lines_block = "\n".join(input_lines)
-    output_lines_block = "\n".join(output_lines)
-    return f"{vanilla_text}\n\n## Fields\n\n{input_lines_block}\n\n## Outputs\n\n{output_lines_block}"
+        description = output["description"].replace("\n", " ")
+        table_row = f"| `{name}` | {description} |"
+        output_lines.append(table_row)
+
+    result = f"{vanilla_text}\n\n"
+    if len(input_lines) > 0:
+        result += "## Fields\n\n"
+        result += INPUTS_TABLE_HEADING + "\n".join(input_lines)
+    if len(output_lines) > 0:
+        result += "\n\n## Outputs\n\n"
+        result += OUTPUTS_TABLE_HEADING + "\n".join(output_lines)
+    return result
 
 
 def _make_module_registry_dict(directory: str) -> Dict[Any, Any]:


### PR DESCRIPTION
# Description
- Formats a table using inputs
- Rename cloud names in "References" section: `aws` -> `AWS`, `google` -> `GCP`, `azure` -> `Azure`

## Before
![image](https://user-images.githubusercontent.com/24857657/135667742-70d12381-6557-46ec-ad23-9a4f0ee12bef.png)

## After
![image](https://user-images.githubusercontent.com/24857657/135667682-3ebdf679-2c18-4db5-b709-71a679c4d31f.png)


# Safety checklist
* [x] This change is backwards compatible and safe to apply by existing users
* [x] This change will NOT lead to data loss
* [x] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
Generated docs using script and visually verified that the change works
