### PR TITLE
Use Log Bucket Domain name

### DIFF
--- a/config/tf_modules/aws-cloudfront-distribution/main.tf
+++ b/config/tf_modules/aws-cloudfront-distribution/main.tf
@@ -2,6 +2,11 @@ data "aws_s3_bucket" "current_bucket" {
   bucket = var.bucket_name
 }
 
+data "aws_s3_bucket" "logging_bucket" {
+  count = var.s3_log_bucket_name == null ? 0 : 1
+  bucket = var.s3_log_bucket_name
+}
+
 resource "aws_cloudfront_distribution" "s3_distribution" {
   origin {
     domain_name = data.aws_s3_bucket.current_bucket.bucket_regional_domain_name
@@ -21,7 +26,7 @@ resource "aws_cloudfront_distribution" "s3_distribution" {
     for_each = var.s3_log_bucket_name == null ? [] : [1]
     content {
       include_cookies = true
-      bucket          = var.s3_log_bucket_name
+      bucket          = data.aws_s3_bucket.logging_bucket[0].bucket_domain_name
       prefix          = "cloudfront/${var.layer_name}/${var.module_name}"
     }
   }

--- a/config/tf_modules/aws-cloudfront-distribution/main.tf
+++ b/config/tf_modules/aws-cloudfront-distribution/main.tf
@@ -3,7 +3,7 @@ data "aws_s3_bucket" "current_bucket" {
 }
 
 data "aws_s3_bucket" "logging_bucket" {
-  count = var.s3_log_bucket_name == null ? 0 : 1
+  count  = var.s3_log_bucket_name == null ? 0 : 1
   bucket = var.s3_log_bucket_name
 }
 


### PR DESCRIPTION
# Description
Use Bucket Domain name instead of Bucket name for Logging Config.

# Safety checklist
* [X] This change is backwards compatible and safe to apply by existing users
* [X] This change will NOT lead to data loss
* [X] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
Manually created the Cloudfront Distribution with terraform.
