### PR TITLE
Adding random string suffix to gcp service accounts

### DIFF
--- a/modules/gcp_k8s_service/tf_module/iam.tf
+++ b/modules/gcp_k8s_service/tf_module/iam.tf
@@ -1,6 +1,13 @@
+resource "random_string" "suffix" {
+  length  = 4
+  upper   = false
+  special = false
+}
+
 resource "google_service_account" "k8s_service" {
-  account_id   = "${local.env_short}-${local.layer_short}-${local.module_short}"
-  display_name = "${local.env_short}-${local.layer_short}-${local.module_short}"
+  account_id   = "${local.layer_short}-${local.module_short}-${random_string.suffix.result}"
+  display_name = "${local.layer_short}-${local.module_short}-${random_string.suffix.result}"
+  lifecycle { ignore_changes = [account_id, display_name] }
 }
 
 resource "google_service_account_iam_binding" "trust_k8s_workload_idu" {

--- a/modules/gcp_k8s_service/tf_module/variables.tf
+++ b/modules/gcp_k8s_service/tf_module/variables.tf
@@ -9,9 +9,8 @@ locals {
     domain : trim(split("/", s)[0], "."),
     pathPrefix : (length(split("/", s)) > 1 ? "/${join("/", slice(split("/", s), 1, length(split("/", s))))}" : "/")
   }]
-  env_short       = substr(var.env_name, 0, 9)
-  layer_short     = substr(var.layer_name, 0, 9)
-  module_short    = substr(var.module_name, 0, 9)
+  layer_short     = substr(var.layer_name, 0, 12)
+  module_short    = substr(var.module_name, 0, 12)
   get_buckets     = toset(concat(var.read_buckets, var.write_buckets))
   uppercase_image = upper(var.image)
 }

--- a/modules/gcp_service_account/tf_module/main.tf
+++ b/modules/gcp_service_account/tf_module/main.tf
@@ -1,6 +1,13 @@
+resource "random_string" "suffix" {
+  length  = 4
+  upper   = false
+  special = false
+}
+
 resource "google_service_account" "k8s_service" {
-  account_id   = var.explicit_name == null ? "${local.env_short}-${local.layer_short}-${local.module_short}" : var.explicit_name
-  display_name = var.explicit_name == null ? "${local.env_short}-${local.layer_short}-${local.module_short}" : var.explicit_name
+  account_id   = var.explicit_name == null ? "${local.layer_short}-${local.module_short}-${random_string.suffix.result}" : var.explicit_name
+  display_name = var.explicit_name == null ? "${local.layer_short}-${local.module_short}-${random_string.suffix.result}" : var.explicit_name
+  lifecycle { ignore_changes = [account_id, display_name] }
 }
 
 resource "google_service_account_iam_binding" "trust_k8s_workload_idu" {

--- a/modules/gcp_service_account/tf_module/variables.tf
+++ b/modules/gcp_service_account/tf_module/variables.tf
@@ -3,9 +3,8 @@ data "google_client_config" "current" {}
 
 
 locals {
-  env_short    = substr(replace(var.env_name, "-", ""), 0, 9)
-  layer_short  = substr(replace(var.layer_name, "-", ""), 0, 9)
-  module_short = substr(replace(var.module_name, "-", ""), 0, 9)
+  layer_short  = substr(replace(var.layer_name, "-", ""), 0, 12)
+  module_short = substr(replace(var.module_name, "-", ""), 0, 12)
   get_buckets  = toset(concat(var.read_buckets, var.write_buckets))
 }
 


### PR DESCRIPTION
# Description
We've been bitten too often about gcp service accounts with same ids, so now we're adding a random suffix. Also, don't worry no existing ones will change cause, this is just for new ones


# Safety checklist
* [x] This change is backwards compatible and safe to apply by existing users
* [x] This change will NOT lead to data loss
* [x] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
n/a