### PR TITLE
Ignore region AWS config

### DIFF
--- a/opta/commands/destroy.py
+++ b/opta/commands/destroy.py
@@ -5,6 +5,7 @@ from typing import Dict, List, Optional
 import boto3
 import click
 from azure.storage.blob import ContainerClient
+from botocore.config import Config
 from google.cloud import storage  # type: ignore
 from google.cloud.exceptions import NotFound
 
@@ -152,8 +153,9 @@ def _aws_get_configs(layer: "Layer") -> List[str]:
     # Opta configs for every layer are saved in the opta_config/ directory
     # in the state bucket.
     bucket_name = layer.state_storage()
+    region = layer.root().providers["aws"]["region"]
     s3_config_dir = "opta_config/"
-    s3_client = boto3.client("s3")
+    s3_client = boto3.client("s3", config=Config(region_name=region))
 
     resp = s3_client.list_objects_v2(Bucket=bucket_name, Prefix=s3_config_dir)
     s3_config_paths = [obj["Key"] for obj in resp.get("Contents", [])]

--- a/opta/core/terraform.py
+++ b/opta/core/terraform.py
@@ -736,7 +736,7 @@ class Terraform:
         bucket_name = providers["terraform"]["backend"]["s3"]["bucket"]
         dynamodb_table = providers["terraform"]["backend"]["s3"]["dynamodb_table"]
         region = providers["terraform"]["backend"]["s3"]["region"]
-        s3 = boto3.client("s3")
+        s3 = boto3.client("s3", config=Config(region_name=region))
         dynamodb = boto3.client("dynamodb", config=Config(region_name=region))
         iam = boto3.client("iam", config=Config(region_name=region))
         try:

--- a/opta/core/terraform.py
+++ b/opta/core/terraform.py
@@ -291,7 +291,8 @@ class Terraform:
     @classmethod
     def _aws_verify_storage(cls, layer: "Layer") -> bool:
         bucket = layer.state_storage()
-        s3 = boto3.client("s3")
+        region = layer.root().providers["aws"]["region"]
+        s3 = boto3.client("s3", config=Config(region_name=region))
         try:
             s3.get_bucket_encryption(Bucket=bucket,)
         except ClientError as e:
@@ -374,12 +375,13 @@ class Terraform:
         providers = layer.gen_providers(0)
         if "s3" in providers.get("terraform", {}).get("backend", {}):
             bucket = providers["terraform"]["backend"]["s3"]["bucket"]
+            region = providers["terraform"]["backend"]["s3"]["region"]
             key = providers["terraform"]["backend"]["s3"]["key"]
             logger.debug(
                 f"Found an s3 backend in bucket {bucket} and key {key}, "
                 "gonna try to download the statefile from there"
             )
-            s3 = boto3.client("s3")
+            s3 = boto3.client("s3", config=Config(region_name=region))
             try:
                 s3.download_file(Bucket=bucket, Key=key, Filename=state_file)
             except ClientError as e:
@@ -460,11 +462,12 @@ class Terraform:
 
         # Delete the state storage bucket
         bucket_name = providers["terraform"]["backend"]["s3"]["bucket"]
-        AWS.delete_bucket(bucket_name)
+        region = providers["terraform"]["backend"]["s3"]["region"]
+        AWS.delete_bucket(bucket_name, region)
 
         # Delete the dynamodb state lock table
         dynamodb_table = providers["terraform"]["backend"]["s3"]["dynamodb_table"]
-        region = providers["terraform"]["backend"]["s3"]["region"]
+
         AWS.delete_dynamodb_table(dynamodb_table, region)
         logger.info("Successfully deleted AWS state storage")
 

--- a/tests/core/test_terraform.py
+++ b/tests/core/test_terraform.py
@@ -156,7 +156,7 @@ class TestTerraform:
         )
         mocked_open.assert_called_once_with("./tmp.tfstate", "r")
         patched_init.assert_not_called()
-        mocked_boto_client.assert_called_once_with("s3")
+        mocked_boto_client.assert_called_once_with("s3", config=mocker.ANY)
 
     def test_google_download_state(self, mocker: MockFixture) -> None:
         layer = mocker.Mock(spec=Layer)
@@ -347,7 +347,7 @@ class TestTerraform:
         )
         mocked_boto3.client.assert_has_calls(
             [
-                mocker.call("s3"),
+                mocker.call("s3", config=mocker.ANY),
                 mocker.call("dynamodb", config=mocker.ANY),
                 mocker.call("iam", config=mocker.ANY),
             ]


### PR DESCRIPTION
# Description
Ignore the AWS Region if any is mentioned in the AWS configuration directory. 
Override it with the Region mentioned in the Environment Configuration.

# Safety checklist
* [x] This change is backwards compatible and safe to apply by existing users
* [x] This change will NOT lead to data loss
* [x] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
Tested Manually.
