### PR TITLE
Check for local PATH dependencies before running a layer

### DIFF
--- a/opta/commands/apply.py
+++ b/opta/commands/apply.py
@@ -11,17 +11,10 @@ import pytz
 import semver
 from botocore.config import Config
 from botocore.exceptions import ClientError
-from packaging import version
 
 from opta.amplitude import amplitude_client
 from opta.commands.local_flag import _clean_tf_folder, _handle_local_flag
-from opta.constants import (
-    DEV_VERSION,
-    MAX_TERRAFORM_VERSION,
-    MIN_TERRAFORM_VERSION,
-    TF_PLAN_PATH,
-    VERSION,
-)
+from opta.constants import DEV_VERSION, TF_PLAN_PATH, VERSION
 from opta.core.aws import AWS
 from opta.core.azure import Azure
 from opta.core.gcp import GCP
@@ -39,8 +32,8 @@ from opta.core.terraform import Terraform, get_terraform_outputs
 from opta.error_constants import USER_ERROR_TF_LOCK
 from opta.exceptions import MissingState, UserErrors
 from opta.layer import Layer, StructuredConfig
-from opta.pre_check import symlink_check
-from opta.utils import check_opta_file_exists, fmt_msg, is_tool, logger
+from opta.pre_check import dependency_check, symlink_check
+from opta.utils import check_opta_file_exists, fmt_msg, logger
 
 
 @click.command()
@@ -124,20 +117,6 @@ def apply(
     )
 
 
