### PR TITLE
Default Values peristence and upgrade

### DIFF
--- a/config/registry/google/modules/gcp-k8s-service.yaml
+++ b/config/registry/google/modules/gcp-k8s-service.yaml
@@ -117,6 +117,7 @@ inputs:
     validator: int(required=False)
     description: Use if the initial delay needs to be changed.
     default: 30
+    force_update_default_counter: 2
   - name: consistent_hash
     user_facing: true
     validator: str(required=False)

--- a/opta/core/aws.py
+++ b/opta/core/aws.py
@@ -5,6 +5,7 @@ import boto3
 from botocore.config import Config
 from mypy_boto3_dynamodb import DynamoDBClient
 
+from opta.core.cloud_client import CloudClient
 from opta.exceptions import UserErrors
 from opta.utils import fmt_msg, json, logger
 
@@ -22,10 +23,10 @@ class AwsArn(TypedDict):
     resource_type: Optional[str]
 
 
-class AWS:
+class AWS(CloudClient):
     def __init__(self, layer: "Layer"):
-        self.layer = layer
         self.region = layer.root().providers["aws"]["region"]
+        super(AWS, self).__init__(layer)
 
     def __get_dynamodb(self, dynamodb_table: str) -> DynamoDBClient:
         dynamodb_client: DynamoDBClient = boto3.client(

--- a/opta/core/aws.py
+++ b/opta/core/aws.py
@@ -26,7 +26,7 @@ class AwsArn(TypedDict):
 class AWS(CloudClient):
     def __init__(self, layer: "Layer"):
         self.region = layer.root().providers["aws"]["region"]
-        super(AWS, self).__init__(layer)
+        super().__init__(layer)
 
     def __get_dynamodb(self, dynamodb_table: str) -> DynamoDBClient:
         dynamodb_client: DynamoDBClient = boto3.client(

--- a/opta/core/azure.py
+++ b/opta/core/azure.py
@@ -5,17 +5,15 @@ from azure.core.exceptions import ResourceNotFoundError
 from azure.identity import DefaultAzureCredential
 from azure.storage.blob import BlobServiceClient, ContainerClient, StorageStreamDownloader
 
+from opta.core.cloud_client import CloudClient
 from opta.utils import json, logger
 
 if TYPE_CHECKING:
-    from opta.layer import Layer, StructuredConfig
+    from opta.layer import StructuredConfig
 
 
-class Azure:
+class Azure(CloudClient):
     project_id: Optional[str] = None
-
-    def __init__(self, layer: "Layer"):
-        self.layer = layer
 
     @classmethod
     def get_credentials(cls) -> Any:

--- a/opta/core/cloud_client.py
+++ b/opta/core/cloud_client.py
@@ -8,17 +8,22 @@ class CloudClient:
     def __init__(self, layer: "Layer"):
         self.layer = layer
 
+    @abstractmethod
     def get_remote_config(self) -> Optional["StructuredConfig"]:
         pass
 
+    @abstractmethod
     def upload_opta_config(self) -> None:
         pass
 
+    @abstractmethod
     def delete_opta_config(self) -> None:
         pass
 
+    @abstractmethod
     def delete_remote_state(self) -> None:
         pass
 
+    @abstractmethod
     def get_terraform_lock_id(self) -> str:
-        pass
+        raise NotImplementedError()

--- a/opta/core/cloud_client.py
+++ b/opta/core/cloud_client.py
@@ -5,7 +5,7 @@ if TYPE_CHECKING:
     from opta.layer import Layer, StructuredConfig
 
 
-class CloudClient:
+class CloudClient(ABC):
     def __init__(self, layer: "Layer"):
         self.layer = layer
 

--- a/opta/core/cloud_client.py
+++ b/opta/core/cloud_client.py
@@ -1,0 +1,24 @@
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:
+    from opta.layer import Layer, StructuredConfig
+
+
+class CloudClient:
+    def __init__(self, layer: "Layer"):
+        self.layer = layer
+
+    def get_remote_config(self) -> Optional["StructuredConfig"]:
+        pass
+
+    def upload_opta_config(self) -> None:
+        pass
+
+    def delete_opta_config(self) -> None:
+        pass
+
+    def delete_remote_state(self) -> None:
+        pass
+
+    def get_terraform_lock_id(self) -> str:
+        pass

--- a/opta/core/cloud_client.py
+++ b/opta/core/cloud_client.py
@@ -1,3 +1,4 @@
+from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Optional
 
 if TYPE_CHECKING:

--- a/opta/core/gcp.py
+++ b/opta/core/gcp.py
@@ -25,7 +25,7 @@ class GCP(CloudClient):
     def __init__(self, layer: "Layer"):
         self.layer = layer
         self.region = layer.root().providers["google"]["region"]
-        super(GCP, self).__init__(layer)
+        super().__init__(layer)
 
     @classmethod
     def get_credentials(cls) -> Tuple[Credentials, str]:

--- a/opta/core/gcp.py
+++ b/opta/core/gcp.py
@@ -10,6 +10,7 @@ from google.cloud.exceptions import NotFound
 from google.oauth2 import service_account
 from googleapiclient import discovery
 
+from opta.core.cloud_client import CloudClient
 from opta.exceptions import UserErrors
 from opta.utils import fmt_msg, json, logger
 
@@ -17,13 +18,14 @@ if TYPE_CHECKING:
     from opta.layer import Layer, StructuredConfig
 
 
-class GCP:
+class GCP(CloudClient):
     project_id: Optional[str] = None
     credentials: Optional[Credentials] = None
 
     def __init__(self, layer: "Layer"):
         self.layer = layer
         self.region = layer.root().providers["google"]["region"]
+        super(GCP, self).__init__(layer)
 
     @classmethod
     def get_credentials(cls) -> Tuple[Credentials, str]:

--- a/opta/core/generator.py
+++ b/opta/core/generator.py
@@ -1,20 +1,22 @@
-from typing import TYPE_CHECKING, Generator, List, Tuple
+from typing import TYPE_CHECKING, Generator, List, Optional, Tuple
 
 from opta import gen_tf
 from opta.constants import TF_FILE_PATH
 from opta.utils import deep_merge, logger
 
 if TYPE_CHECKING:
-    from opta.layer import Layer
+    from opta.layer import Layer, StructuredConfig
     from opta.module import Module
 
 
-def gen_all(layer: "Layer") -> None:
+def gen_all(layer: "Layer", previous_config: Optional["StructuredConfig"] = None) -> None:
     # Just run the generator till the end
-    list(gen(layer))
+    list(gen(layer, previous_config))
 
 
-def gen(layer: "Layer") -> Generator[Tuple[int, List["Module"], int], None, None]:
+def gen(
+    layer: "Layer", previous_config: Optional["StructuredConfig"] = None
+) -> Generator[Tuple[int, List["Module"], int], None, None]:
     """Generate TF file based on opta config file"""
     logger.debug("Loading infra blocks")
 
@@ -26,7 +28,7 @@ def gen(layer: "Layer") -> Generator[Tuple[int, List["Module"], int], None, None
         if not module.halt and module_idx + 1 != total_module_count:
             continue
         ret = layer.gen_providers(module_idx)
-        ret = deep_merge(layer.gen_tf(module_idx), ret)
+        ret = deep_merge(layer.gen_tf(module_idx, previous_config), ret)
 
         gen_tf.gen(ret, TF_FILE_PATH)
 

--- a/opta/core/local.py
+++ b/opta/core/local.py
@@ -47,7 +47,7 @@ class Local(CloudClient):
         else:
             logger.warn(f"Did not find opta config {self.config_file_path} to delete")
 
-    def delete_local_tf_state(self) -> None:
+    def delete_remote_state(self) -> None:
 
         if os.path.isfile(self.tf_file):
             os.remove(self.tf_file)

--- a/opta/core/local.py
+++ b/opta/core/local.py
@@ -2,15 +2,15 @@ import os
 from pathlib import Path
 from typing import TYPE_CHECKING, Optional
 
+from opta.core.cloud_client import CloudClient
 from opta.utils import json, logger
 
 if TYPE_CHECKING:
     from opta.layer import Layer, StructuredConfig
 
 
-class Local:
+class Local(CloudClient):
     def __init__(self, layer: "Layer"):
-        self.layer = layer
         local_dir = os.path.join(os.path.join(str(Path.home()), ".opta", "local"))
         self.tf_file = os.path.join(
             str(Path.home()), ".opta", "local", "tfstate", layer.name
@@ -20,6 +20,7 @@ class Local:
         )
         if not os.path.exists(os.path.dirname(self.config_file_path)):
             os.makedirs(os.path.dirname(self.config_file_path))
+        super(Local, self).__init__(layer)
 
     def get_remote_config(self) -> Optional["StructuredConfig"]:
         try:
@@ -55,3 +56,6 @@ class Local:
             logger.info("Deleted opta tf backup config from local")
         else:
             logger.warn(f"Did not find opta tf state {self.tf_file} to delete")
+
+    def get_terraform_lock_id(self) -> str:
+        return ""

--- a/opta/core/local.py
+++ b/opta/core/local.py
@@ -20,7 +20,8 @@ class Local(CloudClient):
         )
         if not os.path.exists(os.path.dirname(self.config_file_path)):
             os.makedirs(os.path.dirname(self.config_file_path))
-        super(Local, self).__init__(layer)
+
+        super().__init__(layer)
 
     def get_remote_config(self) -> Optional["StructuredConfig"]:
         try:

--- a/opta/core/terraform.py
+++ b/opta/core/terraform.py
@@ -29,6 +29,7 @@ from oauth2client.client import GoogleCredentials
 
 from opta.core.aws import AWS
 from opta.core.azure import Azure
+from opta.core.cloud_client import CloudClient
 from opta.core.gcp import GCP
 from opta.core.local import Local
 from opta.exceptions import MissingState, UserErrors
@@ -185,25 +186,19 @@ class Terraform:
 
         # After the layer is completely deleted, remove the opta config from the state bucket.
         if layer.cloud == "aws":
-            aws = AWS(layer)
-            aws.delete_opta_config()
-            aws.delete_remote_state()
+            cloud_client: CloudClient = AWS(layer)
         elif layer.cloud == "google":
-            gcp = GCP(layer)
-            gcp.delete_opta_config()
-            gcp.delete_remote_state()
+            cloud_client = GCP(layer)
         elif layer.cloud == "azurerm":
-            azure = Azure(layer)
-            azure.delete_opta_config()
-            azure.delete_remote_state()
+            cloud_client = Azure(layer)
         elif layer.cloud == "local":
-            local = Local(layer)
-            local.delete_opta_config()
-            local.delete_local_tf_state()
+            cloud_client = Local(layer)
         else:
             raise Exception(
                 f"Can not handle opta config deletion for cloud {layer.cloud}"
             )
+        cloud_client.delete_opta_config()
+        cloud_client.delete_remote_state()
 
         # If this is the env layer, delete the state bucket & dynamo table as well.
         if layer.name == layer.root().name:

--- a/opta/layer.py
+++ b/opta/layer.py
@@ -70,7 +70,7 @@ class StructuredConfig(TypedDict):
     opta_version: str
     date: str
     original_spec: str
-    defaults: dict[str, list[StructuredDefault]]
+    defaults: Dict[str, List[StructuredDefault]]
 
 
 class Layer:

--- a/opta/layer.py
+++ b/opta/layer.py
@@ -60,10 +60,17 @@ from opta.plugins.derived_providers import DerivedProviders
 from opta.utils import deep_merge, hydrate, logger, yaml
 
 
+class StructuredDefault(TypedDict):
+    input_name: str
+    default: Any
+    force_update_default_counter: int
+
+
 class StructuredConfig(TypedDict):
     opta_version: str
     date: str
     original_spec: str
+    defaults: dict[str, list[StructuredDefault]]
 
 
 class Layer:
@@ -213,6 +220,7 @@ class Layer:
             "opta_version": VERSION,
             "date": datetime.utcnow().isoformat(),
             "original_spec": self.original_spec,
+            "defaults": {module.name: module.used_defaults for module in self.modules},
         }
 
     @classmethod
@@ -357,7 +365,9 @@ class Layer:
             ret += module.outputs()
         return ret
 
-    def gen_tf(self, module_idx: int) -> Dict[Any, Any]:
+    def gen_tf(
+        self, module_idx: int, existing_config: Optional[StructuredConfig] = None
+    ) -> Dict[Any, Any]:
         ret: Dict[Any, Any] = {}
         for module in self.modules[0 : module_idx + 1]:
             module_type = module.aliased_type or module.type
@@ -373,9 +383,16 @@ class Layer:
                 None if len(self.get_module_by_type(module.type)) == 1 else module.name
             )
             try:
