### PR TITLE
Adding CI for Additional Node Pools/Groups for GCP/AWS

### DIFF
--- a/.github/workflows/aws-nodegroup.yml
+++ b/.github/workflows/aws-nodegroup.yml
@@ -1,0 +1,75 @@
+name: AWS Additional Node Group
+on: workflow_dispatch
+
+jobs:
+  additional-aws-nodegroup:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout Opta Repository
+        uses: actions/checkout@v2
+
+      - name: Pin terraform version
+        uses: hashicorp/setup-terraform@v1
+        with:
+          terraform_version: 1.0.0
+          terraform_wrapper: false
+
+      - name: Limit concurrency to 1.
+        uses: softprops/turnstyle@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.ALL_GITHUB_TOKEN }}
+
+      - name: Setup SSH
+        uses: webfactory/ssh-agent@v0.4.1
+        with:
+          ssh-private-key: ${{ secrets.SSH_KEY }}
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_OPTA_CI_ACCESS_KEY }}
+          aws-secret-access-key: ${{ secrets.AWS_OPTA_CI_SECRET_KEY }}
+          aws-region: us-east-1
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+
+      - name: Install dependencies
+        run: |
+          pip install pipenv
+          pipenv install --deploy --dev
+          source $(pipenv --venv)/bin/activate
+      - name: Build Release Binary
+        run: |
+          source $(pipenv --venv)/bin/activate
+          export PYTHONPATH=$(pwd)
+          make build-binary
+      - name: Create Test Enrironment with no Additional Nodegroup
+        run: |
+          OPTA_DISABLE_REPORTING=true ./dist/opta/opta apply \
+          --config ./examples/ci-tests/aws-nodegroup/aws-nodegroup-state1.yml \
+          --auto-approve \
+          --refresh
+      - name: Update Test Environment to have Additional Nodegroup
+        run: |
+          OPTA_DISABLE_REPORTING=true ./dist/opta/opta apply \
+          --config ./examples/ci-tests/aws-nodegroup/aws-nodegroup-state2.yml \
+          --auto-approve \
+          --refresh
+      - name: Update Test Environment to remove Additional Nodegroup
+        run: |
+          OPTA_DISABLE_REPORTING=true ./dist/opta/opta apply \
+          --config ./examples/ci-tests/aws-nodegroup/aws-nodegroup-state1.yml \
+          --auto-approve \
+          --refresh
+      - name: Destroy Test Enrironment
+        run: |
+          yes | OPTA_DISABLE_REPORTING=true ./dist/opta/opta destroy \
+          --config ./examples/ci-tests/aws-nodegroup/aws-nodegroup-state1.yml \
+          --auto-approve

--- a/.github/workflows/gcp-nodepool.yml
+++ b/.github/workflows/gcp-nodepool.yml
@@ -1,0 +1,71 @@
+name: GCP Additional Node Pool
+on: workflow_dispatch
+
+jobs:
+  additional-gcp-nodepool:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout Opta Repository
+        uses: actions/checkout@v2
+
+      - name: Pin terraform version
+        uses: hashicorp/setup-terraform@v1
+        with:
+          terraform_version: 1.0.0
+          terraform_wrapper: false
+
+      - name: Limit concurrency to 1.
+        uses: softprops/turnstyle@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.ALL_GITHUB_TOKEN }}
+
+      - name: Setup SSH
+        uses: webfactory/ssh-agent@v0.4.1
+        with:
+          ssh-private-key: ${{ secrets.SSH_KEY }}
+
+      - name: Configure GCP credentials
+        uses: google-github-actions/setup-gcloud@master
+        with:
+          service_account_key: ${{ secrets.CI_GKE_SA_KEY }}
+          project_id: opta-ci-1
+          export_default_credentials: true
+
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+
+      - name: Install dependencies
+        run: |
+          pip install pipenv
+          pipenv install --deploy --dev
+          source $(pipenv --venv)/bin/activate
+      - name: Build Release Binary
+        run: |
+          source $(pipenv --venv)/bin/activate
+          export PYTHONPATH=$(pwd)
+          make build-binary
+      - name: Create Test Enrironment with no Additional Nodepool
+        run: |
+          OPTA_DISABLE_REPORTING=true ./dist/opta/opta apply \
+          --config ./examples/ci-tests/gcp-nodepool/gcp-nodepool-state1.yml \
+          --auto-approve \
+          --refresh
+      - name: Update Test Environment to have Additional Nodepool
+        run: |
+          OPTA_DISABLE_REPORTING=true ./dist/opta/opta apply \
+          --config ./examples/ci-tests/gcp-nodepool/gcp-nodepool-state2.yml \
+          --auto-approve \
+          --refresh
+      - name: Update Test Environment to remove Additional Nodepool
+        run: |
+          OPTA_DISABLE_REPORTING=true ./dist/opta/opta apply \
+          --config ./examples/ci-tests/gcp-nodepool/gcp-nodepool-state1.yml \
+          --auto-approve \
+          --refresh
+      - name: Destroy Test Enrironment
+        run: |
+          yes | OPTA_DISABLE_REPORTING=true ./dist/opta/opta destroy \
+          --config ./examples/ci-tests/gcp-nodepool/gcp-nodepool-state1.yml \
+          --auto-approve

