### PR TITLE
Added missing storage bucket get role need for gcs

### DIFF
--- a/config/tf_modules/gcp-k8s-service/iam.tf
+++ b/config/tf_modules/gcp-k8s-service/iam.tf
@@ -12,10 +12,10 @@ resource "google_service_account_iam_binding" "trust_k8s_workload_idu" {
 }
 
 resource "google_storage_bucket_iam_member" "bucket_get" {
-  count  = length(local.get_buckets)
-  bucket = local.get_buckets[count.index]
-  role   = "roles/storage.legacyBucketReader"
-  member = "serviceAccount:${google_service_account.k8s_service.email}"
+  for_each = local.get_buckets
+  bucket   = each.key
+  role     = "roles/storage.legacyBucketReader"
+  member   = "serviceAccount:${google_service_account.k8s_service.email}"
 }
 
 resource "google_storage_bucket_iam_member" "bucket_viewer" {

--- a/config/tf_modules/gcp-k8s-service/iam.tf
+++ b/config/tf_modules/gcp-k8s-service/iam.tf
@@ -11,6 +11,13 @@ resource "google_service_account_iam_binding" "trust_k8s_workload_idu" {
   ]
 }
 
+resource "google_storage_bucket_iam_member" "bucket_get" {
+  count  = length(local.get_buckets)
+  bucket = local.get_buckets[count.index]
+  role   = "roles/storage.legacyBucketReader"
+  member = "serviceAccount:${google_service_account.k8s_service.email}"
+}
+
 resource "google_storage_bucket_iam_member" "bucket_viewer" {
   count  = length(var.read_buckets)
   bucket = var.read_buckets[count.index]

--- a/config/tf_modules/gcp-k8s-service/variables.tf
+++ b/config/tf_modules/gcp-k8s-service/variables.tf
@@ -12,7 +12,7 @@ locals {
   env_short       = substr(var.env_name, 0, 9)
   layer_short     = substr(var.layer_name, 0, 9)
   module_short    = substr(var.module_name, 0, 9)
-  get_buckets  = concat(var.read_buckets, var.write_buckets)
+  get_buckets     = concat(var.read_buckets, var.write_buckets)
   uppercase_image = upper(var.image)
 }
 

--- a/config/tf_modules/gcp-k8s-service/variables.tf
+++ b/config/tf_modules/gcp-k8s-service/variables.tf
@@ -12,7 +12,7 @@ locals {
   env_short       = substr(var.env_name, 0, 9)
   layer_short     = substr(var.layer_name, 0, 9)
   module_short    = substr(var.module_name, 0, 9)
-  get_buckets     = concat(var.read_buckets, var.write_buckets)
+  get_buckets     = toset(concat(var.read_buckets, var.write_buckets))
   uppercase_image = upper(var.image)
 }
 

--- a/config/tf_modules/gcp-k8s-service/variables.tf
+++ b/config/tf_modules/gcp-k8s-service/variables.tf
@@ -12,6 +12,7 @@ locals {
   env_short       = substr(var.env_name, 0, 9)
   layer_short     = substr(var.layer_name, 0, 9)
   module_short    = substr(var.module_name, 0, 9)
+  get_buckets  = concat(var.read_buckets, var.write_buckets)
   uppercase_image = upper(var.image)
 }
 

--- a/config/tf_modules/gcp-service-account/main.tf
+++ b/config/tf_modules/gcp-service-account/main.tf
@@ -12,10 +12,10 @@ resource "google_service_account_iam_binding" "trust_k8s_workload_idu" {
 }
 
 resource "google_storage_bucket_iam_member" "bucket_get" {
-  count  = length(local.get_buckets)
-  bucket = local.get_buckets[count.index]
-  role   = "roles/storage.legacyBucketReader"
-  member = "serviceAccount:${google_service_account.k8s_service.email}"
+  for_each = local.get_buckets
+  bucket   = each.key
+  role     = "roles/storage.legacyBucketReader"
+  member   = "serviceAccount:${google_service_account.k8s_service.email}"
 }
 
 resource "google_storage_bucket_iam_member" "bucket_viewer" {

--- a/config/tf_modules/gcp-service-account/main.tf
+++ b/config/tf_modules/gcp-service-account/main.tf
@@ -11,6 +11,13 @@ resource "google_service_account_iam_binding" "trust_k8s_workload_idu" {
 
 }
 
+resource "google_storage_bucket_iam_member" "bucket_get" {
+  count  = length(local.get_buckets)
+  bucket = local.get_buckets[count.index]
+  role   = "roles/storage.legacyBucketReader"
+  member = "serviceAccount:${google_service_account.k8s_service.email}"
+}
+
 resource "google_storage_bucket_iam_member" "bucket_viewer" {
   count  = length(var.read_buckets)
   bucket = var.read_buckets[count.index]

--- a/config/tf_modules/gcp-service-account/variables.tf
+++ b/config/tf_modules/gcp-service-account/variables.tf
@@ -6,6 +6,7 @@ locals {
   env_short    = substr(replace(var.env_name, "-", ""), 0, 9)
   layer_short  = substr(replace(var.layer_name, "-", ""), 0, 9)
   module_short = substr(replace(var.module_name, "-", ""), 0, 9)
+  get_buckets = concat(var.read_buckets, var.write_buckets)
 }
 
 variable "env_name" {

--- a/config/tf_modules/gcp-service-account/variables.tf
+++ b/config/tf_modules/gcp-service-account/variables.tf
@@ -6,7 +6,7 @@ locals {
   env_short    = substr(replace(var.env_name, "-", ""), 0, 9)
   layer_short  = substr(replace(var.layer_name, "-", ""), 0, 9)
   module_short = substr(replace(var.module_name, "-", ""), 0, 9)
-  get_buckets  = concat(var.read_buckets, var.write_buckets)
+  get_buckets  = toset(concat(var.read_buckets, var.write_buckets))
 }
 
 variable "env_name" {

--- a/config/tf_modules/gcp-service-account/variables.tf
+++ b/config/tf_modules/gcp-service-account/variables.tf
@@ -6,7 +6,7 @@ locals {
   env_short    = substr(replace(var.env_name, "-", ""), 0, 9)
   layer_short  = substr(replace(var.layer_name, "-", ""), 0, 9)
   module_short = substr(replace(var.module_name, "-", ""), 0, 9)
-  get_buckets = concat(var.read_buckets, var.write_buckets)
+  get_buckets  = concat(var.read_buckets, var.write_buckets)
 }
 
 variable "env_name" {


### PR DESCRIPTION
# Description
If you can read/write to buckets you ought to be able to "get" the buckets (i.e. their metadata).

Needed for flyte gcp


# Safety checklist
* [x] This change is backwards compatible and safe to apply by existing users
* [x] This change will NOT lead to data loss
* [x] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
Deployed flyte to gcp, had Haytham and Prafulla confirm it worked
