### PR TITLE
Adding a 10 sleep after tfstate s3 bucket creation

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -8,8 +8,6 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
-        with:
-          ref: dev
       - name: Pin terraform version
         uses: hashicorp/setup-terraform@v1
         with:

--- a/opta/core/terraform.py
+++ b/opta/core/terraform.py
@@ -802,6 +802,7 @@ class Terraform:
                     Bucket=bucket_name,
                     CreateBucketConfiguration={"LocationConstraint": region},
                 )
+            time.sleep(10)
             s3.put_bucket_encryption(
                 Bucket=bucket_name,
                 ServerSideEncryptionConfiguration={


### PR DESCRIPTION
# Description
As sometimes we get race condtitions for the bucket's existence


# Safety checklist
* [x] This change is backwards compatible and safe to apply by existing users
* [x] This change will NOT lead to data loss
* [x] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
n/a
