### PR TITLE
Several improvements on the gcp service account

### DIFF
--- a/config/registry/google/modules/gcp-k8s-service.yaml
+++ b/config/registry/google/modules/gcp-k8s-service.yaml
@@ -31,12 +31,14 @@ inputs:
     description: "Manually set secrets"
     default: [ ]
   - name: read_buckets
-    user_facing: false
-    description: Buckets linked for reading
+    user_facing: true
+    description: Buckets to grant read permissions for
+    validator: list(str(), required=False)
     default: []
   - name: write_buckets
-    user_facing: false
-    description: Buckets linked for writing
+    user_facing: true
+    description: Buckets to grant write permissions for
+    validator: list(str(), required=False)
     default: []
   - name: image
     user_facing: true
@@ -152,6 +154,11 @@ inputs:
       A list persistent storages to add to each instance of your service (need to give a `size` which is the size in GB
       for the storage volume to be, and `path` which is the path in the filesystem of each instance to place it under)
     default: []
+  - name: extra_project_iam_roles
+    user_facing: true
+    description: A list of extra project-level iam roles to grant to the service account created for this k8s service
+    validator: list(str(), required=False)
+    default: [ ]
 extra_validators:
   persistent_storage:
     size: int(required=True)

--- a/config/registry/google/modules/gcp-k8s-service.yaml
+++ b/config/registry/google/modules/gcp-k8s-service.yaml
@@ -31,14 +31,12 @@ inputs:
     description: "Manually set secrets"
     default: [ ]
   - name: read_buckets
-    user_facing: true
+    user_facing: false
     description: Buckets to grant read permissions for
-    validator: list(str(), required=False)
     default: []
   - name: write_buckets
-    user_facing: true
+    user_facing: false
     description: Buckets to grant write permissions for
-    validator: list(str(), required=False)
     default: []
   - name: image
     user_facing: true
@@ -154,7 +152,7 @@ inputs:
       A list persistent storages to add to each instance of your service (need to give a `size` which is the size in GB
       for the storage volume to be, and `path` which is the path in the filesystem of each instance to place it under)
     default: []
-  - name: extra_project_iam_roles
+  - name: additional_iam_roles
     user_facing: true
     description: A list of extra project-level iam roles to grant to the service account created for this k8s service
     validator: list(str(), required=False)

--- a/config/registry/google/modules/gcp-service-account.yaml
+++ b/config/registry/google/modules/gcp-service-account.yaml
@@ -24,16 +24,14 @@ inputs:
     description: A list of extra IAM role policies not captured by Opta which you wish to give to your service.
     default: []
   - name: read_buckets
-    user_facing: true
+    user_facing: false
     description: Buckets to grant read permissions for
-    validator: list(str(), required=False)
     default: []
   - name: write_buckets
-    user_facing: true
+    user_facing: false
     description: Buckets to grant write permissions for
-    validator: list(str(), required=False)
     default: []
-  - name: extra_project_iam_roles
+  - name: additional_iam_roles
     user_facing: true
     description: A list of extra project-level iam roles to grant to the service account
     validator: list(str(), required=False)

--- a/config/registry/google/modules/gcp-service-account.yaml
+++ b/config/registry/google/modules/gcp-service-account.yaml
@@ -24,13 +24,25 @@ inputs:
     description: A list of extra IAM role policies not captured by Opta which you wish to give to your service.
     default: []
   - name: read_buckets
-    user_facing: false
-    description: Buckets linked for reading
+    user_facing: true
+    description: Buckets to grant read permissions for
+    validator: list(str(), required=False)
     default: []
   - name: write_buckets
-    user_facing: false
-    description: Buckets linked for writing
+    user_facing: true
+    description: Buckets to grant write permissions for
+    validator: list(str(), required=False)
     default: []
+  - name: extra_project_iam_roles
+    user_facing: true
+    description: A list of extra project-level iam roles to grant to the service account
+    validator: list(str(), required=False)
+    default: [ ]
+  - name: explicit_name
+    user_facing: true
+    validator: str(required=False)
+    description: An explicit name to give to your service account (warning-- must be unique per account)
+    default: null
 extra_validators:
   allowed-k8s-services:
     service_account_name: str(required=True)

