### PR TITLE
Separate the Unlock and Helm Command.

### DIFF
--- a/opta/commands/force_unlock.py
+++ b/opta/commands/force_unlock.py
@@ -28,23 +28,66 @@ def force_unlock(config: str, env: Optional[str]) -> None:
     amplitude_client.send_event(amplitude_client.FORCE_UNLOCK_EVENT)
     layer = Layer.load_from_yaml(config, env)
     layer.verify_cloud_credentials()
+    modules = Terraform.get_existing_modules(layer)
+    layer.modules = [x for x in layer.modules if x.name in modules]
     gen_all(layer)
 
-    Terraform.init(layer=layer)
+    if Terraform.download_state(layer):
+        tf_lock_exists, _ = Terraform.tf_lock_details(layer)
+        if tf_lock_exists:
+            Terraform.init(layer=layer)
+            click.confirm(
+                "This will remove the lock on the remote state."
+                "\nPlease make sure that no other instance of opta command is running on this file."
+                "\nDo you still want to proceed?",
+                abort=True,
+            )
+            tf_flags.append("-force")
+            Terraform.force_unlock(layer, *tf_flags)
 
-    click.confirm(
-        "This will remove the lock on the remote state."
-        "\n\tPlease make sure that no other instance of opta command is running on this file."
-        "\n\tDo you still want to proceed?",
-        abort=True,
-    )
+        if "k8scluster" in modules:
+            configure_kubectl(layer)
+            pending_upgrade_release_list = Helm.get_helm_list(status="pending-upgrade")
+            click.confirm(
+                "Do you also wish to Rollback the Helm releases in Pending-Upgrade State?"
+                "\nPlease make sure that no other instance of opta command is running on this file."
+                "\nDo you still want to proceed?",
+                abort=True,
+            )
 
-    Terraform.force_unlock(layer, *tf_flags)
-    configure_kubectl(layer)
+            for release in pending_upgrade_release_list:
+                Helm.rollback_helm(
+                    release["name"],
+                    namespace=release["namespace"],
+                    revision=release["revision"],
+                )
 
-    release_list = Helm.get_helm_list(status="pending-upgrade")
+    # Terraform.init(layer=layer)
+    #
+    # click.confirm(
+    #     "This will remove the lock on the remote state."
+    #     "\nPlease make sure that no other instance of opta command is running on this file."
+    #     "\nDo you still want to proceed?",
+    #     abort=True,
+    # )
+    #
+    # Terraform.force_unlock(layer, *tf_flags)
+    #
+    # click.confirm(
+    #     "Do you also wish to Rollback the Helm releases in Pending-Upgrade State?"
+    #     "\nPlease make sure that no other instance of opta command is running on this file."
+    #     "\nDo you still want to proceed?",
+    #     abort=True,
+    # )
+    # configure_kubectl(layer)
+    #
+    # release_list = Helm.get_helm_list(status="pending-upgrade")
+    #
+    # for release in release_list:
+    #     Helm.rollback_helm(
+    #         release["name"], namespace=release["namespace"], revision=release["revision"]
+    #     )
 
-    for release in release_list:
-        Helm.rollback_helm(
-            release["name"], namespace=release["namespace"], revision=release["revision"]
-        )
+
+# def _check_cluster_exists(layer: "Layer") -> bool:
+#     if layer.get_module_by_type()

--- a/opta/commands/force_unlock.py
+++ b/opta/commands/force_unlock.py
@@ -45,7 +45,7 @@ def force_unlock(config: str, env: Optional[str]) -> None:
             tf_flags.append("-force")
             Terraform.force_unlock(layer, *tf_flags)
 
-        if "k8scluster" in modules:
+        if layer.parent is not None or "k8scluster" in modules:
             configure_kubectl(layer)
             pending_upgrade_release_list = Helm.get_helm_list(status="pending-upgrade")
             click.confirm(

--- a/opta/commands/force_unlock.py
+++ b/opta/commands/force_unlock.py
@@ -61,33 +61,3 @@ def force_unlock(config: str, env: Optional[str]) -> None:
                     namespace=release["namespace"],
                     revision=release["revision"],
                 )
