### PR TITLE
Fix k8s-service failing when public_uri is not specified

### DIFF
--- a/opta/module_processors/base.py
+++ b/opta/module_processors/base.py
@@ -89,16 +89,17 @@ class K8sServiceModuleProcessor(ModuleProcessor):
         if isinstance(self.module.data.get("public_uri"), str):
             self.module.data["public_uri"] = [self.module.data["public_uri"]]
 
-        new_uris: list[str] = []
-        public_uri: str
-        for public_uri in self.module.data["public_uri"]:
-            if public_uri.startswith("/"):
-                new_uris.append(f"all{public_uri}")
-            elif public_uri.startswith("*"):
-                new_uris.append(f"all{public_uri[1:]}")
-            else:
-                new_uris.append(public_uri)
-        self.module.data["public_uri"] = new_uris
+        if "public_uri" in self.module.data:
+            new_uris: list[str] = []
+            public_uri: str
+            for public_uri in self.module.data["public_uri"]:
+                if public_uri.startswith("/"):
+                    new_uris.append(f"all{public_uri}")
+                elif public_uri.startswith("*"):
+                    new_uris.append(f"all{public_uri[1:]}")
+                else:
+                    new_uris.append(public_uri)
+            self.module.data["public_uri"] = new_uris
 
         super(K8sServiceModuleProcessor, self).process(module_idx)
 


### PR DESCRIPTION
# Description
With [this change](https://github.com/run-x/opta/pull/450/files#diff-b8b1125f4ec2e2d7c9529ba8a3773b7e6933f61016fc590aaaa17e4969dc2161R94), `public_uri` inadvertently became required, even though its not required [in the registry](https://github.com/run-x/opta/blob/8a70c16106fdd89bb81584f65767e707a04eaa2f/config/registry/aws/modules/aws-k8s-service.yaml#L139).

# Safety checklist
* [x] This change is backwards compatible and safe to apply by existing users
* [x] This change will NOT lead to data loss
* [x] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
None
