### PR TITLE
Adding Secondary Gcp NodePool Opta module

### DIFF
--- a/config/registry/google/modules/gcp-nodepool.md
+++ b/config/registry/google/modules/gcp-nodepool.md
@@ -1,0 +1,12 @@
+---
+title: "gcp-nodepool"
+linkTitle: "gcp-nodegpool"
+date: 2021-07-21
+draft: false
+weight: 1
+description: Creates an additional nodepool for the primary GKE cluster.
+---
+
+This module creates an additional nodepool for the primary GKE cluster. Note that the
+`gcp-gke` module creates a default nodepool so this should only be used when
+you want one more.

--- a/config/registry/google/modules/gcp-nodepool.yaml
+++ b/config/registry/google/modules/gcp-nodepool.yaml
@@ -1,0 +1,70 @@
+halt: true
+environment_module: true
+inputs:
+  - name: env_name
+    user_facing: false
+    description: Opta Environment name
+    default: None
+  - name: layer_name
+    user_facing: false
+    description: Opta Layer name
+    default: None
+  - name: module_name
+    user_facing: false
+    description: Opta Module name
+    default: None
+  - name: node_zone_names
+    user_facing: false
+    description: The names of the zones to put the nodes in.
+    default: null
+  - name: vpc_self_link
+    user_facing: false
+    description: The self link to the vpc to use.
+    default: null
+  - name: private_subnet_self_link
+    user_facing: false
+    description: The self link to the private subnet to use.
+    default: null
+  - name: k8s_master_ipv4_cidr_block
+    user_facing: false
+    description: The the cidr block for the control plane.
+    default: null
+  - name: max_nodes
+    user_facing: true
+    validator: any(str(), int(), required=False)
+    description: The maximum number of nodes to be set by the autoscaler in for the default nodegroup.
+    default: 5
+  - name: min_nodes
+    user_facing: true
+    validator: any(str(), int(), required=False)
+    description: The minimum number of nodes to be set by the autoscaler in for the default nodegroup.
+    default: 1
+  - name: node_disk_size
+    user_facing: true
+    validator: any(str(), int(), required=False)
+    description: The size of disk to give the nodes' vms in GB.
+    default: 20
+  - name: node_instance_type
+    user_facing: true
+    validator: str(required=False)
+    description: The [gcloud machine type](https://cloud.google.com/compute/docs/machine-types) for the nodes.
+    default: "n2-highcpu-4"
+  - name: gke_channel
+    user_facing: true
+    validator: str(required=False)
+    description: The GKE K8s [release channel](https://cloud.google.com/kubernetes-engine/docs/concepts/release-channels) to bind the cluster too. Gives you automatic K8s version management for the cluster and node pools.
+    default: REGULAR
+  - name: preemptible
+    user_facing: true
+    validator: bool(required=False)
+    description: |
+      A boolean specifying whether to use [preemptible instances](https://cloud.google.com/compute/docs/instances/preemptible)
+      for the default nodegroup or not. The preemptible instances will be configured to have the max price equal to the on-demand
+      price (so no danger of overcharging). _WARNING_: By using preemptible instances you must accept the real risk of frequent abrupt
+      node terminations and possibly (although extremely rarely) even full blackouts (all nodes die). The former is a small
+      risk as containers of Opta services will be automatically restarted on surviving nodes. So just make sure to specify
+      a minimum of more than 1 containers -- Opta by default attempts to spread them out amongst many nodes.
+    default: false
+outputs: []
+output_providers: {}
+output_data: {}

--- a/config/tf_modules/gcp-nodepool/main.tf
+++ b/config/tf_modules/gcp-nodepool/main.tf
@@ -1,0 +1,54 @@
+resource "random_string" "node_pool_hash" {
+  length  = 4
+  special = false
+  lower   = true
+  upper   = false
+}
+
+resource "google_service_account" "gke_node" {
+  account_id   = "opta-${var.layer_name}-${random_string.node_pool_hash.result}"
+  display_name = "opta-${var.layer_name}-default-node-pool"
+}
+
+resource "google_container_node_pool" "node_pool" {
+  name               = "opta-${var.layer_name}-secondary"
+  cluster            = data.google_container_cluster.main.name
+  location           = data.google_client_config.current.region
+  initial_node_count = var.min_nodes
+
+  autoscaling {
+    max_node_count = var.max_nodes
+    min_node_count = var.min_nodes
+  }
+
+  management {
+    auto_repair  = true
+    auto_upgrade = true
+  }
+
+  node_config {
+    preemptible  = var.preemptible
+    machine_type = var.node_instance_type
+    disk_size_gb = var.node_disk_size
+    tags         = ["opta-${var.layer_name}-nodes"]
+
+    service_account = google_service_account.gke_node.email
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/cloud-platform",
+    ]
+    metadata = {
+      disable-legacy-endpoints = true
+    }
+
+    workload_metadata_config {
+      node_metadata = "GKE_METADATA_SERVER"
+    }
+
+    labels = {
+      node_pool_name = "opta-${var.layer_name}-default"
+    }
+  }
+  lifecycle {
+    ignore_changes = [location, initial_node_count]
+  }
+}

--- a/config/tf_modules/gcp-nodepool/variables.tf
+++ b/config/tf_modules/gcp-nodepool/variables.tf
@@ -1,0 +1,81 @@
+data "google_client_config" "current" {}
+
+data "google_container_cluster" "main" {
+  name     = "opta-${var.layer_name}"
+  location = data.google_client_config.current.region
+}
+
+variable "env_name" {
+  description = "Env name"
+  type        = string
+}
+
+variable "layer_name" {
+  description = "Layer name"
+  type        = string
+}
+
+variable "module_name" {
+  description = "Module name"
+  type        = string
+}
+
+variable "gke_channel" {
+  type    = string
+  default = "REGULAR"
+}
+
+variable "node_zone_names" {
+  type = list(string)
+}
+
+data "google_secret_manager_secret_version" "kms_suffix" {
+  secret = "opta-${var.layer_name}-kms-suffix"
+}
+
+data "google_kms_key_ring" "key_ring" {
+  name     = "opta-${var.env_name}-${data.google_secret_manager_secret_version.kms_suffix.secret_data}"
+  location = data.google_client_config.current.region
+}
+
+data "google_kms_crypto_key" "kms" {
+  key_ring = data.google_kms_key_ring.key_ring.self_link
+  name     = "opta-${var.env_name}-${data.google_secret_manager_secret_version.kms_suffix.secret_data}"
+}
+
+variable "vpc_self_link" {
+  type = string
+}
+
+variable "private_subnet_self_link" {
+  type = string
+}
+
+variable "max_nodes" {
+  type    = number
+  default = 5
+}
+
+variable "min_nodes" {
+  type    = number
+  default = 1
+}
+
+variable "k8s_master_ipv4_cidr_block" {
+  type = string
+}
+
+variable "node_disk_size" {
+  type    = number
+  default = 20
+}
+
+variable "node_instance_type" {
+  type    = string
+  default = "n2-highcpu-4"
+}
+
+variable "preemptible" {
+  type    = bool
+  default = false
+}


### PR DESCRIPTION
# Description
Add an Opta module for Integrating a Secondary Gcp Node Pool in addition to an already existing Node Pool.

Sample Module List:
<img width="226" alt="Screenshot 2021-10-05 at 2 17 27 PM" src="https://user-images.githubusercontent.com/20905988/136024505-89e9095a-e429-4727-97ea-92bc92718a5c.png">
Sample Google Console UI:
<img width="1450" alt="Screenshot 2021-10-05 at 2 17 57 PM" src="https://user-images.githubusercontent.com/20905988/136024638-00d85e6c-dc9c-4e1d-af6a-cfb767958ac1.png">

# Safety checklist
* [ ] This change is backwards compatible and safe to apply by existing users
* [ ] This change will NOT lead to data loss
* [ ] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
Need to manually setup and test a service on the above criterias.
