### PR TITLE
Fixing a bug where due to a silly fix gcp k8s base needed gcp dns

### DIFF
--- a/config/tf_modules/gcp-k8s-base/load_balancer.tf
+++ b/config/tf_modules/gcp-k8s-base/load_balancer.tf
@@ -90,7 +90,7 @@ resource "google_compute_global_forwarding_rule" "https" {
 }
 
 resource "google_dns_record_set" "default" {
-  count        = var.hosted_zone_name == null ? 0 : 1
+  count        = var.hosted_zone_name == "" ? 0 : 1
   name         = "${var.domain}."
   type         = "A"
   ttl          = 3600
@@ -99,7 +99,7 @@ resource "google_dns_record_set" "default" {
 }
 
 resource "google_dns_record_set" "wildcard" {
-  count        = var.hosted_zone_name == null ? 0 : 1
+  count        = var.hosted_zone_name == "" ? 0 : 1
   name         = "*.${var.domain}."
   type         = "A"
   ttl          = 3600

--- a/config/tf_modules/gcp-k8s-base/variables.tf
+++ b/config/tf_modules/gcp-k8s-base/variables.tf
@@ -58,7 +58,7 @@ variable "cert_self_link" {
 
 variable "hosted_zone_name" {
   type    = string
-  default = null
+  default = ""
 }
 
 variable "domain" {


### PR DESCRIPTION
# Description


# Safety checklist
* [x] This change is backwards compatible and safe to apply by existing users
* [x] This change will NOT lead to data loss
* [x] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
Ran manually w/o gcp-dns, verified it worked
