### PR TITLE
Disabling ssl for gcp postgres

### DIFF
--- a/config/tf_modules/gcp-postgres/main.tf
+++ b/config/tf_modules/gcp-postgres/main.tf
@@ -24,7 +24,7 @@ resource "google_sql_database_instance" "instance" {
     ip_configuration {
       ipv4_enabled    = false
       private_network = data.google_compute_network.vpc.id
-      require_ssl     = true
+      require_ssl     = false
     }
     backup_configuration {
       enabled    = true


### PR DESCRIPTION
# Description
Doing this because in order to enable ssl for postgres a user would need to download the ssl CA/key files and include them in all outgoing connections, which makes psql incredibly cumbersome to use. So for now, we won't be supporting it.

# Safety checklist
* [x] This change is backwards compatible and safe to apply by existing users
* [x] This change will NOT lead to data loss
* [x] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
Ran it locally against the environment we spun up for the debugging and with this change the test service worked!