### PR TITLE
Fixing logs/events command

### DIFF
--- a/opta/commands/apply.py
+++ b/opta/commands/apply.py
@@ -1,3 +1,4 @@
+import datetime
 import os
 from pathlib import Path
 from subprocess import CalledProcessError  # nosec
@@ -6,6 +7,7 @@ from typing import Any, Dict, List, Optional, Set
 
 import boto3
 import click
+import pytz
 import semver
 from botocore.config import Config
 from botocore.exceptions import ClientError
@@ -334,13 +336,25 @@ def _apply(
                     )
                     new_thread = Thread(
                         target=tail_module_log,
-                        args=(layer, service_module.name, 10, 2),
+                        args=(
+                            layer,
+                            service_module.name,
+                            10,
+                            datetime.datetime.utcnow().replace(tzinfo=pytz.UTC),
+                            2,
+                        ),
                         daemon=True,
                     )
                     # Tailing events
                     new_thread.start()
                     new_thread = Thread(
-                        target=tail_namespace_events, args=(layer, 0, 1), daemon=True,
+                        target=tail_namespace_events,
+                        args=(
+                            layer,
+                            datetime.datetime.utcnow().replace(tzinfo=pytz.UTC),
+                            1,
+                        ),
+                        daemon=True,
                     )
                     new_thread.start()
 

--- a/opta/commands/events.py
+++ b/opta/commands/events.py
@@ -1,6 +1,8 @@
+import datetime
 from typing import Optional
 
 import click
+import pytz
 from kubernetes.config import load_kube_config
 
 from opta.amplitude import amplitude_client
@@ -33,8 +35,13 @@ def events(env: Optional[str], config: str, seconds: Optional[int]) -> None:
         amplitude_client.SHELL_EVENT,
         event_properties={"org_name": layer.org_name, "layer_name": layer.name},
     )
+    start_time = None
+    if seconds:
+        start_time = pytz.utc.localize(datetime.datetime.min) - datetime.timedelta(
+            seconds=seconds
+        )
     layer.verify_cloud_credentials()
     gen_all(layer)
     configure_kubectl(layer)
     load_kube_config()
-    tail_namespace_events(layer, seconds)
+    tail_namespace_events(layer, start_time)

--- a/tests/commands/test_apply.py
+++ b/tests/commands/test_apply.py
@@ -108,12 +108,14 @@ def test_apply(mocker: MockFixture, mocked_layer: Any, basic_mocks: Any) -> None
         [
             mocker.call(
                 target=tail_module_log,
-                args=(mocked_layer, mocker.ANY, 10, 2),
+                args=(mocked_layer, mocker.ANY, 10, mocker.ANY, 2),
                 daemon=True,
             ),
             mocker.call().start(),
             mocker.call(
-                target=tail_namespace_events, args=(mocked_layer, 0, 1), daemon=True,
+                target=tail_namespace_events,
+                args=(mocked_layer, mocker.ANY, 1),
+                daemon=True,
             ),
             mocker.call().start(),
         ]
@@ -172,12 +174,14 @@ def test_auto_approve(mocker: MockFixture, mocked_layer: Any, basic_mocks: Any) 
         [
             mocker.call(
                 target=tail_module_log,
-                args=(mocked_layer, mocker.ANY, 10, 2),
+                args=(mocked_layer, mocker.ANY, 10, mocker.ANY, 2),
                 daemon=True,
             ),
             mocker.call().start(),
             mocker.call(
-                target=tail_namespace_events, args=(mocked_layer, 0, 1), daemon=True,
+                target=tail_namespace_events,
+                args=(mocked_layer, mocker.ANY, 1),
+                daemon=True,
             ),
             mocker.call().start(),
         ]

--- a/tests/core/test_kubernetes.py
+++ b/tests/core/test_kubernetes.py
@@ -166,7 +166,7 @@ class TestKubernetes:
             "opta.core.kubernetes.Thread", side_effect=[thread_1, thread_2]
         )
 
-        tail_module_log(layer, "mocked_module_name", seconds=3, start_color_idx=2)
+        tail_module_log(layer, "mocked_module_name", since_seconds=3, start_color_idx=2)
         mocked_watch_call.assert_called_once_with()
         mocked_core_v1_api_call.assert_called_once_with()
         mocked_load_kube_config.assert_called_once_with()
@@ -224,7 +224,7 @@ class TestKubernetes:
             "opta.core.kubernetes.Thread", side_effect=[thread_1, thread_2]
         )
 
-        tail_module_log(layer, "mocked_module_name", seconds=3, start_color_idx=2)
+        tail_module_log(layer, "mocked_module_name", since_seconds=3, start_color_idx=2)
         mocked_watch_call.assert_called_once_with()
         mocked_core_v1_api_call.assert_called_once_with()
         mocked_load_kube_config.assert_called_once_with()
@@ -273,14 +273,24 @@ class TestKubernetes:
         mocked_core_v1_api_call.assert_called_once_with()
         mocked_time.sleep.assert_has_calls(
             [
+                mocker.call(0),
                 mocker.call(1),
                 mocker.call(2),
+                mocker.call(3),
                 mocker.call(4),
+                mocker.call(5),
+                mocker.call(6),
+                mocker.call(7),
                 mocker.call(8),
-                mocker.call(16),
+                mocker.call(9),
+                mocker.call(10),
+                mocker.call(11),
+                mocker.call(12),
+                mocker.call(13),
+                mocker.call(14),
             ]
         )
-        assert mocked_time.sleep.call_count == 5
+        assert mocked_time.sleep.call_count == 15
 
         # Tailing should not retry upon encountering a 404 API exception.
         mocked_watch.stream.side_effect = [
@@ -346,8 +356,9 @@ class TestKubernetes:
             ApiException(status=400),
         ]
         mocked_time = mocker.patch("opta.core.kubernetes.time")
+        start_time = datetime.datetime.now(pytz.utc) - datetime.timedelta(seconds=2)
 
-        tail_namespace_events(layer, 2, 3)
+        tail_namespace_events(layer, start_time, 3)
 
         mocked_core_v1_api.list_namespaced_event.assert_called_once_with(
             namespace="mocked_layer"


### PR DESCRIPTION
# Description
So what's happening?
* If someone does opta logs, then they will get all logs for all pods printed to stdout (and color-coded like before)
* Like before (e.g. not changing desired behavior), someone can do opta logs -s X where X is an int and get the logs from up to X seconds ago and going forwards
* If someone does opta events, then they will get all events for their service's namespaces printed to stdout
* Like before (e.g. not changing desired behavior), someone can do opta events -s X where X is an int and get the events from up to X seconds ago and going forwards
* When doing opta apply, the current time is passed into the thread directly  so even in the multithread we will accurately know what are the new events/pods/logs (no race condition possible)
* Nicer log fetching backoff  (used to be exponential base 2 which explains why we sometimes did not see the logs)



# Safety checklist
* [x] This change is backwards compatible and safe to apply by existing users
* [x] This change will NOT lead to data loss
* [x] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
Manual testing
