### PR TITLE
Adding a wait for in opta base cause it keeps race conditioning

### DIFF
--- a/modules/aws_k8s_base/tf_module/opta_base.tf
+++ b/modules/aws_k8s_base/tf_module/opta_base.tf
@@ -10,6 +10,17 @@ resource "helm_release" "opta_base" {
     })
   ]
   depends_on = [
-    helm_release.cert_manager
+    time_sleep.wait_a_bit
   ]
+}
+
+resource "time_sleep" "wait_a_bit" {
+  depends_on = [
+    helm_release.cert_manager,
+    helm_release.autoscaler,
+    helm_release.load_balancer,
+    helm_release.external-dns
+  ]
+
+  create_duration = "30s"
 }


### PR DESCRIPTION
# Description
Like right here: https://app.circleci.com/pipelines/github/run-x/opta/305/workflows/7f590e3d-1b1c-40de-a7ab-c88c52a44d25/jobs/689

So now opta base waits 30 seconds to make sure all the things it depends on are up and running smoothly


# Safety checklist
* [x] This change is backwards compatible and safe to apply by existing users
* [x] This change will NOT lead to data loss
* [x] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
YOUR_ANSWER
