### PR TITLE
Fix issues with multiple ports

### DIFF
--- a/config/opta-k8s-service-helm/templates/service.yaml
+++ b/config/opta-k8s-service-helm/templates/service.yaml
@@ -15,7 +15,7 @@ metadata:
 spec:
   ports:
     {{- range $portSpec := .Values.ports }}
-    - port: {{ $portSpec.port }}
+    - port: {{ $portSpec.servicePort }}
       targetPort: {{ $portSpec.name | quote }}
       name: {{ $portSpec.name | quote }}
       protocol: TCP

--- a/config/registry/aws/modules/aws-k8s-service.yaml
+++ b/config/registry/aws/modules/aws-k8s-service.yaml
@@ -196,6 +196,7 @@ extra_validators:
     http: int(required=False)
     tcp: int(required=False)
     grpc: int(required=False)
+    websocket: int(required=False)
 outputs:
   - name: docker_repo_url
     export: true

--- a/config/registry/aws/modules/aws-k8s-service.yaml
+++ b/config/registry/aws/modules/aws-k8s-service.yaml
@@ -191,6 +191,7 @@ extra_validators:
     name: regex('^[a-z0-9-]+$', name='valid service name')
     type: regex('^(http|tcp)$', name='http or tcp')
     port: int(min=1, max=65535)
+    service_port: int(min=1, max=65535, required=False)
     protocol: regex('^(grpc|websocket)$', name='grpc or websocket', required=False)
   service_port:
     http: int(required=False)

--- a/config/registry/azurerm/modules/azure-k8s-service.yaml
+++ b/config/registry/azurerm/modules/azure-k8s-service.yaml
@@ -171,6 +171,7 @@ extra_validators:
     name: regex('^[a-z0-9-]+$', name='valid service name')
     type: regex('^(http|tcp)$', name='http or tcp')
     port: int(min=1, max=65535)
+    service_port: int(min=1, max=65535, required=False)
     protocol: regex('^(grpc|websocket)$', name='grpc or websocket', required=False)
   service_port:
     http: int(required=False)

--- a/config/registry/google/modules/gcp-k8s-service.yaml
+++ b/config/registry/google/modules/gcp-k8s-service.yaml
@@ -180,6 +180,7 @@ extra_validators:
     name: regex('^[a-z0-9-]+$', name='valid service name')
     type: regex('^(http|tcp)$', name='http or tcp')
     port: int(min=1, max=65535)
+    service_port: int(min=1, max=65535, required=False)
     protocol: regex('^(grpc|websocket)$', name='grpc or websocket', required=False)
   service_port:
     http: int(required=False)

--- a/config/registry/local/modules/local-k8s-service.yaml
+++ b/config/registry/local/modules/local-k8s-service.yaml
@@ -162,6 +162,7 @@ extra_validators:
     name: regex('^[a-z0-9-]+$', name='valid service name')
     type: regex('^(http|tcp)$', name='http or tcp')
     port: int(min=1, max=65535)
+    service_port: int(min=1, max=65535, required=False)
     protocol: regex('^(grpc|websocket)$', name='grpc or websocket', required=False)
   service_port:
     http: int(required=False)

--- a/opta/module_processors/base.py
+++ b/opta/module_processors/base.py
@@ -264,7 +264,6 @@ class K8sServiceModuleProcessor(ModuleProcessor):
         port_mapping = {port.port: port.name for port in ports if port.is_tcp}
 
         if not port_mapping:
-            logger.debug("no tcp ports")
             return {}
 
         return {


### PR DESCRIPTION
# Description
- Fix that `port.websocket` does not pass validation, even though we support the conversion in Python.
- Add `service_port` field

# Safety checklist
* [x] This change is backwards compatible and safe to apply by existing users
* [x] This change will NOT lead to data loss
* [x] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
Manual
