### PR TITLE
AWS TF resources with Valid Resource Names

### DIFF
--- a/config/tf_modules/aws-documentdb/main.tf
+++ b/config/tf_modules/aws-documentdb/main.tf
@@ -14,7 +14,7 @@ data "aws_kms_key" "main" {
 resource "random_string" "db_name_hash" {
   length  = 4
   special = false
-  upper = false
+  upper   = false
 }
 
 resource "aws_docdb_cluster_instance" "cluster_instances" {

--- a/config/tf_modules/aws-postgres/main.tf
+++ b/config/tf_modules/aws-postgres/main.tf
@@ -14,7 +14,7 @@ data "aws_kms_key" "main" {
 resource "random_string" "db_name_hash" {
   length  = 4
   special = false
-  upper = false
+  upper   = false
 }
 
 resource "aws_rds_cluster" "db_cluster" {

--- a/config/tf_modules/aws-redis/main.tf
+++ b/config/tf_modules/aws-redis/main.tf
@@ -6,7 +6,7 @@ resource "random_password" "redis_auth" {
 resource "random_string" "redis_name_hash" {
   length  = 4
   special = false
-  upper = false
+  upper   = false
 }
 
 data "aws_security_group" "security_group" {

--- a/config/tf_modules/k8s-service/ecr.tf
+++ b/config/tf_modules/k8s-service/ecr.tf
@@ -1,7 +1,7 @@
 resource "random_string" "repo_name_hash" {
   length  = 4
   special = false
-  upper = false
+  upper   = false
 }
 
 resource "aws_ecr_repository" "repo" {


### PR DESCRIPTION
# Description
Update the AWS TF resources with valid identifiers and names.
Using only lower case alphabets and numerics.

> Failed Github Action: https://github.com/run-x/opta/runs/4017235079?check_suite_focus=true

# Safety checklist
* [ ] This change is backwards compatible and safe to apply by existing users
* [ ] This change will NOT lead to data loss
* [ ] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
Not tested yet.
