### PR TITLE
Fixing azure destroy (#414)

### DIFF
--- a/config/config.rego
+++ b/config/config.rego
@@ -42,4 +42,9 @@ rules[rule] {
       "rule_id": "FG_R00433",
       "status": "DISABLED"
     }
+} {
+  rule := {
+    "rule_id": "FG_R00227",
+    "status": "DISABLED"
   }
+}

--- a/config/registry/azurerm/index.yaml
+++ b/config/registry/azurerm/index.yaml
@@ -1,7 +1,7 @@
 required_providers:
   azurerm:
     source: "hashicorp/azurerm"
-    version: "2.76.0"
+    version: "2.79.1"
 backend:
   azurerm:
     resource_group_name: "opta-{env}"

--- a/config/tf_modules/azure-base/encryption.tf
+++ b/config/tf_modules/azure-base/encryption.tf
@@ -13,7 +13,6 @@ resource "azurerm_key_vault" "opta" {
   enabled_for_deployment          = true
   enabled_for_template_deployment = true
   purge_protection_enabled        = true
-  soft_delete_enabled             = true
   lifecycle {
     ignore_changes = [location]
   }

--- a/opta/layer.py
+++ b/opta/layer.py
@@ -507,7 +507,9 @@ class Layer:
             new_provider_data["allowed_account_ids"] = [aws_account_id]
 
         if provider_name == "azurerm":
-            new_provider_data["features"] = {}
+            new_provider_data["features"] = {
+                "key_vault": {"purge_soft_delete_on_destroy": False}
+            }
 
         # TODO(ankur): Very ugly
         if clean and provider_name == "azurerm":


### PR DESCRIPTION
# Description
* Fixing azure destroy

Sometime in the past week Azure terraform started failing when trying to destroy the acr key vault key because we disabled purge and yet destroy causes a purge. Found the new toggle to just do a soft delete on purge and confirmed that it worked.

* Disabling regular rule for purge


# Safety checklist
* [x] This change is backwards compatible and safe to apply by existing users
* [x] This change will NOT lead to data loss
* [x] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
ran locally create/destroy worked fine