--- a/config/tf_modules/gcp-k8s-service/iam.tf
+++ b/config/tf_modules/gcp-k8s-service/iam.tf
@@ -25,3 +25,9 @@ resource "google_storage_bucket_iam_member" "viewer" {
   member = "serviceAccount:${google_service_account.k8s_service.email}"
 }
 
+resource "google_project_iam_member" "project" {
+  count = length(var.extra_project_iam_roles)
+  project = data.google_client_config.current.project
+  role    = var.extra_project_iam_roles[count.index]
+  member  = "serviceAccount:${google_service_account.k8s_service.email}"
+}

--- a/config/tf_modules/gcp-k8s-service/iam.tf
+++ b/config/tf_modules/gcp-k8s-service/iam.tf
@@ -26,7 +26,7 @@ resource "google_storage_bucket_iam_member" "viewer" {
 }
 
 resource "google_project_iam_member" "project" {
-  count = length(var.additional_iam_roles)
+  count   = length(var.additional_iam_roles)
   project = data.google_client_config.current.project
   role    = var.additional_iam_roles[count.index]
   member  = "serviceAccount:${google_service_account.k8s_service.email}"

--- a/config/tf_modules/gcp-k8s-service/iam.tf
+++ b/config/tf_modules/gcp-k8s-service/iam.tf
@@ -26,8 +26,8 @@ resource "google_storage_bucket_iam_member" "viewer" {
 }
 
 resource "google_project_iam_member" "project" {
-  count = length(var.extra_project_iam_roles)
+  count = length(var.additional_iam_roles)
   project = data.google_client_config.current.project
-  role    = var.extra_project_iam_roles[count.index]
+  role    = var.additional_iam_roles[count.index]
   member  = "serviceAccount:${google_service_account.k8s_service.email}"
 }

--- a/config/tf_modules/gcp-k8s-service/variables.tf
+++ b/config/tf_modules/gcp-k8s-service/variables.tf
@@ -163,3 +163,7 @@ variable "persistent_storage" {
   type    = list(map(string))
   default = []
 }
+
+variable "extra_project_iam_roles" {
+  default = []
+}

--- a/config/tf_modules/gcp-k8s-service/variables.tf
+++ b/config/tf_modules/gcp-k8s-service/variables.tf
@@ -164,6 +164,6 @@ variable "persistent_storage" {
   default = []
 }
 
-variable "extra_project_iam_roles" {
+variable "additional_iam_roles" {
   default = []
 }

--- a/config/tf_modules/gcp-service-account/main.tf
+++ b/config/tf_modules/gcp-service-account/main.tf
@@ -26,7 +26,7 @@ resource "google_storage_bucket_iam_member" "viewer" {
 }
 
 resource "google_project_iam_member" "project" {
-  count = length(var.additional_iam_roles)
+  count   = length(var.additional_iam_roles)
   project = data.google_client_config.current.project
   role    = var.additional_iam_roles[count.index]
   member  = "serviceAccount:${google_service_account.k8s_service.email}"

--- a/config/tf_modules/gcp-service-account/main.tf
+++ b/config/tf_modules/gcp-service-account/main.tf
@@ -26,8 +26,8 @@ resource "google_storage_bucket_iam_member" "viewer" {
 }
 
 resource "google_project_iam_member" "project" {
-  count = length(var.extra_project_iam_roles)
+  count = length(var.additional_iam_roles)
   project = data.google_client_config.current.project
-  role    = var.extra_project_iam_roles[count.index]
+  role    = var.additional_iam_roles[count.index]
   member  = "serviceAccount:${google_service_account.k8s_service.email}"
 }

--- a/config/tf_modules/gcp-service-account/main.tf
+++ b/config/tf_modules/gcp-service-account/main.tf
@@ -1,6 +1,6 @@
 resource "google_service_account" "k8s_service" {
-  account_id   = "${local.env_short}-${local.layer_short}-${local.module_short}"
-  display_name = "${local.env_short}-${local.layer_short}-${local.module_short}"
+  account_id   = var.explicit_name == null ? "${local.env_short}-${local.layer_short}-${local.module_short}" : var.explicit_name
+  display_name = var.explicit_name == null ? "${local.env_short}-${local.layer_short}-${local.module_short}" : var.explicit_name
 }
 
 resource "google_service_account_iam_binding" "trust_k8s_workload_idu" {
@@ -25,3 +25,9 @@ resource "google_storage_bucket_iam_member" "viewer" {
   member = "serviceAccount:${google_service_account.k8s_service.email}"
 }
 
+resource "google_project_iam_member" "project" {
+  count = length(var.extra_project_iam_roles)
+  project = data.google_client_config.current.project
+  role    = var.extra_project_iam_roles[count.index]
+  member  = "serviceAccount:${google_service_account.k8s_service.email}"
+}

--- a/config/tf_modules/gcp-service-account/variables.tf
+++ b/config/tf_modules/gcp-service-account/variables.tf
@@ -41,7 +41,7 @@ variable "links" {
   default = []
 }
 
-variable "extra_project_iam_roles" {
+variable "additional_iam_roles" {
   default = []
 }
 

--- a/config/tf_modules/gcp-service-account/variables.tf
+++ b/config/tf_modules/gcp-service-account/variables.tf
@@ -40,3 +40,12 @@ variable "allowed_k8s_services" {
 variable "links" {
   default = []
 }
+
+variable "extra_project_iam_roles" {
+  default = []
+}
+
+variable "explicit_name" {
+  type    = string
+  default = null
+}

--- a/examples/gcp-resources/opta.yml
+++ b/examples/gcp-resources/opta.yml
@@ -5,6 +5,10 @@ environments:
       max_containers: 2
 name: blah42
 modules:
+  - type: gcp-service-account
+    explicit_name: "hello-world-blah"
+    extra_project_iam_roles:
+      - "roles/firebase.admin"
   - type: k8s-service
     image: kennethreitz/httpbin
     min_containers: 2

--- a/examples/gcp-resources/opta.yml
+++ b/examples/gcp-resources/opta.yml
@@ -7,7 +7,7 @@ name: blah42
 modules:
   - type: gcp-service-account
     explicit_name: "hello-world-blah"
-    extra_project_iam_roles:
+    additional_iam_roles:
       - "roles/firebase.admin"
   - type: k8s-service
     image: kennethreitz/httpbin

--- a/opta/module_processors/gcp_k8s_service.py
+++ b/opta/module_processors/gcp_k8s_service.py
@@ -72,8 +72,12 @@ class GcpK8sServiceProcessor(GcpK8sModuleProcessor, K8sServiceModuleProcessor):
                     f"Unsupported module type for k8s service link: {module_type}"
                 )
 
-        self.module.data["read_buckets"] = self.read_buckets
-        self.module.data["write_buckets"] = self.write_buckets
+        self.module.data["read_buckets"] = (
+            self.module.data.get("read_buckets", []) + self.read_buckets
+        )
+        self.module.data["write_buckets"] = (
+            self.module.data.get("write_buckets", []) + self.write_buckets
+        )
         if "image_tag" in self.layer.variables:
             self.module.data["tag"] = self.layer.variables["image_tag"]
 

--- a/opta/module_processors/gcp_service_account.py
+++ b/opta/module_processors/gcp_service_account.py
@@ -60,6 +60,10 @@ class GcpServiceAccountProcessor(ModuleProcessor):
                     f"Unsupported module type for gcp service account link: {module_type}"
                 )
 
-        self.module.data["read_buckets"] = self.read_buckets
-        self.module.data["write_buckets"] = self.write_buckets
+        self.module.data["read_buckets"] = (
+            self.module.data.get("read_buckets", []) + self.read_buckets
+        )
+        self.module.data["write_buckets"] = (
+            self.module.data.get("write_buckets", []) + self.write_buckets
+        )
         super(GcpServiceAccountProcessor, self).process(module_idx)


### PR DESCRIPTION
# Description
1. For both the k8s service and gcp service account modules a user can include an extra_project_iam_roles field which is a list of project-level roles to include for the selected accounts. NOTE some services like gcs or bigquery have more fine-grained permissions, like bigquery's [Roles applied on the Dataset level](https://cloud.google.com/bigquery/docs/access-control#dataset_level). This does NOT cover those, just the project level.
2. The service account now has an explicit_name field to give it a user-specified name (as opposed to the constructed one by opta)
3. For both the k8s service and gcp service account modules the read and write bucket fields are exposed to the user in case they want to directly add buckets not in opta (and so they could not use links)


# Safety checklist
* [x] This change is backwards compatible and safe to apply by existing users
* [x] This change will NOT lead to data loss
* [x] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
tested new fields locally
