### PR TITLE
Attempt at stopping opta destroy failures due to  destroyed k8s cluster

### DIFF
--- a/opta/core/terraform.py
+++ b/opta/core/terraform.py
@@ -164,11 +164,12 @@ class Terraform:
     @classmethod
     def destroy_all(cls, layer: "Layer", *tf_flags: str) -> None:
         existing_modules = Terraform.get_existing_modules(layer)
+        targets = list(map(lambda x: f"-target=module.{x}", sorted(existing_modules)))
 
         # Refreshing the state is necessary to update terraform outputs.
         # This includes fetching the latest EKS cluster auth token, which is
         # necessary for destroying many k8s resources.
-        cls.refresh(layer)
+        cls.refresh(layer, *targets)
         kwargs = cls.insert_extra_env(layer)
 
         idx = len(layer.modules) - 1


### PR DESCRIPTION
# Description
The problem is that it's pointless to refresh w/ destroyed outputs. I don't think we need the refresh in the destroy but for now I am only limiting its scope to avoid big changes

# Safety checklist
* [x] This change is backwards compatible and safe to apply by existing users
* [x] This change will NOT lead to data loss
* [x] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
@NitinAgg could you help with this?