-
-    # Terraform.init(layer=layer)
-    #
-    # click.confirm(
-    #     "This will remove the lock on the remote state."
-    #     "\nPlease make sure that no other instance of opta command is running on this file."
-    #     "\nDo you still want to proceed?",
-    #     abort=True,
-    # )
-    #
-    # Terraform.force_unlock(layer, *tf_flags)
-    #
-    # click.confirm(
-    #     "Do you also wish to Rollback the Helm releases in Pending-Upgrade State?"
-    #     "\nPlease make sure that no other instance of opta command is running on this file."
-    #     "\nDo you still want to proceed?",
-    #     abort=True,
-    # )
-    # configure_kubectl(layer)
-    #
-    # release_list = Helm.get_helm_list(status="pending-upgrade")
-    #
-    # for release in release_list:
-    #     Helm.rollback_helm(
-    #         release["name"], namespace=release["namespace"], revision=release["revision"]
-    #     )
-
-
-# def _check_cluster_exists(layer: "Layer") -> bool:
-#     if layer.get_module_by_type()

--- a/tests/commands/test_force_unlock.py
+++ b/tests/commands/test_force_unlock.py
@@ -5,6 +5,7 @@ from pytest_mock import MockFixture
 
 from opta.cli import cli
 from opta.layer import Layer