--- a/examples/ci-tests/aws-nodegroup/aws-nodegroup-state1.yml
+++ b/examples/ci-tests/aws-nodegroup/aws-nodegroup-state1.yml
@@ -1,0 +1,16 @@
+name: multi-node-group
+org_name: runx-ci
+providers:
+  aws:
+    region: us-east-2
+    account_id: 693658092572
+modules:
+- type: base
+- type: dns
+  domain: opta-ci.runx.dev
+  delegated: false
+- type: k8s-cluster
+  spot_instances: true
+  min_nodes: 1
+  max_nodes: 3
+- type: k8s-base

--- a/examples/ci-tests/aws-nodegroup/aws-nodegroup-state2.yml
+++ b/examples/ci-tests/aws-nodegroup/aws-nodegroup-state2.yml
@@ -1,0 +1,21 @@
+name: multi-node-group
+org_name: runx-ci
+providers:
+  aws:
+    region: us-east-2
+    account_id: 693658092572
+modules:
+- type: base
+- type: dns
+  domain: opta-ci.runx.dev
+  delegated: false
+- type: k8s-cluster
+  spot_instances: true
+  min_nodes: 1
+  max_nodes: 3
+- type: k8s-base
+- type: aws-nodegroup
+  name: nodegroup1
+  spot_instances: true
+  min_nodes: 1
+  max_nodes: 3

--- a/examples/ci-tests/gcp-nodepool/gcp-nodepool-state1.yml
+++ b/examples/ci-tests/gcp-nodepool/gcp-nodepool-state1.yml
@@ -1,0 +1,14 @@
+name: gcp-multi-nodepool
+org_name: runx-ci
+providers:
+  google:
+    region: us-central1
+    project: opta-ci-1
+modules:
+  - type: base
+  - type: dns
+    domain: gcp-release.runx.dev
+    delegated: false
+  - type: k8s-cluster
+    max_nodes: 4
+  - type: k8s-base

--- a/examples/ci-tests/gcp-nodepool/gcp-nodepool-state2.yml
+++ b/examples/ci-tests/gcp-nodepool/gcp-nodepool-state2.yml
@@ -1,0 +1,18 @@
+name: gcp-multi-nodepool
+org_name: runx-ci
+providers:
+  google:
+    region: us-central1
+    project: opta-ci-1
+modules:
+  - type: base
+  - type: dns
+    domain: gcp-release.runx.dev
+    delegated: false
+  - type: k8s-cluster
+    max_nodes: 4
+  - type: k8s-base
+  - type: gcp-nodepool
+    name: nodepool2
+    min_nodes: 1
+    max_nodes: 5


### PR DESCRIPTION
# Description
CI for testing the Creation and destruction of the Additinoal Node Pools/Groups for GCP/AWS

# Safety checklist
* [X] This change is backwards compatible and safe to apply by existing users
* [X] This change will NOT lead to data loss
* [X] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
Does not affect the opta functionality.
