### PR TITLE
Some resources are failing in CD because they are not unique enough

### DIFF
--- a/config/tf_modules/aws-documentdb/main.tf
+++ b/config/tf_modules/aws-documentdb/main.tf
@@ -11,17 +11,25 @@ data "aws_kms_key" "main" {
   key_id = "alias/opta-${var.env_name}"
 }
 
+resource "random_string" "db_name_hash" {
+  length  = 4
+  special = false
+}
+
 resource "aws_docdb_cluster_instance" "cluster_instances" {
   count                      = var.instance_count
-  identifier                 = "opta-${var.layer_name}-${var.module_name}-${count.index}"
+  identifier                 = "opta-${var.layer_name}-${var.module_name}-${random_string.db_name_hash.result}-${count.index}"
   cluster_identifier         = aws_docdb_cluster.cluster.id
   instance_class             = var.instance_class
   apply_immediately          = true
   auto_minor_version_upgrade = true
+  lifecycle {
+    ignore_changes = [identifier]
+  }
 }
 
 resource "aws_docdb_cluster" "cluster" {
-  cluster_identifier      = "opta-${var.layer_name}-${var.module_name}"
+  cluster_identifier      = "opta-${var.layer_name}-${var.module_name}-${random_string.db_name_hash.result}"
   master_username         = "master_user"
   master_password         = random_password.documentdb_auth.result
   db_subnet_group_name    = "opta-${var.env_name}-docdb"
@@ -32,4 +40,7 @@ resource "aws_docdb_cluster" "cluster" {
   backup_retention_period = 5
   apply_immediately       = true
   skip_final_snapshot     = true
+  lifecycle {
+    ignore_changes = [cluster_identifier]
+  }
 }

--- a/config/tf_modules/aws-postgres/main.tf
+++ b/config/tf_modules/aws-postgres/main.tf
@@ -11,8 +11,13 @@ data "aws_kms_key" "main" {
   key_id = "alias/opta-${var.env_name}"
 }
 
+resource "random_string" "db_name_hash" {
+  length  = 4
+  special = false
+}
+
 resource "aws_rds_cluster" "db_cluster" {
-  cluster_identifier      = "opta-${var.layer_name}-${var.module_name}"
+  cluster_identifier      = "opta-${var.layer_name}-${var.module_name}-${random_string.db_name_hash.result}"
   db_subnet_group_name    = "opta-${var.env_name}"
   database_name           = "app"
   engine                  = "aurora-postgresql"
@@ -27,13 +32,13 @@ resource "aws_rds_cluster" "db_cluster" {
   kms_key_id              = data.aws_kms_key.main.arn
   deletion_protection     = var.safety
   lifecycle {
-    ignore_changes = [storage_encrypted, kms_key_id]
+    ignore_changes = [storage_encrypted, kms_key_id, cluster_identifier]
   }
 }
 
 resource "aws_rds_cluster_instance" "db_instance" {
   count                           = var.multi_az ? 2 : 1
-  identifier                      = "opta-${var.layer_name}-${var.module_name}-${count.index}"
+  identifier                      = "opta-${var.layer_name}-${var.module_name}-${random_string.db_name_hash.result}-${count.index}"
   cluster_identifier              = aws_rds_cluster.db_cluster.id
   instance_class                  = var.instance_class
   engine                          = aws_rds_cluster.db_cluster.engine
@@ -42,4 +47,7 @@ resource "aws_rds_cluster_instance" "db_instance" {
   auto_minor_version_upgrade      = false
   performance_insights_enabled    = true
   performance_insights_kms_key_id = data.aws_kms_key.main.arn
+  lifecycle {
+    ignore_changes = [identifier]
+  }
 }

--- a/config/tf_modules/aws-redis/main.tf
+++ b/config/tf_modules/aws-redis/main.tf
@@ -3,6 +3,11 @@ resource "random_password" "redis_auth" {
   special = false
 }
 
+resource "random_string" "redis_name_hash" {
+  length  = 4
+  special = false
+}
+
 data "aws_security_group" "security_group" {
   name = "opta-${var.env_name}-elasticache-sg"
 }
@@ -16,8 +21,8 @@ resource "aws_elasticache_replication_group" "redis_cluster" {
   auto_minor_version_upgrade    = true
   security_group_ids            = [data.aws_security_group.security_group.id]
   subnet_group_name             = "opta-${var.env_name}"
-  replication_group_id          = "opta-${var.layer_name}-${var.module_name}"
-  replication_group_description = "Elasticache opta-${var.layer_name}-${var.module_name}"
+  replication_group_id          = "opta-${var.layer_name}-${var.module_name}-${random_string.redis_name_hash.result}"
+  replication_group_description = "Elasticache opta-${var.layer_name}-${var.module_name}-${random_string.redis_name_hash.result}"
   node_type                     = var.node_type
   engine_version                = var.redis_version
   number_cache_clusters         = 2
@@ -31,6 +36,6 @@ resource "aws_elasticache_replication_group" "redis_cluster" {
   snapshot_window               = var.snapshot_window
   snapshot_retention_limit      = var.snapshot_retention_limit
   lifecycle {
-    ignore_changes = [engine_version]
+    ignore_changes = [engine_version, replication_group_id, replication_group_description]
   }
 }

--- a/config/tf_modules/k8s-service/ecr.tf
+++ b/config/tf_modules/k8s-service/ecr.tf
@@ -1,8 +1,16 @@
+resource "random_string" "repo_name_hash" {
+  length  = 4
+  special = false
+}
+
 resource "aws_ecr_repository" "repo" {
   count = var.image == "AUTO" ? 1 : 0
-  name  = "opta-${var.layer_name}-${var.module_name}"
+  name  = "opta-${var.layer_name}-${var.module_name}-${random_string.repo_name_hash.result}"
   tags = {
     terraform = "true"
+  }
+  lifecycle {
+    ignore_changes = [name]
   }
 }
 


### PR DESCRIPTION
# Description
Honestly, surprised it took this long to spot this. Just adding some random hashes based on the failures here:
https://github.com/run-x/opta/actions/runs/1379261534


# Safety checklist
* [x] This change is backwards compatible and safe to apply by existing users
* [x] This change will NOT lead to data loss
* [x] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
Ran locally, verified resources were not being destroyed