+from opta.module import Module
 
 FAKE_ENV_CONFIG = os.path.join(
     os.path.dirname(os.path.dirname(__file__)),
@@ -20,6 +21,11 @@ def test_force_unlock_env(mocker: MockFixture) -> None:
     mocked_os_path_exists = mocker.patch("opta.utils.os.path.exists")
     mocked_os_path_exists.return_value = True
     mocked_layer = mocker.Mock(spec=Layer)
+    mocked_module_1 = mocker.Mock(spec=Module)
+    mocked_module_1.name = "base"
+    mocked_module_2 = mocker.Mock(spec=Module)
+    mocked_module_2.name = "k8scluster"
+    mocked_layer.modules = [mocked_module_1, mocked_module_2]
     mocker.patch(
         "opta.commands.force_unlock.Layer.load_from_yaml", return_value=mocked_layer
     )
@@ -27,8 +33,92 @@ def test_force_unlock_env(mocker: MockFixture) -> None:
     mocker.patch(
         "opta.commands.force_unlock.Layer.verify_cloud_credentials", return_value=None
     )
+    mocker.patch(
+        "opta.commands.force_unlock.Terraform.get_existing_modules",
+        return_value=["base", "k8scluster"],
+    )
     mocker.patch("opta.commands.force_unlock.gen_all")
     mocker.patch("opta.commands.force_unlock.Terraform.init")
+    mocker.patch("opta.commands.force_unlock.Terraform.download_state", return_value=True)
+    mocker.patch(
+        "opta.commands.apply.Terraform.tf_lock_details",
+        return_value=(True, "mock_lock_id"),
+    )
+    mocker.patch("opta.commands.force_unlock.Terraform.force_unlock")
+    mocker.patch("opta.commands.force_unlock.configure_kubectl")
+    mocked_helm_list = mocker.patch(
+        "opta.commands.force_unlock.Helm.get_helm_list",
+        return_value=[
+            {
+                "name": "mocked-app",
+                "namespace": "mocked-namespace",
+                "revision": "1",
+                "updated": "2021-09-23 19:55:15.503881027 +0000 UTC",
+                "status": "pending-upgrade",
+                "chart": "mocked-chart",
+                "app_version": "mocked-version",
+            }
+        ],
+    )
+    mocked_rollback_helm = mocker.patch("opta.commands.force_unlock.Helm.rollback_helm")
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["force-unlock", "--config", FAKE_ENV_CONFIG])
+
+    assert result.exit_code == 0
+    mocked_click_confirm.assert_has_calls(
+        [
+            mocker.call(
+                "This will remove the lock on the remote state."
+                "\nPlease make sure that no other instance of opta command is running on this file."
+                "\nDo you still want to proceed?",
+                abort=True,
+            ),
+            mocker.call(
+                "Do you also wish to Rollback the Helm releases in Pending-Upgrade State?"
+                "\nPlease make sure that no other instance of opta command is running on this file."
+                "\nDo you still want to proceed?",
+                abort=True,
+            ),
+        ]
+    )
+    mocked_helm_list.assert_called_once_with(status="pending-upgrade")
+    mocked_rollback_helm.assert_called_once_with(
+        "mocked-app", namespace="mocked-namespace", revision="1"
+    )
+
+
+def test_force_unlock_env_no_cluster(mocker: MockFixture) -> None:
+    mocked_click_confirm = mocker.patch(
+        "opta.commands.apply.click.confirm", return_value="y"
+    )
+    mocked_os_path_exists = mocker.patch("opta.utils.os.path.exists")
+    mocked_os_path_exists.return_value = True
+    mocked_layer = mocker.Mock(spec=Layer)
+    mocked_module_1 = mocker.Mock(spec=Module)
+    mocked_module_1.name = "base"
+    mocked_module_2 = mocker.Mock(spec=Module)
+    mocked_module_2.name = "k8scluster"
+    # mocked_layer.modules = [mocked_module_1, mocked_module_2]
+    mocked_layer.modules = [mocked_module_1]
+    mocker.patch(
+        "opta.commands.force_unlock.Layer.load_from_yaml", return_value=mocked_layer
+    )
+    mocker.patch("opta.commands.force_unlock.amplitude_client.send_event")
+    mocker.patch(
+        "opta.commands.force_unlock.Layer.verify_cloud_credentials", return_value=None
+    )
+    mocker.patch(
+        "opta.commands.force_unlock.Terraform.get_existing_modules",
+        return_value=["base"],
+    )
+    mocker.patch("opta.commands.force_unlock.gen_all")
+    mocker.patch("opta.commands.force_unlock.Terraform.init")
+    mocker.patch("opta.commands.force_unlock.Terraform.download_state", return_value=True)
+    mocker.patch(
+        "opta.commands.apply.Terraform.tf_lock_details",
+        return_value=(True, "mock_lock_id"),
+    )
     mocker.patch("opta.commands.force_unlock.Terraform.force_unlock")
     mocker.patch("opta.commands.force_unlock.configure_kubectl")
     mocked_helm_list = mocker.patch(
@@ -53,14 +143,12 @@ def test_force_unlock_env(mocker: MockFixture) -> None:
     assert result.exit_code == 0
     mocked_click_confirm.assert_called_once_with(
         "This will remove the lock on the remote state."
-        "\n\tPlease make sure that no other instance of opta command is running on this file."
-        "\n\tDo you still want to proceed?",
+        "\nPlease make sure that no other instance of opta command is running on this file."
+        "\nDo you still want to proceed?",
         abort=True,
     )
-    mocked_helm_list.assert_called_once_with(status="pending-upgrade")
-    mocked_rollback_helm.assert_called_once_with(
-        "mocked-app", namespace="mocked-namespace", revision="1"
-    )
+    mocked_helm_list.assert_not_called()
+    mocked_rollback_helm.assert_not_called()
 
 
 def test_force_unlock_env_no_rollback(mocker: MockFixture) -> None:
@@ -70,6 +158,11 @@ def test_force_unlock_env_no_rollback(mocker: MockFixture) -> None:
     mocked_os_path_exists = mocker.patch("opta.utils.os.path.exists")
     mocked_os_path_exists.return_value = True
     mocked_layer = mocker.Mock(spec=Layer)
+    mocked_module_1 = mocker.Mock(spec=Module)
+    mocked_module_1.name = "base"
+    mocked_module_2 = mocker.Mock(spec=Module)
+    mocked_module_2.name = "k8scluster"
+    mocked_layer.modules = [mocked_module_1, mocked_module_2]
     mocker.patch(
         "opta.commands.force_unlock.Layer.load_from_yaml", return_value=mocked_layer
     )
@@ -77,8 +170,17 @@ def test_force_unlock_env_no_rollback(mocker: MockFixture) -> None:
     mocker.patch(
         "opta.commands.force_unlock.Layer.verify_cloud_credentials", return_value=None
     )
+    mocker.patch(
+        "opta.commands.force_unlock.Terraform.get_existing_modules",
+        return_value=["base", "k8scluster"],
+    )
     mocker.patch("opta.commands.force_unlock.gen_all")
     mocker.patch("opta.commands.force_unlock.Terraform.init")
+    mocker.patch("opta.commands.force_unlock.Terraform.download_state", return_value=True)
+    mocker.patch(
+        "opta.commands.apply.Terraform.tf_lock_details",
+        return_value=(True, "mock_lock_id"),
+    )
     mocker.patch("opta.commands.force_unlock.Terraform.force_unlock")
     mocker.patch("opta.commands.force_unlock.configure_kubectl")
     mocked_helm_list = mocker.patch(
@@ -90,11 +192,21 @@ def test_force_unlock_env_no_rollback(mocker: MockFixture) -> None:
     result = runner.invoke(cli, ["force-unlock", "--config", FAKE_ENV_CONFIG])
 
     assert result.exit_code == 0
-    mocked_click_confirm.assert_called_once_with(
-        "This will remove the lock on the remote state."
-        "\n\tPlease make sure that no other instance of opta command is running on this file."
-        "\n\tDo you still want to proceed?",
-        abort=True,
+    mocked_click_confirm.assert_has_calls(
+        [
+            mocker.call(
+                "This will remove the lock on the remote state."
+                "\nPlease make sure that no other instance of opta command is running on this file."
+                "\nDo you still want to proceed?",
+                abort=True,
+            ),
+            mocker.call(
+                "Do you also wish to Rollback the Helm releases in Pending-Upgrade State?"
+                "\nPlease make sure that no other instance of opta command is running on this file."
+                "\nDo you still want to proceed?",
+                abort=True,
+            ),
+        ]
     )
     mocked_helm_list.assert_called_once_with(status="pending-upgrade")
     mocked_rollback_helm.assert_not_called()

--- a/tests/commands/test_force_unlock.py
+++ b/tests/commands/test_force_unlock.py
@@ -21,6 +21,7 @@ def test_force_unlock_env(mocker: MockFixture) -> None:
     mocked_os_path_exists = mocker.patch("opta.utils.os.path.exists")
     mocked_os_path_exists.return_value = True
     mocked_layer = mocker.Mock(spec=Layer)
+    mocked_layer.parent = None
     mocked_module_1 = mocker.Mock(spec=Module)
     mocked_module_1.name = "base"
     mocked_module_2 = mocker.Mock(spec=Module)
@@ -95,6 +96,7 @@ def test_force_unlock_env_no_cluster(mocker: MockFixture) -> None:
     mocked_os_path_exists = mocker.patch("opta.utils.os.path.exists")
     mocked_os_path_exists.return_value = True
     mocked_layer = mocker.Mock(spec=Layer)
+    mocked_layer.parent = None
     mocked_module_1 = mocker.Mock(spec=Module)
     mocked_module_1.name = "base"
     mocked_module_2 = mocker.Mock(spec=Module)
@@ -158,6 +160,7 @@ def test_force_unlock_env_no_rollback(mocker: MockFixture) -> None:
     mocked_os_path_exists = mocker.patch("opta.utils.os.path.exists")
     mocked_os_path_exists.return_value = True
     mocked_layer = mocker.Mock(spec=Layer)
+    mocked_layer.parent = None
     mocked_module_1 = mocker.Mock(spec=Module)
     mocked_module_1.name = "base"
     mocked_module_2 = mocker.Mock(spec=Module)


### PR DESCRIPTION
# Description
Separate the Terraform Unlock and Helm Release command.


# Safety checklist
* [X] This change is backwards compatible and safe to apply by existing users
* [X] This change will NOT lead to data loss
* [X] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
Tested Manually by Creating the Environment in AWS and GCP. Tested Force Unlock before and after k8s-cluster creation,
