### PR TITLE
Remove Azure published and nightly CI runs

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -39,6 +39,23 @@ jobs:
       #   if: ${{ failure() }}
       #   run: echo "TODO, send slack alert to notify failure"
 
+  create-destroy-tests-azure:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Pin terraform version
+        uses: hashicorp/setup-terraform@v1
+        with:
+          terraform_version: 1.0.0
+          terraform_wrapper: false
+      - name: Create and destroy test-service and opta environment
+        run: ./scripts/dispatch_workflow.sh opta create-and-destroy-azure.yml main
+        env:
+          github_token: ${{ secrets.ALL_GITHUB_TOKEN }}
+      # - name: Slack alert if failed.
+      #   if: ${{ failure() }}
+      #   run: echo "TODO, send slack alert to notify failure"
+
   package-linux:
     # needs: create-destroy-tests
     runs-on: ubuntu-18.04


### PR DESCRIPTION
# Description
Remove Azure Create and Destroy from Published and Nightly runs.

# Safety checklist
* [ ] This change is backwards compatible and safe to apply by existing users
* [ ] This change will NOT lead to data loss
* [ ] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
Removing CI test triggers.
