### PR TITLE
Fix missing request for memory errors

### DIFF
--- a/config/opta-k8s-service-helm/templates/deployment.yaml
+++ b/config/opta-k8s-service-helm/templates/deployment.yaml
@@ -26,6 +26,11 @@ spec:
         ad.datadoghq.com/linkerd-proxy.check_names: '["linkerd"]'
         ad.datadoghq.com/linkerd-proxy.init_configs: '[{}]'
         ad.datadoghq.com/linkerd-proxy.instances: '[{"prometheus_url": "http://%%host%%:4191/metrics"}]'
+        # See https://linkerd.io/2021/05/27/linkerd-vs-istio-benchmarks/
+        config.linkerd.io/proxy-cpu-limit: "0.1"
+        config.linkerd.io/proxy-cpu-request: "0.05"
+        config.linkerd.io/proxy-memory-limit: "20Mi"
+        config.linkerd.io/proxy-memory-request: "10Mi"
     spec:
       serviceAccountName: {{ include "k8s-service.serviceAccountName" . }}
       containers:

--- a/config/opta-k8s-service-helm/templates/statefulset.yaml
+++ b/config/opta-k8s-service-helm/templates/statefulset.yaml
@@ -38,6 +38,11 @@ spec:
         ad.datadoghq.com/linkerd-proxy.check_names: '["linkerd"]'
         ad.datadoghq.com/linkerd-proxy.init_configs: '[{}]'
         ad.datadoghq.com/linkerd-proxy.instances: '[{"prometheus_url": "http://%%host%%:4191/metrics"}]'
+        # See https://linkerd.io/2021/05/27/linkerd-vs-istio-benchmarks/
+        config.linkerd.io/proxy-cpu-limit: "0.1"
+        config.linkerd.io/proxy-cpu-request: "0.05"
+        config.linkerd.io/proxy-memory-limit: "20Mi"
+        config.linkerd.io/proxy-memory-request: "10Mi"
     spec:
       serviceAccountName: {{ include "k8s-service.serviceAccountName" . }}
       containers:


### PR DESCRIPTION
# Description
kubectl events was being filled with "Namespace foobar event: missing request for memory errors"
This was due to the fact that the linkerd sidecars did not have resource requests/limitations set making the horizontal pod autoscaler complain.

This pr fixes it by adding the necessary annotations for cpu/memory requests/limits for the sidecar.



# Safety checklist
* [x] This change is backwards compatible and safe to apply by existing users
* [x] This change will NOT lead to data loss
* [x] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
manually run
