### PR TITLE
Making sure k8s service can be put in env

### DIFF
--- a/opta/commands/apply.py
+++ b/opta/commands/apply.py
@@ -212,7 +212,7 @@ def _apply(
         existing_modules: Set[str] = set()
         first_loop = True
         for module_idx, current_modules, total_block_count in gen(
-            layer, previous_config, image_tag, image_digest, test
+            layer, previous_config, image_tag, image_digest, test, True
         ):
             if first_loop:
                 # This is set during the first iteration, since the tf file must exist.

--- a/opta/core/generator.py
+++ b/opta/core/generator.py
@@ -27,6 +27,7 @@ def gen(
     image_tag: Optional[str] = None,
     image_digest: Optional[str] = None,
     test: bool = False,
+    check_image: bool = False,
 ) -> Generator[Tuple[int, List["Module"], int], None, None]:
     """Generate TF file based on opta config file"""
     logger.debug("Loading infra blocks")
@@ -39,7 +40,11 @@ def gen(
         if not module.halt and module_idx + 1 != total_module_count:
             continue
         service_modules = layer.get_module_by_type("k8s-service", module_idx)
-        if len(service_modules) > 0 and (get_cluster_name(layer.root()) is not None):
+        if (
+            check_image
+            and len(service_modules) > 0
+            and (get_cluster_name(layer.root()) is not None)
+        ):
             configure_kubectl(layer)
 
             for service_module in service_modules:

--- a/opta/layer.py
+++ b/opta/layer.py
@@ -363,7 +363,7 @@ class Layer:
     def get_module(
         self, module_name: str, module_idx: Optional[int] = None
     ) -> Optional[Module]:
-        module_idx = module_idx or len(self.modules) - 1
+        module_idx = len(self.modules) - 1 if module_idx is None else module_idx
         for module in self.modules[0 : module_idx + 1]:
             if module.name == module_name:
                 return module
@@ -384,7 +384,7 @@ class Layer:
     def get_module_by_type(
         self, module_type: str, module_idx: Optional[int] = None
     ) -> list[Module]:
-        module_idx = module_idx or len(self.modules) - 1
+        module_idx = len(self.modules) - 1 if module_idx is None else module_idx
         modules = []
         for module in self.modules[0 : module_idx + 1]:
             if module.type == module_type or module.aliased_type == module_type:
@@ -393,7 +393,7 @@ class Layer:
 
     def outputs(self, module_idx: Optional[int] = None) -> Iterable[str]:
         ret: List[str] = []
-        module_idx = module_idx or len(self.modules) - 1
+        module_idx = len(self.modules) - 1 if module_idx is None else module_idx
         for module in self.modules[0 : module_idx + 1]:
             ret += module.outputs()
         return ret

--- a/tests/commands/test_apply.py
+++ b/tests/commands/test_apply.py
@@ -61,7 +61,6 @@ def test_apply(mocker: MockFixture, mocked_layer: Any, basic_mocks: Any) -> None
     )
 
     mocked_click = mocker.patch("opta.commands.apply.click")
-    mocker.patch("opta.commands.apply.configure_kubectl")
     mocker.patch(
         "opta.commands.apply._fetch_availability_zones", return_value=["a", "b", "c"]
     )
@@ -73,10 +72,6 @@ def test_apply(mocker: MockFixture, mocked_layer: Any, basic_mocks: Any) -> None
     tf_create_storage = mocker.patch("opta.commands.apply.Terraform.create_state_storage")
     mocked_thread = mocker.patch("opta.commands.apply.Thread")
     mocked_layer.get_module_by_type.return_value = [mocker.Mock()]
-    mocker.patch(
-        "opta.commands.apply.current_image_digest_tag",
-        return_value={"tag": "abc", "digest": None},
-    )
 
     # Terraform apply should be called with the configured module (fake_module) and the remote state
     # module (deleted_module) as targets.
@@ -99,9 +94,7 @@ def test_apply(mocker: MockFixture, mocked_layer: Any, basic_mocks: Any) -> None
         "The above are the planned changes for your opta run. Do you approve?",
         abort=True,
     )
-    mocked_layer.get_module_by_type.assert_has_calls(
-        [mocker.call("k8s-service"), mocker.call("k8s-service", 0)]
-    )
+    mocked_layer.get_module_by_type.assert_has_calls([mocker.call("k8s-service", 0)])
     mocked_layer.validate_required_path_dependencies.assert_called_once()
     tf_create_storage.assert_called_once_with(mocked_layer)
     mocked_thread.assert_has_calls(
@@ -131,7 +124,6 @@ def test_auto_approve(mocker: MockFixture, mocked_layer: Any, basic_mocks: Any) 
     )
 
     mocked_click = mocker.patch("opta.commands.apply.click")
-    mocker.patch("opta.commands.apply.configure_kubectl")
     mocker.patch(
         "opta.commands.apply._fetch_availability_zones", return_value=["a", "b", "c"]
     )
@@ -143,10 +135,6 @@ def test_auto_approve(mocker: MockFixture, mocked_layer: Any, basic_mocks: Any) 
     tf_create_storage = mocker.patch("opta.commands.apply.Terraform.create_state_storage")
     mocked_thread = mocker.patch("opta.commands.apply.Thread")
     mocked_layer.get_module_by_type.return_value = [mocker.Mock()]
-    mocker.patch(
-        "opta.commands.apply.current_image_digest_tag",
-        return_value={"tag": "abc", "digest": None},
-    )
 
     # Terraform apply should be called with the configured module (fake_module) and the remote state
     # module (deleted_module) as targets.
@@ -166,9 +154,7 @@ def test_auto_approve(mocker: MockFixture, mocked_layer: Any, basic_mocks: Any) 
         layer=mocked_layer,
     )
     mocked_click.confirm.assert_not_called()
-    mocked_layer.get_module_by_type.assert_has_calls(
-        [mocker.call("k8s-service"), mocker.call("k8s-service", 0)]
-    )
+    mocked_layer.get_module_by_type.assert_has_calls([mocker.call("k8s-service", 0)])
     tf_create_storage.assert_called_once_with(mocked_layer)
     mocked_thread.assert_has_calls(
         [


### PR DESCRIPTION
# Description
Code fixes to make sure k8s services can go in env files directly

# Safety checklist
* [x] This change is backwards compatible and safe to apply by existing users
* [x] This change will NOT lead to data loss
* [x] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
manually run in existing and new envs