+                existing_defaults: Optional[List[StructuredDefault]] = None
+                if existing_config is not None:
+                    existing_defaults = existing_config.get("defaults", {}).get(
+                        module.name
+                    )
                 ret = deep_merge(
                     module.gen_tf(
-                        depends_on=previous_module_reference, output_prefix=output_prefix,
+                        depends_on=previous_module_reference,
+                        output_prefix=output_prefix,
+                        existing_defaults=existing_defaults,
                     ),
                     ret,
                 )

--- a/opta/module.py
+++ b/opta/module.py
@@ -75,10 +75,7 @@ class Module:
             )
         except StopIteration:
             return input["default"], input_counter
-        if (
-            input_counter
-            > existing_default["force_update_default_counter"]
-        ):
+        if input_counter > existing_default["force_update_default_counter"]:
             return input["default"], input_counter
         return (
             existing_default["default"],

--- a/opta/module.py
+++ b/opta/module.py
@@ -76,7 +76,7 @@ class Module:
         except StopIteration:
             return input["default"], input_counter
         if (
-            input.get("force_update_default_counter", 0)
+            input_counter
             > existing_default["force_update_default_counter"]
         ):
             return input["default"], input_counter

--- a/opta/module.py
+++ b/opta/module.py
@@ -1,6 +1,6 @@
 import os
 import re
-from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Tuple
 
 import hcl2
 
@@ -11,7 +11,7 @@ from opta.utils import deep_merge, json
 
 TAGS_OVERRIDE_FILE = "tags_override.tf.json"
 if TYPE_CHECKING:
-    from opta.layer import Layer
+    from opta.layer import Layer, StructuredDefault
 
 
 class Module:
@@ -41,6 +41,7 @@ class Module:
         self.module_dir_path: str = self.translate_location(
             self.desc.get("terraform_module", self.aliased_type or self.type)
         )
+        self.used_defaults: List["StructuredDefault"] = []
 
     def outputs(self) -> Iterable[str]:
         ret = []
@@ -55,9 +56,42 @@ class Module:
         pattern = "^[A-Za-z0-9]*$"
         return bool(re.match(pattern, name))
 
+    def resolve_default_input(
+        self,
+        input: dict[str, Any],
+        existing_defaults: Optional[List["StructuredDefault"]] = None,
+    ) -> Tuple[Any, int]:
+        """If there is no existing default list (because folks have not yet run the version where we have started
+        storing the defaults) then use the hard coded one. If we can't find the input name in the list of existing
+        inputs, then also use the hard coded one. If we do find the existing input, but the force_update_default_counter
+        was increased, then use the hard coded one. Otherwise keep using the existing one"""
+        input_name = input["name"]
+        input_counter = input.get("force_update_default_counter", 0)
+        if existing_defaults is None:
+            return input["default"], input_counter
+        try:
+            existing_default: "StructuredDefault" = next(
+                x for x in existing_defaults if x["input_name"] == input_name
+            )
+        except StopIteration:
+            return input["default"], input_counter
+        if (
+            input.get("force_update_default_counter", 0)
+            > existing_default["force_update_default_counter"]
+        ):
+            return input["default"], input_counter
+        return (
+            existing_default["default"],
+            existing_default["force_update_default_counter"],
+        )
+
     def gen_tf(
-        self, depends_on: Optional[List[str]] = None, output_prefix: Optional[str] = None
+        self,
+        depends_on: Optional[List[str]] = None,
+        output_prefix: Optional[str] = None,
+        existing_defaults: Optional[List["StructuredDefault"]] = None,
     ) -> Dict[Any, Any]:
+        self.used_defaults = []
         if self.module_dir_path == "":
             return {}
         module_blk: Dict[Any, Any] = {
@@ -76,7 +110,17 @@ class Module:
             elif not input["required"]:
                 # TODO(patrick): This cannot handle inputs that have defaults but are removed by a module's `process` method
                 if "default" in input:
-                    module_blk["module"][self.name][input_name] = input["default"]
+                    default, counter = self.resolve_default_input(
+                        input, existing_defaults
+                    )
+                    module_blk["module"][self.name][input_name] = default
+                    self.used_defaults.append(
+                        {
+                            "input_name": input_name,
+                            "default": default,
+                            "force_update_default_counter": counter,
+                        }
+                    )
             else:
                 raise Exception(f"Unable to hydrate {input_name}")
         for output in self.desc["outputs"]:

--- a/opta/module.py
+++ b/opta/module.py
@@ -58,7 +58,7 @@ class Module:
 
     def resolve_default_input(
         self,
-        input: dict[str, Any],
+        input: Dict[str, Any],
         existing_defaults: Optional[List["StructuredDefault"]] = None,
     ) -> Tuple[Any, int]:
         """If there is no existing default list (because folks have not yet run the version where we have started

--- a/tests/core/test_azure.py
+++ b/tests/core/test_azure.py
@@ -66,7 +66,7 @@ class TestAzure:
         mocked_container_client_instance.download_blob = mocker.Mock()
         download_stream_mock = mocker.Mock()
         download_stream_mock.readall = mocker.Mock(
-            return_value='{"opta_version":"1", "date": "mock_date", "original_spec": "mock_spec"}'
+            return_value='{"opta_version":"1", "date": "mock_date", "original_spec": "mock_spec", "defaults": {}}'
         )
         mocked_container_client_instance.download_blob.return_value = download_stream_mock
         mocked_container_client = mocker.patch(
@@ -77,6 +77,7 @@ class TestAzure:
             "opta_version": "1",
             "date": "mock_date",
             "original_spec": "mock_spec",
+            "defaults": {},
         }
 
         assert Azure(azure_layer).get_remote_config() == mocked_structured_config

--- a/tests/core/test_local.py
+++ b/tests/core/test_local.py
@@ -57,6 +57,6 @@ class LocalTests(unittest.TestCase):
             ["opta_version", "original_spec", "date", "defaults"]
         )
 
-    def test_delete_local_tf_state(self) -> None:
-        self.local.delete_local_tf_state()
+    def test_delete_remote_state(self) -> None:
+        self.local.delete_remote_state()
         assert os.path.isfile(self.local.tf_file) is False

--- a/tests/core/test_local.py
+++ b/tests/core/test_local.py
@@ -20,7 +20,15 @@ class LocalTests(unittest.TestCase):
         self.local.tf_file = "/tmp/tfconfig"
         self.local.config_file_path = "/tmp/localconfig"
         with open(self.local.config_file_path, "w") as f:
-            json.dump({"a": "1"}, f)
+            json.dump(
+                {
+                    "opta_version": "dev",
+                    "date": "2021-11-15T18:26:47.553097",
+                    "original_spec": "",
+                    "defaults": {},
+                },
+                f,
+            )
         with open(self.local.tf_file, "w") as f:
             f.write("Some tf state for testing")
 
@@ -35,12 +43,19 @@ class LocalTests(unittest.TestCase):
         return super().tearDown()
 
     def test_get_remote_config(self) -> None:
-        assert self.local.get_remote_config() == {"a": "1"}
+        assert self.local.get_remote_config() == {
+            "opta_version": "dev",
+            "date": "2021-11-15T18:26:47.553097",
+            "original_spec": "",
+            "defaults": {},
+        }
 
     def test_upload_opta_config(self) -> None:
         self.local.upload_opta_config()
         dict = json.load(open(self.local.config_file_path, "r"))
-        assert set(dict.keys()) == set(["opta_version", "original_spec", "date"])
+        assert set(dict.keys()) == set(
+            ["opta_version", "original_spec", "date", "defaults"]
+        )
 
     def test_delete_local_tf_state(self) -> None:
         self.local.delete_local_tf_state()


### PR DESCRIPTION
# Description

## The Issue

Right now, for user inputs each module has a default value for each of them to use if the user does not include one themselves. The problem comes for when we want to update the default value and whether the update is NEEDED or optional. We've already had issue where for users their deployment got messed up due to an "optional" change on the default value. Here is the proposed fix:

## Proposal

In the registry modules, each user input will have a new field called "force_update_default_counter" (if it's not set, then it defaults to 0) like so:

```yaml
halt: false
environment_module: true
inputs:
.
.
.
  - name: max_nodes
    user_facing: true
    validator: any(str(), int(), required=False)
    description: Max number of nodes to allow via autoscaling
    default: 15
    force_update_default_counter: 1
```

After a successful opta apply we already store a metadata json in the state storage bucket— now we will add the defaults used

```json
{
  "opta_version": "v0.18.1",
  "date": "2021-11-12T17:37:27.737326",
  "defaults": {
    "module_x": [
      { "input_name": "max_nodes", "default": 15, "force_update_default_counter": 1 }
    ]
  },
  "original_spec": "environments:\n  - name: gcp-staging\n    path: \"../environments/gcp-env.yml\"\n    variables:\n      max_containers: 2\nname: blah40\nmodules:\n  - type: k8s-service\n    image: kennethreitz/httpbin\n    min_containers: 2\n    max_containers: \"{vars.max_containers}\"\n    liveness_probe_path: \"/get\"\n    readiness_probe_path: \"/get\"\n    port:\n      http: 80\n    public_uri: \"test-service.{parent.domain}\"\n    healthcheck_path: \"/healthcheck\"\n    env_vars:\n      - name: APPENV\n        value: \"{env}\"\n      - name: CLOUD_PROVIDER\n        value: gcp\n      - name: hello\n        value: world5\n    links:\n      - pg\n      - redis\n    persistent_storage:\n      - path: \"/DESIRED/PATH1\"\n        size: 5 # 5 GB\n      - path: \"/DESIRED/PATH2\"\n        size: 10 # 10 GB\n  - name: pg\n    type: postgres\n    safety: false\n  - name: redis\n    type: redis\n"
}
```

So upon every opta apply, when generating main.tf.json and selecting the defaults, we shall compare these default values found in the existing metadata json (i.e. the ones used in the last successful opta apply), and reconcile them with the existing ones, using the older values unless the force_default_counter has been incremented, in which case we use the new one found in the registry yaml. After the reconciliation we apply just like before and upload the new default values used. Rinse and repeat

On the first run, it will behave like before— e.g. if no data is found in the metadata.json, it shrugs, keeps the show going and runs with the current default values )because there is no stored state to tell it otherwise).


# Safety checklist
* [x] This change is backwards compatible and safe to apply by existing users
* [x] This change will NOT lead to data loss
* [x] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
Here is how I tested this out:
I first ran it once and made sure that nothing in terraform changed. I then downloaded the opta config and verified that the existing defaults where preserved as planned. I then changed one random default (initial_readiness_delay) from 30 seconds, to 25, reran opta and confirmed that since I did NOT change/add the force_update_default_counter field, that the initial_readiness_delay kept its original value of 30 (and applied and confirmed that the remote config was not changed too). I did that a couple of times to be sure, and then I updated force_update_default_counter to 1. Sure enough, on the next apply, the old default of 30 was replaced with the new one of 25, and after the successful apply it was changed in the remote config too. I changed the value back to 30 but because I again did NOT update the force_update_default_counter, it stayed at its current value of 25 (and also in remote config). I then updated force_update_default_counter to 2 and once again it picked up the change to the value, setting it to 30. 
