### PR TITLE
Fixed terraform local working dir

### DIFF
--- a/config/tf_modules/local-base/main.tf
+++ b/config/tf_modules/local-base/main.tf
@@ -1,7 +1,8 @@
 resource "null_resource" "local-base" {
 
   provisioner "local-exec" {
-    command = "bash -c config/tf_modules/local-base/install_software.sh"
+    working_dir = path.module
+    command     = "bash ./install_software.sh"
   }
   provisioner "local-exec" {
     when    = destroy
@@ -24,7 +25,8 @@ resource "null_resource" "k8s-installer" {
     null_resource.local-base
   ]
   provisioner "local-exec" {
-    command = "bash -c config/tf_modules/local-base/install-cluster.sh"
+    working_dir = path.module
+    command     = "bash -c ./install-cluster.sh"
   }
   provisioner "local-exec" {
     when    = destroy
@@ -43,11 +45,11 @@ resource "null_resource" "kind-installer" {
     null_resource.k8s-installer
   ]
   provisioner "local-exec" {
-
-    command = <<EOT
+    working_dir = path.module
+    command     = <<EOT
       echo "Installing Nginx ingress"
       kubectl config use-context kind-opta-local-cluster
-      kubectl  apply -f config/tf_modules/local-base/deploy.yaml
+      kubectl  apply -f deploy.yaml
       echo "Waiting 20s for nginx ingress to stabilize"
       sleep 20 # Wait for nginx to be ready
     EOT


### PR DESCRIPTION
# Description
With the opta binary, the relative paths need to be give the main.tf of local because it calls scripts that will not be found otherwise.

# Safety checklist
* [X ] This change is backwards compatible and safe to apply by existing users
* [ X] This change will NOT lead to data loss
* [X ] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
Manual testing
