### PR TITLE
Modules linked to dbs will now need to wait for db to be fully up

### DIFF
--- a/config/tf_modules/aws-postgres/outputs.tf
+++ b/config/tf_modules/aws-postgres/outputs.tf
@@ -1,20 +1,20 @@
 output "db_user" {
-  value = aws_rds_cluster.db_cluster.master_username
+  value      = aws_rds_cluster.db_cluster.master_username
   depends_on = [aws_rds_cluster_instance.db_instance[0]]
 }
 
 output "db_password" {
-  value     = aws_rds_cluster.db_cluster.master_password
-  sensitive = true
+  value      = aws_rds_cluster.db_cluster.master_password
+  sensitive  = true
   depends_on = [aws_rds_cluster_instance.db_instance[0]]
 }
 
 output "db_host" {
-  value = aws_rds_cluster.db_cluster.endpoint
+  value      = aws_rds_cluster.db_cluster.endpoint
   depends_on = [aws_rds_cluster_instance.db_instance[0]]
 }
 
 output "db_name" {
-  value = aws_rds_cluster.db_cluster.database_name
+  value      = aws_rds_cluster.db_cluster.database_name
   depends_on = [aws_rds_cluster_instance.db_instance[0]]
 }

--- a/config/tf_modules/aws-postgres/outputs.tf
+++ b/config/tf_modules/aws-postgres/outputs.tf
@@ -1,16 +1,20 @@
 output "db_user" {
   value = aws_rds_cluster.db_cluster.master_username
+  depends_on = [aws_rds_cluster_instance.db_instance[0]]
 }
 
 output "db_password" {
   value     = aws_rds_cluster.db_cluster.master_password
   sensitive = true
+  depends_on = [aws_rds_cluster_instance.db_instance[0]]
 }
 
 output "db_host" {
   value = aws_rds_cluster.db_cluster.endpoint
+  depends_on = [aws_rds_cluster_instance.db_instance[0]]
 }
 
 output "db_name" {
   value = aws_rds_cluster.db_cluster.database_name
+  depends_on = [aws_rds_cluster_instance.db_instance[0]]
 }


### PR DESCRIPTION
# Description
Just made the outputs depend on the first db instance to be up and running.


# Safety checklist
* [x] This change is backwards compatible and safe to apply by existing users
* [x] This change will NOT lead to data loss
* [x] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
locally and yup, it's now waiting for db instance
