### PR TITLE
Postgres db identifier bugfix

### DIFF
--- a/config/tf_modules/aws-postgres/main.tf
+++ b/config/tf_modules/aws-postgres/main.tf
@@ -14,6 +14,7 @@ data "aws_kms_key" "main" {
 resource "random_string" "db_name_hash" {
   length  = 4
   special = false
+  upper   = false
 }
 
 resource "aws_rds_cluster" "db_cluster" {


### PR DESCRIPTION
# Description
This is not backwards incompatible because
1. We have lifecycle ignore changes on the db identifier
2. Upper case letters in the db identifier is not allowed, so there would be no identifiers of running clusters who would be changed

# Safety checklist
* [x] This change is backwards compatible and safe to apply by existing users
* [x] This change will NOT lead to data loss
* [x] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
Ran locally and as expected, it did not cause anything existing to change
