### PR TITLE
Adding some retry to websocket tests

### DIFF
--- a/examples/ci-tests/create-and-destroy-aws/websocket-validate.py
+++ b/examples/ci-tests/create-and-destroy-aws/websocket-validate.py
@@ -1,17 +1,25 @@
+import time
 from os import environ
 
 from websocket import WebSocket
 
 ws = WebSocket()
 HOST: str = environ.get("HOST", "")
-try:
-    ws.connect(f"ws://{HOST}/websocket")
-    test_message = "Test WebSocket"
-    ws.send(test_message)
-    actual_result = ws.recv()
-    expected_result = f"Server received from client: {test_message}"
-    assert expected_result == actual_result
-    exit(0)
-except Exception as e:
-    print(e)
-    exit(1)
+retry_count = 0
+while True:
+    try:
+        ws.connect(f"ws://{HOST}/websocket")
+        test_message = "Test WebSocket"
+        ws.send(test_message)
+        actual_result = ws.recv()
+        expected_result = f"Server received from client: {test_message}"
+        assert expected_result == actual_result
+        exit(0)
+    except Exception as e:
+        if retry_count < 15:
+            print(f"Got exception {e}. Retrying in a bit")
+            time.sleep(retry_count)
+            retry_count += 1
+        else:
+            print(e)
+            exit(1)


### PR DESCRIPTION
# Description
Cause the test is flaky

# Safety checklist
* [x] This change is backwards compatible and safe to apply by existing users
* [x] This change will NOT lead to data loss
* [x] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
n/a