-def _check_terraform_version() -> None:
-    if not is_tool("terraform"):
-        raise UserErrors("Please install terraform on your machine")
-    current_version = Terraform.get_version()
-    if version.parse(current_version) < version.parse(MIN_TERRAFORM_VERSION):
-        raise UserErrors(
-            f"Invalid terraform version {current_version}-- must be at least {MIN_TERRAFORM_VERSION}"
-        )
-    if version.parse(current_version) >= version.parse(MAX_TERRAFORM_VERSION):
-        raise UserErrors(
-            f"Invalid terraform version {current_version}-- must be less than  {MAX_TERRAFORM_VERSION}"
-        )
-
-
 def _apply(
     config: str,
     env: Optional[str],
@@ -151,7 +130,7 @@ def _apply(
     detailed_plan: bool = False,
 ) -> None:
     symlink_check()
-    _check_terraform_version()
+    dependency_check()
     _clean_tf_folder()
     if local:
         adjusted_config = _handle_local_flag(config, test)
@@ -174,6 +153,7 @@ def _apply(
 
     layer = Layer.load_from_yaml(config, env)
     layer.verify_cloud_credentials()
+    layer.validate_required_path_dependencies()
 
     if Terraform.download_state(layer):
         tf_lock_exists, _ = Terraform.tf_lock_details(layer)

--- a/opta/commands/apply.py
+++ b/opta/commands/apply.py
@@ -32,7 +32,7 @@ from opta.core.terraform import Terraform, get_terraform_outputs
 from opta.error_constants import USER_ERROR_TF_LOCK
 from opta.exceptions import MissingState, UserErrors
 from opta.layer import Layer, StructuredConfig
-from opta.pre_check import dependency_check, symlink_check
+from opta.pre_check import pre_check
 from opta.utils import check_opta_file_exists, fmt_msg, logger
 
 
@@ -129,8 +129,7 @@ def _apply(
     stdout_logs: bool = True,
     detailed_plan: bool = False,
 ) -> None:
-    symlink_check()
-    dependency_check()
+    pre_check()
     _clean_tf_folder()
     if local:
         adjusted_config = _handle_local_flag(config, test)

--- a/opta/commands/deploy.py
+++ b/opta/commands/deploy.py
@@ -110,6 +110,7 @@ def deploy(
         event_properties={"org_name": layer.org_name, "layer_name": layer.name},
     )
     layer.verify_cloud_credentials()
+    layer.validate_required_path_dependencies()
     if Terraform.download_state(layer):
         tf_lock_exists, _ = Terraform.tf_lock_details(layer)
         if tf_lock_exists:

--- a/opta/commands/deploy.py
+++ b/opta/commands/deploy.py
@@ -12,6 +12,7 @@ from opta.core.terraform import Terraform
 from opta.error_constants import USER_ERROR_TF_LOCK
 from opta.exceptions import MissingState, UserErrors
 from opta.layer import Layer
+from opta.pre_check import pre_check
 from opta.utils import check_opta_file_exists, fmt_msg, logger
 
 
@@ -70,6 +71,8 @@ def deploy(
     opta deploy -c my_config.yaml -i my_container:latest --local
 
     """
+
+    pre_check()
 
     config = check_opta_file_exists(config)
     if not is_service_config(config):

--- a/opta/commands/destroy.py
+++ b/opta/commands/destroy.py
@@ -60,6 +60,7 @@ def destroy(
         amplitude_client.DESTROY_EVENT, event_properties=event_properties,
     )
     layer.verify_cloud_credentials()
+    layer.validate_required_path_dependencies()
     if not Terraform.download_state(layer):
         logger.info(
             "The opta state could not be found. This may happen if destroy ran successfully before."

--- a/opta/commands/destroy.py
+++ b/opta/commands/destroy.py
@@ -17,6 +17,7 @@ from opta.core.terraform import Terraform
 from opta.error_constants import USER_ERROR_TF_LOCK
 from opta.exceptions import UserErrors
 from opta.layer import Layer
+from opta.pre_check import pre_check
 from opta.utils import check_opta_file_exists, fmt_msg, logger
 
 
@@ -49,6 +50,8 @@ def destroy(
 
     opta destroy -c my_config.yaml --auto-approve
     """
+
+    pre_check()
 
     config = check_opta_file_exists(config)
     if local:

--- a/opta/commands/inspect_cmd.py
+++ b/opta/commands/inspect_cmd.py
@@ -7,8 +7,9 @@ from opta.constants import TF_FILE_PATH
 from opta.core.generator import gen_all
 from opta.core.terraform import fetch_terraform_state_resources
 from opta.layer import Layer
+from opta.pre_check import pre_check
 from opta.resource import Resource
-from opta.utils import check_opta_file_exists, column_print, deep_merge, is_tool, json
+from opta.utils import check_opta_file_exists, column_print, deep_merge, json
 
 
 @click.command(hidden=True)
@@ -20,6 +21,8 @@ from opta.utils import check_opta_file_exists, column_print, deep_merge, is_tool
 )
 def inspect(config: str, env: Optional[str]) -> None:
     """ Displays important resources and AWS/Datadog links to them """
+
+    pre_check()
 
     config = check_opta_file_exists(config)
     layer = Layer.load_from_yaml(config, env)
@@ -39,10 +42,6 @@ class InspectCommand:
         self.terraform_state = fetch_terraform_state_resources(self.layer)
 
     def run(self) -> None:
-        # Make sure the user has the prerequisite CLI tools installed
-        if not is_tool("terraform"):
-            raise Exception("Please install terraform on your machine")
-
         inspect_details = []
         target_resources = self._get_opta_config_terraform_resources()
         for resource in target_resources:

--- a/opta/commands/push.py
+++ b/opta/commands/push.py
@@ -14,9 +14,7 @@ from opta.exceptions import UserErrors
 from opta.layer import Layer
 from opta.nice_subprocess import nice_run
 from opta.utils import check_opta_file_exists, fmt_msg, yaml
-from opta.utils.dependencies import ensure_installed, register_path_executable
-
-register_path_executable("docker")
+from opta.utils.dependencies import ensure_installed
 
 
 def get_push_tag(local_image: str, tag_override: Optional[str]) -> str:

--- a/opta/commands/push.py
+++ b/opta/commands/push.py
@@ -13,7 +13,10 @@ from opta.core.terraform import get_terraform_outputs
 from opta.exceptions import UserErrors
 from opta.layer import Layer
 from opta.nice_subprocess import nice_run
-from opta.utils import check_opta_file_exists, fmt_msg, is_tool, yaml
+from opta.utils import check_opta_file_exists, fmt_msg, yaml
+from opta.utils.dependencies import ensure_installed, register_path_executable
+
+register_path_executable("docker")
 
 
 def get_push_tag(local_image: str, tag_override: Optional[str]) -> str:
@@ -175,8 +178,7 @@ def push(image: str, config: str, env: Optional[str], tag: Optional[str]) -> Non
 def _push(
     image: str, config: str, env: Optional[str], tag: Optional[str]
 ) -> Tuple[str, str]:
-    if not is_tool("docker"):
-        raise Exception("Please install docker on your machine")
+    ensure_installed("docker")
     layer = Layer.load_from_yaml(config, env)
     amplitude_client.send_event(
         amplitude_client.PUSH_EVENT,

--- a/opta/core/helm.py
+++ b/opta/core/helm.py
@@ -1,11 +1,18 @@
 from subprocess import CalledProcessError  # nosec
-from typing import List
+from typing import FrozenSet, List
 
 from opta.exceptions import UserErrors
 from opta.nice_subprocess import nice_run
 from opta.utils import is_tool, json
+from opta.utils.dependencies import register_path_executable
 
 HELM_INSTALL_URL = "https://helm.sh/docs/intro/install/"
+
+register_path_executable("helm", install_url=HELM_INSTALL_URL)
+
+
+def get_required_path_executables() -> FrozenSet[str]:
+    return frozenset({"helm"})
 
 
 def helm_check() -> None:

--- a/opta/core/helm.py
+++ b/opta/core/helm.py
@@ -4,11 +4,7 @@ from typing import FrozenSet, List
 from opta.exceptions import UserErrors
 from opta.nice_subprocess import nice_run
 from opta.utils import json
-from opta.utils.dependencies import ensure_installed, register_path_executable
-
-HELM_INSTALL_URL = "https://helm.sh/docs/intro/install/"
-
-register_path_executable("helm", install_url=HELM_INSTALL_URL)
+from opta.utils.dependencies import ensure_installed
 
 
 class Helm:

--- a/opta/core/helm.py
+++ b/opta/core/helm.py
@@ -3,29 +3,26 @@ from typing import FrozenSet, List
 
 from opta.exceptions import UserErrors
 from opta.nice_subprocess import nice_run
-from opta.utils import is_tool, json
-from opta.utils.dependencies import register_path_executable
+from opta.utils import json
+from opta.utils.dependencies import ensure_installed, register_path_executable
 
 HELM_INSTALL_URL = "https://helm.sh/docs/intro/install/"
 
 register_path_executable("helm", install_url=HELM_INSTALL_URL)
 
 
-def get_required_path_executables() -> FrozenSet[str]:
-    return frozenset({"helm"})
-
-
-def helm_check() -> None:
-    if not is_tool("helm"):
-        raise UserErrors(
-            f"Please visit this link to install helm first: {HELM_INSTALL_URL}"
-        )
-
-
 class Helm:
+    @staticmethod
+    def get_required_path_executables() -> FrozenSet[str]:
+        return frozenset({"helm"})
+
+    @staticmethod
+    def validate_helm_installed() -> None:
+        ensure_installed("helm")
+
     @classmethod
     def rollback_helm(cls, release: str, namespace: str, revision: str = "") -> None:
-        helm_check()
+        cls.validate_helm_installed()
         try:
             if revision == "1":
                 nice_run(
@@ -47,7 +44,7 @@ class Helm:
 
     @classmethod
     def get_helm_list(cls, **kwargs) -> List:  # type: ignore # nosec
-        helm_check()
+        cls.validate_helm_installed()
         namespaces: List[str] = []
         if kwargs.get("namespace") is not None:
             namespaces.append("--namespace")

--- a/opta/core/kubernetes.py
+++ b/opta/core/kubernetes.py
@@ -58,7 +58,7 @@ def get_required_path_executables(cloud: str) -> FrozenSet[str]:
         "azurerm": {"az"},
     }
 
-    return frozenset("kubectl") | exec_map.get(cloud, set())
+    return frozenset({"kubectl"}) | exec_map.get(cloud, set())
 
 
 def configure_kubectl(layer: "Layer") -> None:

--- a/opta/core/kubernetes.py
+++ b/opta/core/kubernetes.py
@@ -2,7 +2,7 @@ import base64
 import datetime
 import time
 from threading import Thread
-from typing import TYPE_CHECKING, Dict, List, Optional, Set, Tuple
+from typing import TYPE_CHECKING, Dict, FrozenSet, List, Optional, Set, Tuple
 
 import boto3
 from botocore.exceptions import ClientError, NoCredentialsError
@@ -32,6 +32,7 @@ from opta.core.terraform import get_terraform_outputs
 from opta.exceptions import UserErrors
 from opta.nice_subprocess import nice_run
 from opta.utils import deep_merge, fmt_msg, is_tool, logger
+from opta.utils.dependencies import register_path_executable
 
 if TYPE_CHECKING:
     from opta.layer import Layer
@@ -42,6 +43,22 @@ AWS_CLI_INSTALL_URL = (
     "https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html"
 )
 GCP_CLI_INSTALL_URL = "https://cloud.google.com/sdk/docs/install"
+
+
+register_path_executable("kubectl", install_url=KUBECTL_INSTALL_URL)
+register_path_executable("aws", install_url=AWS_CLI_INSTALL_URL)
+register_path_executable("gcloud", install_url=GCP_CLI_INSTALL_URL)
+register_path_executable("az")
+
+
+def get_required_path_executables(cloud: str) -> FrozenSet[str]:
+    exec_map = {
+        "aws": {"aws"},
+        "google": {"gcloud"},
+        "azurerm": {"az"},
+    }
+
+    return frozenset("kubectl") | exec_map.get(cloud, set())
 
 
 def configure_kubectl(layer: "Layer") -> None:

--- a/opta/core/kubernetes.py
+++ b/opta/core/kubernetes.py
@@ -32,23 +32,10 @@ from opta.core.terraform import get_terraform_outputs
 from opta.exceptions import UserErrors
 from opta.nice_subprocess import nice_run
 from opta.utils import deep_merge, fmt_msg, logger
-from opta.utils.dependencies import ensure_installed, register_path_executable
+from opta.utils.dependencies import ensure_installed
 
 if TYPE_CHECKING:
     from opta.layer import Layer
-
-
-KUBECTL_INSTALL_URL = "https://kubernetes.io/docs/tasks/tools/install-kubectl-macos/"
-AWS_CLI_INSTALL_URL = (
-    "https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html"
-)
-GCP_CLI_INSTALL_URL = "https://cloud.google.com/sdk/docs/install"
-
-
-register_path_executable("kubectl", install_url=KUBECTL_INSTALL_URL)
-register_path_executable("aws", install_url=AWS_CLI_INSTALL_URL)
-register_path_executable("gcloud", install_url=GCP_CLI_INSTALL_URL)
-register_path_executable("az")
 
 
 def get_required_path_executables(cloud: str) -> FrozenSet[str]:

--- a/opta/core/terraform.py
+++ b/opta/core/terraform.py
@@ -35,8 +35,8 @@ from opta.core.gcp import GCP
 from opta.core.local import Local
 from opta.exceptions import MissingState, UserErrors
 from opta.nice_subprocess import nice_run
-from opta.utils import deep_merge, fmt_msg, is_tool, json, logger
-from opta.utils.dependencies import register_path_executable
+from opta.utils import deep_merge, fmt_msg, json, logger
+from opta.utils.dependencies import ensure_installed, register_path_executable
 
 if TYPE_CHECKING:
     from opta.layer import Layer
@@ -100,8 +100,7 @@ class Terraform:
 
     @classmethod
     def validate_version(cls) -> None:
-        if not is_tool("terraform"):
-            raise UserErrors("Please install terraform on your machine")
+        ensure_installed("terraform")
 
         current_version = Terraform.get_version()
         current_parsed = version.parse(current_version)

--- a/opta/core/terraform.py
+++ b/opta/core/terraform.py
@@ -36,16 +36,14 @@ from opta.core.local import Local
 from opta.exceptions import MissingState, UserErrors
 from opta.nice_subprocess import nice_run
 from opta.utils import deep_merge, fmt_msg, json, logger
-from opta.utils.dependencies import ensure_installed, register_path_executable
+from opta.utils.dependencies import ensure_installed
 
 if TYPE_CHECKING:
     from opta.layer import Layer
+
 EXTRA_ENV = (
     {"KUBE_CONFIG_PATH": "~/.kube/config"} if os.path.isfile("~/.kube/config") else {}
 )
-
-
-register_path_executable("terraform")
 
 
 class Terraform:

--- a/opta/layer.py
+++ b/opta/layer.py
@@ -9,7 +9,18 @@ from datetime import datetime
 from os import path
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any, Dict, Iterable, List, Optional, Set, Tuple, Type, TypedDict
+from typing import (
+    Any,
+    Dict,
+    FrozenSet,
+    Iterable,
+    List,
+    Optional,
+    Set,
+    Tuple,
+    Type,
+    TypedDict,
+)
 
 import boto3
 import click
@@ -58,6 +69,7 @@ from opta.module_processors.local_k8s_service import LocalK8sServiceProcessor
 from opta.module_processors.runx import RunxProcessor
 from opta.plugins.derived_providers import DerivedProviders
 from opta.utils import deep_merge, hydrate, logger, yaml
+from opta.utils.dependencies import validate_installed_path_executables
 
 
 class StructuredConfig(TypedDict):
@@ -141,7 +153,7 @@ class Layer:
         else:
             raise UserErrors("No cloud provider (AWS, GCP, or Azure) found")
         self.variables = variables or {}
-        self.modules = []
+        self.modules: List[Module] = []
         for module_data in modules_data:
             self.modules.append(Module(self, module_data, self.parent,))
         module_names: set = set()
@@ -339,6 +351,18 @@ class Layer:
                 return module
         return None
 
+    def get_required_path_dependencies(self) -> FrozenSet[str]:
+        deps: Set[str] = set()
+        for module in self.modules:
+            module_deps = self.processor_for(module).required_path_dependencies
+            deps |= module_deps
+
+        return frozenset(deps)
+
+    def validate_required_path_dependencies(self) -> None:
+        deps = self.get_required_path_dependencies()
+        validate_installed_path_executables(deps)
+
     def get_module_by_type(
         self, module_type: str, module_idx: Optional[int] = None
     ) -> list[Module]:
@@ -359,9 +383,8 @@ class Layer:
     def gen_tf(self, module_idx: int) -> Dict[Any, Any]:
         ret: Dict[Any, Any] = {}
         for module in self.modules[0 : module_idx + 1]:
-            module_type = module.aliased_type or module.type
-            processor = self.PROCESSOR_DICT.get(module_type, ModuleProcessor)
-            processor(module, self).process(module_idx)
+            self.processor_for(module).process(module_idx)
+
         if self.parent is not None and self.parent.get_module("runx") is not None:
             RunxProcessor(self.parent.get_module("runx"), self).process(  # type:ignore
                 module_idx
@@ -388,9 +411,8 @@ class Layer:
 
     def pre_hook(self, module_idx: int) -> None:
         for module in self.modules[0 : module_idx + 1]:
-            module_type = module.aliased_type or module.type
-            processor = self.PROCESSOR_DICT.get(module_type, ModuleProcessor)
-            processor(module, self).pre_hook(module_idx)
+            self.processor_for(module).pre_hook(module_idx)
+
         if self.parent is not None and self.parent.get_module("runx") is not None:
             RunxProcessor(self.parent.get_module("runx"), self).pre_hook(  # type:ignore
                 module_idx
@@ -398,9 +420,8 @@ class Layer:
 
     def post_hook(self, module_idx: int, exception: Optional[Exception]) -> None:
         for module in self.modules[0 : module_idx + 1]:
-            module_type = module.aliased_type or module.type
-            processor = self.PROCESSOR_DICT.get(module_type, ModuleProcessor)
-            processor(module, self).post_hook(module_idx, exception)
+            self.processor_for(module).post_hook(module_idx, exception)
+
         if self.parent is not None and self.parent.get_module("runx") is not None:
             RunxProcessor(self.parent.get_module("runx"), self).post_hook(  # type:ignore
                 module_idx, exception
@@ -409,9 +430,12 @@ class Layer:
     def post_delete(self, module_idx: int) -> None:
         module = self.modules[module_idx]
         logger.debug(f"Running post delete for module {module.name}")
+        self.processor_for(module).post_delete(module_idx)
+
+    def processor_for(self, module: Module) -> ModuleProcessor:
         module_type = module.aliased_type or module.type
-        processor = self.PROCESSOR_DICT.get(module_type, ModuleProcessor)
-        processor(module, self).post_delete(module_idx)
+        processor_class = self.PROCESSOR_DICT.get(module_type, ModuleProcessor)
+        return processor_class(module, self)
 
     def metadata_hydration(self) -> Dict[Any, Any]:
         parent_name = self.parent.name if self.parent is not None else "nil"
@@ -437,9 +461,7 @@ class Layer:
     def get_event_properties(self) -> Dict[str, Any]:
         current_keys: Dict[str, Any] = {}
         for module in self.modules:
-            module_type = module.aliased_type or module.type
-            processor = self.PROCESSOR_DICT.get(module_type, ModuleProcessor)
-            new_keys = processor(module, self).get_event_properties()
+            new_keys = self.processor_for(module).get_event_properties()
             for key, val in new_keys.items():
                 current_keys[key] = current_keys.get(key, 0) + val
         current_keys["total_resources"] = sum([x for x in current_keys.values()])

--- a/opta/module_processors/helm_chart.py
+++ b/opta/module_processors/helm_chart.py
@@ -1,8 +1,9 @@
 import os
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, FrozenSet
 
 from ruamel.yaml.compat import StringIO
 
+from opta.core.helm import Helm
 from opta.exceptions import UserErrors
 from opta.module_processors.base import ModuleProcessor
 from opta.utils import logger, yaml
@@ -19,6 +20,10 @@ class HelmChartProcessor(ModuleProcessor):
                 f"The module {module.name} was expected to be of type k8s service"
             )
         super(HelmChartProcessor, self).__init__(module, layer)
+
+    @property
+    def required_path_dependencies(self) -> FrozenSet[str]:
+        return super().required_path_dependencies | Helm.get_required_path_executables()
 
     def process(self, module_idx: int) -> None:
         if "repository" in self.module.data and "chart_version" not in self.module.data:

--- a/opta/pre_check.py
+++ b/opta/pre_check.py
@@ -11,6 +11,11 @@ def dependency_check() -> None:
     Terraform.validate_version()
 
 
+def pre_check() -> None:
+    symlink_check()
+    dependency_check()
+
+
 def symlink_check() -> None:
     is_symlink, cwd_path = is_symlinked_path()
     if is_symlink:

--- a/opta/pre_check.py
+++ b/opta/pre_check.py
@@ -1,8 +1,14 @@
 import os
 from typing import Tuple
 
+from opta.core.terraform import Terraform
 from opta.exceptions import UserErrors
 from opta.nice_subprocess import nice_run
+
+
+def dependency_check() -> None:
+    """Check dependencies that are required globally"""
+    Terraform.validate_version()
 
 
 def symlink_check() -> None:

--- a/opta/utils/dependencies.py
+++ b/opta/utils/dependencies.py
@@ -9,6 +9,13 @@ _registered_path_executables: Dict[str, Optional[str]] = {}
 StringSetOrFrozen = Union[Set[str], FrozenSet[str]]
 
 
+def ensure_installed(*names: str) -> None:
+    """
+    Convienince function to make calling validate_installed_path_executables easier with hardcoded names (using the `fozenset({"name"})` syntax isn't required).
+    """
+    validate_installed_path_executables(frozenset(names))
+
+
 def get_missing_path_executables(names: StringSetOrFrozen) -> Dict[str, Optional[str]]:
     """
     Returns a dict whose keys are executables missing from the PATH, limited to `names`.

--- a/opta/utils/dependencies.py
+++ b/opta/utils/dependencies.py
@@ -1,0 +1,56 @@
+from typing import Dict, FrozenSet, Optional, Set, Union
+
+from opta.exceptions import UserErrors
+from opta.utils import is_tool
+
+_registered_path_executables: Dict[str, Optional[str]] = {}
+
+# TODO: In python 3.9+, switch to using collections.abc.Set
+StringSetOrFrozen = Union[Set[str], FrozenSet[str]]
+
+
+def get_missing_path_executables(names: StringSetOrFrozen) -> Dict[str, Optional[str]]:
+    """
+    Returns a dict whose keys are executables missing from the PATH, limited to `names`.
+    The dict value, if not None, is the URL to the install page for that tool.
+    """
+    missing: Dict[str, Optional[str]] = {}
+
+    for name in names:
+        if is_tool(name):
+            continue
+
+        try:
+            missing[name] = _registered_path_executables[name]
+        except KeyError:
+            raise ValueError(f"{name} is not a registered path executable")
+
+    return missing
+
+
+def register_path_executable(name: str, *, install_url: Optional[str] = None) -> None:
+    """
+    Registers an executable for later use in dependency checks.
+    """
+    if name in _registered_path_executables:
+        raise ValueError(f"{name} already registered as a path executable")
+
+    _registered_path_executables[name] = install_url
+
+
+def validate_installed_path_executables(names: FrozenSet[str]) -> None:
+    """Raises a UserErrors exception if any executables listed in `names` are missing from PATH"""
+    missing = get_missing_path_executables(names)
+    if not missing:
+        return
+
+    sorted_names = sorted(missing)
+
+    nice_missing = [
+        name + (f" (visit {missing[name]} to install)" if missing[name] else "")
+        for name in sorted_names
+    ]
+
+    message = "Missing required executables on PATH: {}".format("; ".join(nice_missing))
+
+    raise UserErrors(message)

--- a/opta/utils/dependencies.py
+++ b/opta/utils/dependencies.py
@@ -24,13 +24,16 @@ def get_missing_path_executables(names: StringSetOrFrozen) -> Dict[str, Optional
     missing: Dict[str, Optional[str]] = {}
 
     for name in names:
+        # Ensure that name is registered so we raise an exception even if the name is found on PATH
+        try:
+            install_url = _registered_path_executables[name]
+        except KeyError:
+            raise ValueError(f"{name} is not a registered path executable")
+
         if is_tool(name):
             continue
 
-        try:
-            missing[name] = _registered_path_executables[name]
-        except KeyError:
-            raise ValueError(f"{name} is not a registered path executable")
+        missing[name] = install_url
 
     return missing
 

--- a/opta/utils/dependencies.py
+++ b/opta/utils/dependencies.py
@@ -64,3 +64,27 @@ def validate_installed_path_executables(names: FrozenSet[str]) -> None:
     message = "Missing required executables on PATH: {}".format("; ".join(nice_missing))
 
     raise UserErrors(message)
+
+
+AWS_CLI_INSTALL_URL = (
+    "https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html"
+)
+AZ_CLI_INSTALL_URL = "https://docs.microsoft.com/en-us/cli/azure/install-azure-cli"
+DOCKER_INSTALL_URL = "https://docs.docker.com/get-docker/"
+GCP_CLI_INSTALL_URL = "https://cloud.google.com/sdk/docs/install"
+HELM_INSTALL_URL = "https://helm.sh/docs/intro/install/"
+KUBECTL_INSTALL_URL = "https://kubernetes.io/docs/tasks/tools/install-kubectl-macos/"
+TERRAFORM_INSTALL_URL = "https://learn.hashicorp.com/tutorials/terraform/install-cli"
+
+
+def _register_all() -> None:
+    register_path_executable("aws", install_url=AWS_CLI_INSTALL_URL)
+    register_path_executable("az", install_url=AZ_CLI_INSTALL_URL)
+    register_path_executable("docker", install_url=DOCKER_INSTALL_URL)
+    register_path_executable("gcloud", install_url=GCP_CLI_INSTALL_URL)
+    register_path_executable("helm", install_url=HELM_INSTALL_URL)
+    register_path_executable("kubectl", install_url=KUBECTL_INSTALL_URL)
+    register_path_executable("terraform")
+
+
+_register_all()

--- a/tests/commands/test_apply.py
+++ b/tests/commands/test_apply.py
@@ -16,7 +16,6 @@ from opta.module import Module
 
 @fixture
 def basic_mocks(mocker: MockFixture) -> None:
-    mocker.patch("opta.commands.apply.is_tool", return_value=True)
     mocker.patch("opta.commands.apply.amplitude_client.send_event")
     mocker.patch("opta.commands.apply.gen_opta_resource_tags")
     mocker.patch("opta.commands.apply.PlanDisplayer")

--- a/tests/commands/test_apply.py
+++ b/tests/commands/test_apply.py
@@ -102,6 +102,7 @@ def test_apply(mocker: MockFixture, mocked_layer: Any, basic_mocks: Any) -> None
     mocked_layer.get_module_by_type.assert_has_calls(
         [mocker.call("k8s-service"), mocker.call("k8s-service", 0)]
     )
+    mocked_layer.validate_required_path_dependencies.assert_called_once()
     tf_create_storage.assert_called_once_with(mocked_layer)
     mocked_thread.assert_has_calls(
         [

--- a/tests/commands/test_deploy.py
+++ b/tests/commands/test_deploy.py
@@ -38,6 +38,7 @@ def test_deploy_basic(mocker: MockFixture) -> None:
     result = runner.invoke(cli, ["deploy", "-i", "local_image:local_tag"])
 
     assert result.exit_code == 0
+    mocked_layer.validate_required_path_dependencies.assert_called_once()
     mock_tf_download_state.assert_called_once_with(mocked_layer)
     mock_push.assert_called_once_with(
         image="local_image:local_tag", config="opta.yml", env=None, tag=None

--- a/tests/commands/test_inspect.py
+++ b/tests/commands/test_inspect.py
@@ -47,8 +47,8 @@ def test_inspect(mocker: MockFixture) -> None:
     mocked_layer.org_name = "dummy_org_name"
     mocked_layer.name = "dummy_name"
     mocker.patch("opta.commands.inspect_cmd.gen_all")
-    # Mock that the terraform CLI tool exists.
-    mocker.patch("opta.commands.inspect_cmd.is_tool", return_value=True)
+    # Mock precheck call
+    mocked_pre_check = mocker.patch("opta.commands.inspect_cmd.pre_check")
     # Mock the inspect config
     mocker.patch("opta.module.REGISTRY", REGISTRY)
     # Mock fetching the terraform state
@@ -80,6 +80,7 @@ def test_inspect(mocker: MockFixture) -> None:
     result = runner.invoke(inspect)
 
     assert result.exit_code == 0
+    mocked_pre_check.assert_called_once()
     # Using split to compare without whitespaces
     assert (
         result.output.split()

--- a/tests/commands/test_kubectl.py
+++ b/tests/commands/test_kubectl.py
@@ -23,7 +23,7 @@ def test_configure_kubectl(mocker: MockFixture) -> None:
     mocker.patch("opta.commands.kubectl.gen_all")
 
     # Mock that the kubectl and aws comamnds exist in the env.
-    mocker.patch("opta.core.kubernetes.is_tool", return_value=True)
+    mocked_ensure_installed = mocker.patch("opta.core.kubernetes.ensure_installed")
 
     # Mock aws commands, including fetching the current aws account id.
     fake_aws_account_id = 1234567890123
@@ -64,6 +64,7 @@ def test_configure_kubectl(mocker: MockFixture) -> None:
     result = runner.invoke(configure_kubectl, [])
     mocked_layer_class.load_from_yaml.assert_called_with("opta.yml", None)
     mock_sts_client.assert_called()
+    mocked_ensure_installed.assert_has_calls([mocker.call("kubectl"), mocker.call("aws")])
     assert result.exit_code == 0
 
     # If the current aws account id does not match the specified opta env's, then

--- a/tests/commands/test_push.py
+++ b/tests/commands/test_push.py
@@ -183,7 +183,9 @@ def test_no_tag(mocker: MockFixture) -> None:
 
 
 def test_no_docker(mocker: MockFixture) -> None:
-    mocker.patch("opta.utils.os.path.exists", return_value=True)  # Make check_opta_file_exists succeed
+    mocker.patch(
+        "opta.utils.os.path.exists", return_value=True
+    )  # Make check_opta_file_exists succeed
     mocker.patch("opta.commands.push.ensure_installed", side_effect=UserErrors("foobar"))
 
     runner = CliRunner()

--- a/tests/commands/test_push.py
+++ b/tests/commands/test_push.py
@@ -13,6 +13,7 @@ from opta.commands.push import (
     get_registry_url,
     push_to_docker,
 )
+from opta.exceptions import UserErrors
 from opta.layer import Layer
 from tests.fixtures.basic_apply import BASIC_APPLY
 
@@ -182,16 +183,12 @@ def test_no_tag(mocker: MockFixture) -> None:
 
 
 def test_no_docker(mocker: MockFixture) -> None:
-    # Opta file check
-    mocked_os_path_exists = mocker.patch("opta.utils.os.path.exists")
-    mocked_os_path_exists.return_value = True
-
-    is_tool_mock = mocker.patch("opta.commands.push.is_tool")
-    is_tool_mock.return_value = False
+    mocker.patch("opta.utils.os.path.exists", return_value=True)  # Make check_opta_file_exists succeed
+    mocker.patch("opta.commands.push.ensure_installed", side_effect=UserErrors("foobar"))
 
     runner = CliRunner()
     result = runner.invoke(cli, ["push", "local_image:local_tag"])
-    assert str(result.exception) == "Please install docker on your machine"
+    assert str(result.exception) == "foobar"
 
 
 def test_no_tag_override(mocker: MockFixture) -> None:

--- a/tests/core/test_helm.py
+++ b/tests/core/test_helm.py
@@ -1,6 +1,6 @@
 from pytest_mock import MockFixture
 
-from opta.core.helm import Helm, get_required_path_executables
+from opta.core.helm import Helm
 
 
 class TestHelm:
@@ -10,32 +10,32 @@ class TestHelm:
     MOCK_REVISION_X = "X"
 
     def test_get_required_path_executables(self) -> None:
-        deps = get_required_path_executables()
+        deps = Helm.get_required_path_executables()
         assert len(deps) == 1
 
     def test_rollback_helm_base_revision_1(self, mocker: MockFixture) -> None:
-        mock_helm_check = mocker.patch("opta.core.helm.helm_check", return_value=None)
+        mock_validate_helm_installed = mocker.patch("opta.core.helm.Helm.validate_helm_installed", return_value=None)
         mock_nice_run_helm_uninstall = mocker.patch("opta.core.helm.nice_run")
 
         Helm.rollback_helm(
             self.MOCK_RELEASE, self.MOCK_NAMESPACE, revision=self.MOCK_REVISION_1
         )
 
-        mock_helm_check.assert_called_once_with()
+        mock_validate_helm_installed.assert_called_once()
         mock_nice_run_helm_uninstall.assert_called_once_with(
             ["helm", "uninstall", self.MOCK_RELEASE, "--namespace", self.MOCK_NAMESPACE],
             check=True,
         )
 
     def test_rollback_helm_base_revision_x(self, mocker: MockFixture) -> None:
-        mock_helm_check = mocker.patch("opta.core.helm.helm_check", return_value=None)
+        mock_validate_helm_installed = mocker.patch("opta.core.helm.Helm.validate_helm_installed", return_value=None)
         mock_nice_run_helm_rollback = mocker.patch("opta.core.helm.nice_run")
 
         Helm.rollback_helm(
             self.MOCK_RELEASE, self.MOCK_NAMESPACE, revision=self.MOCK_REVISION_X
         )
 
-        mock_helm_check.assert_called_once_with()
+        mock_validate_helm_installed.assert_called_once()
         mock_nice_run_helm_rollback.assert_called_once_with(
             [
                 "helm",
@@ -49,14 +49,14 @@ class TestHelm:
         )
 
     def test_get_helm_list_without_namespace(self, mocker: MockFixture) -> None:
-        mock_helm_check = mocker.patch("opta.core.helm.helm_check", return_value=None)
+        mock_validate_helm_installed = mocker.patch("opta.core.helm.Helm.validate_helm_installed", return_value=None)
         mock_namespace_placeholder = ["--all-namespaces"]
         mock_nice_run_helm_list_process = mocker.patch("opta.core.helm.nice_run")
 
         mock_json_loads = mocker.patch("opta.core.helm.json.loads")
 
         Helm.get_helm_list()
-        mock_helm_check.assert_called_once_with()
+        mock_validate_helm_installed.assert_called_once()
         mock_nice_run_helm_list_process.assert_called_once_with(
             ["helm", "list", "--all", *mock_namespace_placeholder, "-o", "json"],
             capture_output=True,
@@ -65,14 +65,14 @@ class TestHelm:
         mock_json_loads.assert_called_once()
 
     def test_get_helm_list_with_namespace(self, mocker: MockFixture) -> None:
-        mock_helm_check = mocker.patch("opta.core.helm.helm_check", return_value=None)
+        mock_validate_helm_installed = mocker.patch("opta.core.helm.Helm.validate_helm_installed", return_value=None)
         mock_namespace_placeholder = ["--namespace", self.MOCK_NAMESPACE]
         mock_nice_run_helm_list_process = mocker.patch("opta.core.helm.nice_run")
 
         mock_json_loads = mocker.patch("opta.core.helm.json.loads")
 
         Helm.get_helm_list(namespace=self.MOCK_NAMESPACE)
-        mock_helm_check.assert_called_once_with()
+        mock_validate_helm_installed.assert_called_once()
         mock_nice_run_helm_list_process.assert_called_once_with(
             ["helm", "list", "--all", *mock_namespace_placeholder, "-o", "json"],
             capture_output=True,

--- a/tests/core/test_helm.py
+++ b/tests/core/test_helm.py
@@ -14,7 +14,9 @@ class TestHelm:
         assert len(deps) == 1
 
     def test_rollback_helm_base_revision_1(self, mocker: MockFixture) -> None:
-        mock_validate_helm_installed = mocker.patch("opta.core.helm.Helm.validate_helm_installed", return_value=None)
+        mock_validate_helm_installed = mocker.patch(
+            "opta.core.helm.Helm.validate_helm_installed", return_value=None
+        )
         mock_nice_run_helm_uninstall = mocker.patch("opta.core.helm.nice_run")
 
         Helm.rollback_helm(
@@ -28,7 +30,9 @@ class TestHelm:
         )
 
     def test_rollback_helm_base_revision_x(self, mocker: MockFixture) -> None:
-        mock_validate_helm_installed = mocker.patch("opta.core.helm.Helm.validate_helm_installed", return_value=None)
+        mock_validate_helm_installed = mocker.patch(
+            "opta.core.helm.Helm.validate_helm_installed", return_value=None
+        )
         mock_nice_run_helm_rollback = mocker.patch("opta.core.helm.nice_run")
 
         Helm.rollback_helm(
@@ -49,7 +53,9 @@ class TestHelm:
         )
 
     def test_get_helm_list_without_namespace(self, mocker: MockFixture) -> None:
-        mock_validate_helm_installed = mocker.patch("opta.core.helm.Helm.validate_helm_installed", return_value=None)
+        mock_validate_helm_installed = mocker.patch(
+            "opta.core.helm.Helm.validate_helm_installed", return_value=None
+        )
         mock_namespace_placeholder = ["--all-namespaces"]
         mock_nice_run_helm_list_process = mocker.patch("opta.core.helm.nice_run")
 
@@ -65,7 +71,9 @@ class TestHelm:
         mock_json_loads.assert_called_once()
 
     def test_get_helm_list_with_namespace(self, mocker: MockFixture) -> None:
-        mock_validate_helm_installed = mocker.patch("opta.core.helm.Helm.validate_helm_installed", return_value=None)
+        mock_validate_helm_installed = mocker.patch(
+            "opta.core.helm.Helm.validate_helm_installed", return_value=None
+        )
         mock_namespace_placeholder = ["--namespace", self.MOCK_NAMESPACE]
         mock_nice_run_helm_list_process = mocker.patch("opta.core.helm.nice_run")
 

--- a/tests/core/test_helm.py
+++ b/tests/core/test_helm.py
@@ -1,6 +1,6 @@
 from pytest_mock import MockFixture
 
-from opta.core.helm import Helm
+from opta.core.helm import Helm, get_required_path_executables
 
 
 class TestHelm:
@@ -8,6 +8,10 @@ class TestHelm:
     MOCK_NAMESPACE = "mock_namesapce"
     MOCK_REVISION_1 = "1"
     MOCK_REVISION_X = "X"
+
+    def test_get_required_path_executables(self) -> None:
+        deps = get_required_path_executables()
+        assert len(deps) == 1
 
     def test_rollback_helm_base_revision_1(self, mocker: MockFixture) -> None:
         mock_helm_check = mocker.patch("opta.core.helm.helm_check", return_value=None)

--- a/tests/core/test_kubernetes.py
+++ b/tests/core/test_kubernetes.py
@@ -52,7 +52,9 @@ class TestKubernetes:
         configure_kubectl(layer)
 
         mocked_terraform_output.assert_called_once_with(layer)
-        mocked_ensure_installed.assert_has_calls([mocker.call("kubectl"), mocker.call("az")])
+        mocked_ensure_installed.assert_has_calls(
+            [mocker.call("kubectl"), mocker.call("az")]
+        )
         mocked_nice_run.assert_has_calls(
             [
                 mocker.call(
@@ -108,7 +110,9 @@ class TestKubernetes:
 
         mock_sts_client.assert_called_once_with("sts")
         mocked_terraform_output.assert_called_once_with(layer)
-        mocked_ensure_installed.assert_has_calls([mocker.call("kubectl"), mocker.call("aws")])
+        mocked_ensure_installed.assert_has_calls(
+            [mocker.call("kubectl"), mocker.call("aws")]
+        )
         mocked_nice_run.assert_has_calls(
             [
                 # TODO: nsarupri -> change the AWS to Boto

--- a/tests/core/test_kubernetes.py
+++ b/tests/core/test_kubernetes.py
@@ -18,9 +18,7 @@ from opta.layer import Layer
 
 class TestKubernetes:
     def test_azure_configure_kubectl(self, mocker: MockFixture) -> None:
-        mocked_is_tool = mocker.patch(
-            "opta.core.kubernetes.is_tool", side_effect=[True, True]
-        )
+        mocked_ensure_installed = mocker.patch("opta.core.kubernetes.ensure_installed")
         layer = mocker.Mock(spec=Layer)
         layer.parent = None
         layer.cloud = "azurerm"
@@ -54,7 +52,7 @@ class TestKubernetes:
         configure_kubectl(layer)
 
         mocked_terraform_output.assert_called_once_with(layer)
-        mocked_is_tool.assert_has_calls([mocker.call("kubectl"), mocker.call("az")])
+        mocked_ensure_installed.assert_has_calls([mocker.call("kubectl"), mocker.call("az")])
         mocked_nice_run.assert_has_calls(
             [
                 mocker.call(
@@ -75,9 +73,7 @@ class TestKubernetes:
         )
 
     def test_configure_kubectl(self, mocker: MockFixture) -> None:
-        mocked_is_tool = mocker.patch(
-            "opta.core.kubernetes.is_tool", side_effect=[True, True]
-        )
+        mocked_ensure_installed = mocker.patch("opta.core.kubernetes.ensure_installed")
         mocked_nice_run = mocker.patch(
             "opta.core.kubernetes.nice_run",
             side_effect=[
@@ -112,7 +108,7 @@ class TestKubernetes:
 
         mock_sts_client.assert_called_once_with("sts")
         mocked_terraform_output.assert_called_once_with(layer)
-        mocked_is_tool.assert_has_calls([mocker.call("kubectl"), mocker.call("aws")])
+        mocked_ensure_installed.assert_has_calls([mocker.call("kubectl"), mocker.call("aws")])
         mocked_nice_run.assert_has_calls(
             [
                 # TODO: nsarupri -> change the AWS to Boto

--- a/tests/core/test_kubernetes.py
+++ b/tests/core/test_kubernetes.py
@@ -8,6 +8,7 @@ from pytest_mock import MockFixture
 
 from opta.core.kubernetes import (
     configure_kubectl,
+    get_required_path_executables,
     tail_module_log,
     tail_namespace_events,
     tail_pod_log,
@@ -128,6 +129,14 @@ class TestKubernetes:
                 ),
             ]
         )
+
+    def test_get_required_path_executables(self) -> None:
+        assert len(get_required_path_executables("local")) == 1
+
+        aws_deps = get_required_path_executables("aws")
+        assert len(aws_deps) == 2
+        for dep in ["aws", "kubectl"]:
+            assert dep in aws_deps
 
     def test_tail_module_log(self, mocker: MockFixture) -> None:
         base_start_time_timestamp = datetime.datetime.utcnow().timestamp()

--- a/tests/core/test_terraform.py
+++ b/tests/core/test_terraform.py
@@ -28,29 +28,29 @@ class TestTerraform:
         assert tf_init.call_count == 2
 
     def test_validate_version_good(self, mocker: MockFixture) -> None:
-        is_tool = mocker.patch("opta.core.terraform.is_tool", return_value=True)
+        ensure_installed = mocker.patch("opta.core.terraform.ensure_installed")
         get_version = mocker.patch("opta.core.terraform.Terraform.get_version")
         get_version.return_value = "1.0.0"
 
         Terraform.validate_version()
 
-        is_tool.assert_called_once_with("terraform")
+        ensure_installed.assert_called_once_with("terraform")
         get_version.assert_called_once()
 
     def test_validate_version_missing(self, mocker: MockFixture) -> None:
-        is_tool = mocker.patch("opta.core.terraform.is_tool", return_value=False)
+        ensure_installed = mocker.patch("opta.core.terraform.ensure_installed", side_effect=UserErrors("foobar"))
         get_version = mocker.patch("opta.core.terraform.Terraform.get_version")
 
         with pytest.raises(UserErrors) as e:
             Terraform.validate_version()
 
-        is_tool.assert_called_once_with("terraform")
-        assert str(e.value) == "Please install terraform on your machine"
+        ensure_installed.assert_called_once_with("terraform")
+        assert str(e.value) == "foobar"
 
         get_version.assert_not_called()
 
     def test_validate_version_low(self, mocker: MockFixture) -> None:
-        mocker.patch("opta.core.terraform.is_tool", return_value=True)
+        mocker.patch("opta.core.terraform.ensure_installed")
         get_version = mocker.patch("opta.core.terraform.Terraform.get_version")
         get_version.return_value = "0.14.9"
 
@@ -63,7 +63,7 @@ class TestTerraform:
         get_version.assert_called_once()
 
     def test_validate_version_high(self, mocker: MockFixture) -> None:
-        mocker.patch("opta.core.terraform.is_tool", return_value=True)
+        mocker.patch("opta.core.terraform.ensure_installed")
         get_version = mocker.patch("opta.core.terraform.Terraform.get_version")
         get_version.return_value = "1.1.0"
 

--- a/tests/core/test_terraform.py
+++ b/tests/core/test_terraform.py
@@ -38,7 +38,9 @@ class TestTerraform:
         get_version.assert_called_once()
 
     def test_validate_version_missing(self, mocker: MockFixture) -> None:
-        ensure_installed = mocker.patch("opta.core.terraform.ensure_installed", side_effect=UserErrors("foobar"))
+        ensure_installed = mocker.patch(
+            "opta.core.terraform.ensure_installed", side_effect=UserErrors("foobar")
+        )
         get_version = mocker.patch("opta.core.terraform.Terraform.get_version")
 
         with pytest.raises(UserErrors) as e:

--- a/tests/test_pre_check.py
+++ b/tests/test_pre_check.py
@@ -1,0 +1,12 @@
+from pytest_mock import MockFixture
+
+from opta.pre_check import dependency_check
+
+
+class TestPreCheck:
+    def test_dependency_check(self, mocker: MockFixture) -> None:
+        validate_version = mocker.patch("opta.pre_check.Terraform.validate_version")
+
+        dependency_check()
+
+        validate_version.assert_called_once()

--- a/tests/utils/test_dependencies.py
+++ b/tests/utils/test_dependencies.py
@@ -1,0 +1,80 @@
+from unittest import mock
+import pytest
+from pytest_mock import MockFixture
+
+
+from opta.exceptions import UserErrors
+from opta.utils import dependencies
+
+class TestDependencies:
+    def test_get_missing_path_executables(self, mocker: MockFixture) -> None:
+        mock_is_tool = mocker.patch("opta.utils.dependencies.is_tool")
+        mock_is_tool.return_value = False
+        dependencies.register_path_executable("foo")
+
+        missing = dependencies.get_missing_path_executables({"foo"})
+
+        mock_is_tool.assert_called_once_with("foo")
+        assert missing == {"foo": None}
+
+    def test_get_missing_path_executables_none(self, mocker: MockFixture) -> None:
+        mock_is_tool = mocker.patch("opta.utils.dependencies.is_tool")
+        mock_is_tool.return_value = True
+        dependencies.register_path_executable("foo")
+
+        missing = dependencies.get_missing_path_executables({"foo"})
+
+        mock_is_tool.assert_called_once_with("foo")
+        assert missing == {}
+
+    def test_get_missing_path_executables_unregistered(self, mocker: MockFixture) -> None:
+        mock_is_tool = mocker.patch("opta.utils.dependencies.is_tool", return_value=True)
+
+        with pytest.raises(ValueError) as e:
+            dependencies.get_missing_path_executables({"foo"})
+
+        assert str(e.value) == "foo is not a registered path executable"
+        mock_is_tool.assert_not_called()
+
+    def test_register_path_executable_new(self) -> None:
+        dependencies.register_path_executable("foo")
+        dependencies.register_path_executable("bar")
+        assert dependencies._registered_path_executables == {"foo": None, "bar": None}
+
+    def test_register_path_executable_new_with_url(self) -> None:
+        dependencies.register_path_executable("foo", install_url="bar")
+        assert dependencies._registered_path_executables == {"foo": "bar"}
+
+    def test_register_path_executable_duplicate(self) -> None:
+        dependencies.register_path_executable("foo")
+
+        with pytest.raises(ValueError) as e:
+            dependencies.register_path_executable("foo")
+
+        assert str(e.value) == "foo already registered as a path executable"
+
+    def test_validate_installed_path_executables(self, mocker: MockFixture) -> None:
+        mocker.patch("opta.utils.dependencies.get_missing_path_executables", return_value={"foo": "bar", "spam": None})
+
+        with pytest.raises(UserErrors) as e:
+            dependencies.validate_installed_path_executables({"foo", "spam"})
+
+        assert str(e.value) == "Missing required executables on PATH: foo (visit bar to install); spam"
+
+    def test_validate_installed_path_executables_none(self, mocker: MockFixture) -> None:
+        mock_get_missing = mocker.patch("opta.utils.dependencies.get_missing_path_executables", return_value={})
+        mock_sorted = mocker.patch("opta.utils.dependencies.sorted")
+
+        dependencies.validate_installed_path_executables({"foo"})
+
+        mock_get_missing.assert_called_once_with({"foo"})
+        mock_sorted.assert_not_called()
+
+    @pytest.fixture(autouse=True)
+    def registered_paths(self) -> None:
+        old = dependencies._registered_path_executables
+        dependencies._registered_path_executables = {}
+
+        yield
+
+        dependencies._registered_path_executables = old

--- a/tests/utils/test_dependencies.py
+++ b/tests/utils/test_dependencies.py
@@ -1,10 +1,11 @@
 from unittest import mock
+
 import pytest
 from pytest_mock import MockFixture
 
-
 from opta.exceptions import UserErrors
 from opta.utils import dependencies
+
 
 class TestDependencies:
     def test_get_missing_path_executables(self, mocker: MockFixture) -> None:
@@ -54,15 +55,23 @@ class TestDependencies:
         assert str(e.value) == "foo already registered as a path executable"
 
     def test_validate_installed_path_executables(self, mocker: MockFixture) -> None:
-        mocker.patch("opta.utils.dependencies.get_missing_path_executables", return_value={"foo": "bar", "spam": None})
+        mocker.patch(
+            "opta.utils.dependencies.get_missing_path_executables",
+            return_value={"foo": "bar", "spam": None},
+        )
 
         with pytest.raises(UserErrors) as e:
             dependencies.validate_installed_path_executables({"foo", "spam"})
 
-        assert str(e.value) == "Missing required executables on PATH: foo (visit bar to install); spam"
+        assert (
+            str(e.value)
+            == "Missing required executables on PATH: foo (visit bar to install); spam"
+        )
 
     def test_validate_installed_path_executables_none(self, mocker: MockFixture) -> None:
-        mock_get_missing = mocker.patch("opta.utils.dependencies.get_missing_path_executables", return_value={})
+        mock_get_missing = mocker.patch(
+            "opta.utils.dependencies.get_missing_path_executables", return_value={}
+        )
         mock_sorted = mocker.patch("opta.utils.dependencies.sorted")
 
         dependencies.validate_installed_path_executables({"foo"})

--- a/tests/utils/test_dependencies.py
+++ b/tests/utils/test_dependencies.py
@@ -1,4 +1,4 @@
-from unittest import mock
+from typing import Generator
 
 import pytest
 from pytest_mock import MockFixture
@@ -61,7 +61,7 @@ class TestDependencies:
         )
 
         with pytest.raises(UserErrors) as e:
-            dependencies.validate_installed_path_executables({"foo", "spam"})
+            dependencies.validate_installed_path_executables(frozenset({"foo", "spam"}))
 
         assert (
             str(e.value)
@@ -74,13 +74,13 @@ class TestDependencies:
         )
         mock_sorted = mocker.patch("opta.utils.dependencies.sorted")
 
-        dependencies.validate_installed_path_executables({"foo"})
+        dependencies.validate_installed_path_executables(frozenset({"foo"}))
 
-        mock_get_missing.assert_called_once_with({"foo"})
+        mock_get_missing.assert_called_once_with(frozenset({"foo"}))
         mock_sorted.assert_not_called()
 
     @pytest.fixture(autouse=True)
-    def registered_paths(self) -> None:
+    def registered_paths(self) -> Generator:
         old = dependencies._registered_path_executables
         dependencies._registered_path_executables = {}
 


### PR DESCRIPTION
# Description
- When running `apply`, `deploy`, or `destroy`, check for PATH dependencies.
- Module processors can override the ModuleProcessor.required_path_dependencies property to return a frozenset of required PATH dependencies.
- Dependencies must be registered (optionally along with the URL to installation instructions) in order to be listed as required (this reduces issues with typos in the code.
- This mechanism allows us to only prompt users for dependencies they actually would need based what modules are present in the layer.
- Updated the Terraform version check to run during deploy and destroy as well.

# Safety checklist
* [x] This change is backwards compatible and safe to apply by existing users
* [x] This change will NOT lead to data loss
* [x] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
Done some manual testing with a layer file that uses AWS. Other clouds haven't been manually tested yet.
