### PR TITLE
Added the flag ENABLE_DATADOG_TO_CONSOLE_IN_DEV

### DIFF
--- a/opta/nice_subprocess.py
+++ b/opta/nice_subprocess.py
@@ -26,11 +26,11 @@ nice_logger.propagate = False
 def log_to_datadog(msg: str, severity: str) -> None:
     msg = ansi_scrub(msg)
     if hasattr(sys, "_called_from_test") or VERSION == DEV_VERSION or not VERSION:
-        print("Not logging to Datadog as this appears to be a dev/test version of opta")
-        print("Would have logged this string to DD:\n")
-        print(">>>>>>>>>>>>>>>>>>>>Datadog log start")
-        print(msg)
-        print("<<<<<<<<<<<<<<<<<<<<Datadog log end")
+        if os.environ.get("ENABLE_DATADOG_TO_CONSOLE_IN_DEV", ""):
+            print("Would have logged this string to DD:\n")
+            print(">>>>>>>>>>>>>>>>>>>>Datadog log start")
+            print(msg)
+            print("<<<<<<<<<<<<<<<<<<<<Datadog log end")
         dd_handler.setLevel(logging.CRITICAL)
 
     if severity == "ERROR":

--- a/opta/nice_subprocess.py
+++ b/opta/nice_subprocess.py
@@ -26,7 +26,7 @@ nice_logger.propagate = False
 def log_to_datadog(msg: str, severity: str) -> None:
     msg = ansi_scrub(msg)
     if hasattr(sys, "_called_from_test") or VERSION == DEV_VERSION or not VERSION:
-        if os.environ.get("ENABLE_DATADOG_TO_CONSOLE_IN_DEV", ""):
+        if os.environ.get("OPTA_DEBUG", "") == "DATADOG_LOCAL":
             print("Would have logged this string to DD:\n")
             print(">>>>>>>>>>>>>>>>>>>>Datadog log start")
             print(msg)


### PR DESCRIPTION
# Description
We have too much log while doing development - this is the Datadog text that is instead printed on screen.
With this PR, the log is ONLY printed if OPTA_DEBUG is set to DATADOG_LOCAL.
# Safety checklist
* [ *] This change is backwards compatible and safe to apply by existing users
* [* ] This change will NOT lead to data loss
* [* ] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
Manually tested 
