### PR TITLE
Broken iam user interpolation

### DIFF
--- a/modules/aws_iam_user/aws_iam_user.py
+++ b/modules/aws_iam_user/aws_iam_user.py
@@ -32,7 +32,7 @@ class AwsIamUserProcessor(ModuleProcessor, AWSIamAssembler):
                 "Sid": "AllowManageOwnPasswords",
                 "Effect": "Allow",
                 "Action": ["iam:ChangePassword", "iam:GetUser"],
-                "Resource": "arn:aws:iam::*:user/${aws:username}",
+                "Resource": "arn:aws:iam::*:user/$${{aws:username}}",
             },
             {
                 "Sid": "AllowManageOwnAccessKeys",
@@ -43,7 +43,7 @@ class AwsIamUserProcessor(ModuleProcessor, AWSIamAssembler):
                     "iam:ListAccessKeys",
                     "iam:UpdateAccessKey",
                 ],
-                "Resource": "arn:aws:iam::*:user/${aws:username}",
+                "Resource": "arn:aws:iam::*:user/$${{aws:username}}",
             },
             {
                 "Sid": "PolicySimulatorAPI",


### PR DESCRIPTION
# Description
This never worked. Need to escape terraform and python interpolation

# Safety checklist
* [x] This change is backwards compatible and safe to apply by existing users
* [x] This change will NOT lead to data loss
* [x] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
Ran locally
