### PR TITLE
Fixing gcp ingress-path health check issue

### DIFF
--- a/config/tf_modules/gcp-k8s-base/ingress_nginx.tf
+++ b/config/tf_modules/gcp-k8s-base/ingress_nginx.tf
@@ -10,6 +10,9 @@ resource "helm_release" "ingress-nginx" {
   values = [
     yamlencode({
       controller : {
+        podLabels: {
+          "opta-ingress-healthcheck" : "yes"
+        }
         extraArgs : var.private_key == "" ? {} : { default-ssl-certificate : "ingress-nginx/secret-tls" }
         config : local.config
         podAnnotations : {

--- a/config/tf_modules/gcp-k8s-base/ingress_nginx.tf
+++ b/config/tf_modules/gcp-k8s-base/ingress_nginx.tf
@@ -10,7 +10,7 @@ resource "helm_release" "ingress-nginx" {
   values = [
     yamlencode({
       controller : {
-        podLabels: {
+        podLabels : {
           "opta-ingress-healthcheck" : "yes"
         }
         extraArgs : var.private_key == "" ? {} : { default-ssl-certificate : "ingress-nginx/secret-tls" }

--- a/config/tf_modules/gcp-k8s-base/opta-base/Chart.yaml
+++ b/config/tf_modules/gcp-k8s-base/opta-base/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.2.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/config/tf_modules/gcp-k8s-base/opta-base/templates/nginx_health_check.yaml
+++ b/config/tf_modules/gcp-k8s-base/opta-base/templates/nginx_health_check.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    opta-generated: "true"
+  name: opta-ingress-healthcheck
+  namespace: ingress-nginx
+spec:
+  ports:
+    - port: 80
+      targetPort: healthcheck
+      protocol: TCP
+      name: healthcheck
+  selector:
+    opta-ingress-healthcheck : "yes"
+---
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name:  opta-ingress-healthcheck
+  namespace: ingress-nginx
+  labels:
+    opta-generated: "true"
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+spec:
+  rules:
+    - http:
+        paths:
+          - path: "/healthz"
+            backend:
+              serviceName: opta-ingress-healthcheck
+              servicePort: 80

--- a/config/tf_modules/gcp-k8s-base/variables.tf
+++ b/config/tf_modules/gcp-k8s-base/variables.tf
@@ -1,6 +1,6 @@
 locals {
   target_ports    = { http : "http", https : "https" }
-  container_ports = { http : 80, https : 443 }
+  container_ports = { http : 80, https : 443, healthcheck : 10254 }
   config          = merge({ ssl-redirect : false }, var.nginx_config)
   annotations     = "{\"exposed_ports\": { \"443\":{\"name\": \"opta-${var.layer_name}-https\"}}}"
   negs            = formatlist("https://www.googleapis.com/compute/v1/projects/%s/zones/%s/networkEndpointGroups/opta-%s-https", data.google_client_config.current.project, var.zone_names, var.layer_name)

--- a/opta/module_processors/aws_k8s_base.py
+++ b/opta/module_processors/aws_k8s_base.py
@@ -79,7 +79,7 @@ class AwsK8sBaseProcessor(AWSK8sModuleProcessor, K8sBaseModuleProcessor):
     def post_hook(self, module_idx: int, exception: Optional[Exception]) -> None:
         if exception is not None:
             return
-        self.add_alpn_olicy()
+        self.add_alpn_policy()
         self.add_admin_roles()
 
     def add_admin_roles(self) -> None:
@@ -140,7 +140,7 @@ class AwsK8sBaseProcessor(AWSK8sModuleProcessor, K8sBaseModuleProcessor):
             "aws-auth", "kube-system", body=aws_auth_config_map
         )
 
-    def add_alpn_olicy(self) -> None:
+    def add_alpn_policy(self) -> None:
         # Manually set the AlpnPolicy to HTTP2Preferred cause the damn K8s service annotation doesn't do its job.
         providers = self.layer.gen_providers(0)
         region = providers["provider"]["aws"]["region"]

--- a/tests/module_processors/test_aws_k8sbase.py
+++ b/tests/module_processors/test_aws_k8sbase.py
@@ -1,7 +1,6 @@
 # type: ignore
 import os
 
-import pytest
 from pytest_mock import MockFixture
 
 from opta.layer import Layer

--- a/tests/module_processors/test_aws_k8sbase.py
+++ b/tests/module_processors/test_aws_k8sbase.py
@@ -1,0 +1,62 @@
+# type: ignore
+import os
+
+import pytest
+from pytest_mock import MockFixture
+
+from opta.layer import Layer
+from opta.module_processors.aws_k8s_base import AwsK8sBaseProcessor
+
+
+class TestAwsK8sBaseProcessor:
+    def test_add_admin_roles(self, mocker: MockFixture):
+        layer = Layer.load_from_yaml(
+            os.path.join(
+                os.path.dirname(os.path.dirname(__file__)),
+                "module_processors",
+                "dummy_config_parent.yaml",
+            ),
+            None,
+        )
+        k8s_base_module = layer.get_module("k8sbase", 8)
+        k8s_base_module.data["admin_arns"] = [
+            "arn:aws:iam::445935066876:user/live-example-dev-live-example-dev-deployeruser",
+            "arn:aws:iam::445935066876:role/live-example-dev-live-example-dev-deployerrole",
+            "arn:aws:iam::445935066876:role/silly-role",
+            "arn:aws:iam::445935066876:user/silly-user",
+        ]
+
+        mocker.patch("opta.module_processors.aws_k8s_base.Terraform")
+        mocker.patch("opta.module_processors.aws_k8s_base.configure_kubectl")
+        mocker.patch("opta.module_processors.aws_k8s_base.load_kube_config")
+
+        mocked_core_v1_api = mocker.Mock()
+        mocker.patch(
+            "opta.module_processors.aws_k8s_base.CoreV1Api",
+            return_value=mocked_core_v1_api,
+        )
+        mocked_aws_auth_config_map = mocker.Mock()
+        mocked_aws_auth_config_map.data = {
+            "mapRoles": "- groups: ['system:bootstrappers', 'system:nodes']\n  rolearn: arn:aws:iam::445935066876:role/opta-live-example-dev-eks-default-node-group\n  username: system:node:{{EC2PrivateDNSName}}\n- groups: ['system:masters']\n  rolearn: arn:aws:iam::445935066876:role/live-example-dev-live-example-dev-deployerrole\n  username: opta-managed\n",
+            "mapUsers": "- groups: ['system:masters']\n  userarn: arn:aws:iam::445935066876:user/live-example-dev-live-example-dev-deployeruser\n  username: opta-managed\n",
+        }
+        mocked_opta_arns_config_map = mocker.Mock()
+        mocked_opta_arns_config_map.data = {
+            "adminArns": '\n- "arn:aws:iam::445935066876:user/live-example-dev-live-example-dev-deployeruser"\n\n- "arn:aws:iam::445935066876:role/live-example-dev-live-example-dev-deployerrole"\n\n- "arn:aws:iam::445935066876:role/silly-role"\n\n- "arn:aws:iam::445935066876:user/silly-user"\n'
+        }
+        mocked_core_v1_api.read_namespaced_config_map.side_effect = [
+            mocked_aws_auth_config_map,
+            mocked_opta_arns_config_map,
+        ]
+        AwsK8sBaseProcessor(k8s_base_module, layer).add_admin_roles()
+        mocked_core_v1_api.read_namespaced_config_map.assert_has_calls(
+            [mocker.call("aws-auth", "kube-system"), mocker.call("opta-arns", "default")]
+        )
+        mocked_core_v1_api.replace_namespaced_config_map.assert_has_calls(
+            [mocker.call("aws-auth", "kube-system", body=mocked_aws_auth_config_map)]
+        )
+
+        assert mocked_aws_auth_config_map.data == {
+            "mapRoles": "- groups: ['system:bootstrappers', 'system:nodes']\n  rolearn: arn:aws:iam::445935066876:role/opta-live-example-dev-eks-default-node-group\n  username: system:node:{{EC2PrivateDNSName}}\n- groups: ['system:masters']\n  rolearn: arn:aws:iam::445935066876:role/live-example-dev-live-example-dev-deployerrole\n  username: opta-managed\n- groups: ['system:masters']\n  rolearn: arn:aws:iam::445935066876:role/silly-role\n  username: opta-managed\n",
+            "mapUsers": "- groups: ['system:masters']\n  userarn: arn:aws:iam::445935066876:user/live-example-dev-live-example-dev-deployeruser\n  username: opta-managed\n- groups: ['system:masters']\n  userarn: arn:aws:iam::445935066876:user/silly-user\n  username: opta-managed\n",
+        }


### PR DESCRIPTION
# Description

"""
Hey @patrick nitin and I ran into a bug I need help with. Here’s what is happening
In GCP, when we setup a load balancer, the load balancer needs a health check (simple http, sending a get request and expecting a 200) for its backend  i.e. something which nginx ingress must have. Right now, it is set to send to the path /healthz because that’s the default backend which nginx ingress has. Normally, this works fine: the GCP lb health check pings nginx for /healthz (I don’t know what host it uses) while nginx fulfills all the other ingress routes being set. But here is where the bug happens-- if someone sets up an ingress w/o the host set up and not including the healthz path (or fulfilling it) e.g. public_uri: "/hello" , then the /healthz path now returns a 404, the gcp lb health check fails, and the whole lb gets blocked. You can try this out easily, e.g. get a cluster (doesn’t need to be GCP), apply the ingresses as I have set, use kubectl port forward, and see what happens when you try /healthz. Right now I got no idea I’m confident about to solve this issue, so any help would be appreciated
"""

OK so here is my solution:
nginx already has a dedicated port for healthchecks, it is port 10254 and I confirmed that it is live and well in the ingress nginx. If you hit that port w/ path /healthz you'll get the 200 response.

So I exposed that port in the k8s pod, created a service to listen to the nginx pods on that port, and added and set an ingress to forward all requests to /healthz over to it (and yes, it's ok to create the ingress before the nginx controller exists). It's basically the "let's add a health check deployment" solution but recycling the nginx native health check.

I tested it out and it fixed the lb health checks just as expected. The only catch is that /healthz (no host specified) is now "officially" (it was unofficially due to the bug so no real change) reserved for opta use.



# Safety checklist
* [x] This change is backwards compatible and safe to apply by existing users
* [x] This change will NOT lead to data loss
* [x] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
ran locally
