### PR TITLE
Err User when using Opta via Symlinked directories

### DIFF
--- a/opta/cli.py
+++ b/opta/cli.py
@@ -26,7 +26,6 @@ from opta.commands.validate import validate
 from opta.commands.version import version
 from opta.exceptions import UserErrors
 from opta.one_time import one_time
-from opta.pre_check import pre_check
 from opta.upgrade import check_version_upgrade
 from opta.utils import dd_handler, dd_listener, logger
 
@@ -62,7 +61,6 @@ if __name__ == "__main__":
         # However, we should still clean them up before the next command, or
         # else it may interfere with it.
         one_time()
-        pre_check()
         cleanup_files()
         cli()
     except CalledProcessError as e:

--- a/opta/cli.py
+++ b/opta/cli.py
@@ -26,6 +26,7 @@ from opta.commands.validate import validate
 from opta.commands.version import version
 from opta.exceptions import UserErrors
 from opta.one_time import one_time
+from opta.pre_check import pre_check
 from opta.upgrade import check_version_upgrade
 from opta.utils import dd_handler, dd_listener, logger
 
@@ -61,6 +62,7 @@ if __name__ == "__main__":
         # However, we should still clean them up before the next command, or
         # else it may interfere with it.
         one_time()
+        pre_check()
         cleanup_files()
         cli()
     except CalledProcessError as e:

--- a/opta/commands/apply.py
+++ b/opta/commands/apply.py
@@ -36,6 +36,7 @@ from opta.core.terraform import Terraform, get_terraform_outputs
 from opta.error_constants import USER_ERROR_TF_LOCK
 from opta.exceptions import MissingState, UserErrors
 from opta.layer import Layer, StructuredConfig
+from opta.pre_check import symlink_check
 from opta.utils import check_opta_file_exists, fmt_msg, is_tool, logger
 
 
@@ -146,6 +147,7 @@ def _apply(
     stdout_logs: bool = True,
     detailed_plan: bool = False,
 ) -> None:
+    symlink_check()
     _check_terraform_version()
     _clean_tf_folder()
     if local:

--- a/opta/commands/destroy.py
+++ b/opta/commands/destroy.py
@@ -17,6 +17,7 @@ from opta.core.terraform import Terraform
 from opta.error_constants import USER_ERROR_TF_LOCK
 from opta.exceptions import UserErrors
 from opta.layer import Layer
+from opta.pre_check import symlink_check
 from opta.utils import check_opta_file_exists, fmt_msg, logger
 
 
@@ -51,6 +52,7 @@ def destroy(
     """
 
     config = check_opta_file_exists(config)
+    symlink_check()
     if local:
         config = _handle_local_flag(config, False)
         _clean_tf_folder()

--- a/opta/pre_check.py
+++ b/opta/pre_check.py
@@ -5,19 +5,23 @@ from opta.exceptions import UserErrors
 from opta.nice_subprocess import nice_run
 
 
-def pre_check() -> None:
+def symlink_check() -> None:
     is_symlink, cwd_path = is_symlinked_path()
     if is_symlink:
         raise UserErrors(
-            f"The current directory seems to be a Symbolic Link.\n"
-            f"Actual Path: {cwd_path}"
+            f"Opta doesn't support running from a Symlinked Directory, "
+            f"and the current directory seems to be a Symbolic Link.\n"
+            f"Please run from a non-Symlinked Directory. "
+            f"Actual Path of current Symlinked Path: {cwd_path}"
         )
 
 
 def is_symlinked_path() -> Tuple[bool, str]:
     pwd_path = (
-        nice_run(["pwd"], capture_output=True, shell=True).stdout.decode("utf-8").strip()
-    )  # nosec
+        nice_run(["pwd"], capture_output=True, shell=True)  # nosec
+        .stdout.decode("utf-8")
+        .strip()
+    )
     cwd_path = os.getcwd()
 
     return pwd_path != cwd_path, cwd_path

--- a/opta/pre_check.py
+++ b/opta/pre_check.py
@@ -17,7 +17,7 @@ def pre_check() -> None:
 def is_symlinked_path() -> Tuple[bool, str]:
     pwd_path = (
         nice_run(["pwd"], capture_output=True, shell=True).stdout.decode("utf-8").strip()
-    )
+    )  # nosec
     cwd_path = os.getcwd()
 
     return pwd_path != cwd_path, cwd_path

--- a/opta/pre_check.py
+++ b/opta/pre_check.py
@@ -15,7 +15,9 @@ def pre_check() -> None:
 
 
 def is_symlinked_path() -> Tuple[bool, str]:
-    pwd_path = nice_run(["pwd"], capture_output=True).stdout.decode("utf-8").strip()
+    pwd_path = (
+        nice_run(["pwd"], capture_output=True, shell=True).stdout.decode("utf-8").strip()
+    )
     cwd_path = os.getcwd()
 
     return pwd_path != cwd_path, cwd_path

--- a/opta/pre_check.py
+++ b/opta/pre_check.py
@@ -1,0 +1,21 @@
+import os
+from typing import Tuple
+
+from opta.exceptions import UserErrors
+from opta.nice_subprocess import nice_run
+
+
+def pre_check() -> None:
+    is_symlink, cwd_path = is_symlinked_path()
+    if is_symlink:
+        raise UserErrors(
+            f"The current directory seems to be a Symbolic Link.\n"
+            f"Actual Path: {cwd_path}"
+        )
+
+
+def is_symlinked_path() -> Tuple[bool, str]:
+    pwd_path = nice_run(["pwd"], capture_output=True).stdout.decode("utf-8").strip()
+    cwd_path = os.getcwd()
+
+    return pwd_path != cwd_path, cwd_path


### PR DESCRIPTION
# Description
Using Opta from Symlink leaves Path calculations haywire. So we will now he issuing an error to the User when using Opta via the Symlinked directories.

# Safety checklist
* [X] This change is backwards compatible and safe to apply by existing users
* [X] This change will NOT lead to data loss
* [X] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
Tested manually on MacOC and Linux machines, to throw an exception when using a Symlinked Directory to run Opta.
