### PR TITLE
Initial preprocessor work; untested

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,9 @@ name: CI
 
 on:
   push:
-    branches: [main, dev]
+    branches: [main, dev, feature/module-api]
   pull_request:
-    branches: [main, dev]
+    branches: [main, dev, feature/module-api]
 
 jobs:
   no-pdb:

--- a/opta/layer.py
+++ b/opta/layer.py
@@ -72,6 +72,7 @@ from opta.crash_reporter import CURRENT_CRASH_REPORTER
 from opta.exceptions import UserErrors
 from opta.module import Module
 from opta.plugins.derived_providers import DerivedProviders
+from opta.preprocessor import preprocess_layer
 from opta.utils import deep_merge, hydrate, logger, yaml
 from opta.utils.dependencies import validate_installed_path_executables
 
@@ -222,6 +223,8 @@ class Layer:
             conf = yaml.load(config_string)
         else:
             raise UserErrors(f"File {config} not found")
+
+        preprocess_layer(conf)
 
         conf["original_spec"] = config_string
         conf["path"] = config_path

--- a/opta/preprocessor/__init__.py
+++ b/opta/preprocessor/__init__.py
@@ -1,0 +1,38 @@
+from opta.exceptions import UserErrors
+from opta.preprocessor.registry import registered
+from opta.preprocessor.util import CURRENT_VERSION, DEFAULT_VERSION
+
+
+def preprocess_layer(data: dict) -> None:
+    version = data.setdefault("version", DEFAULT_VERSION)
+    if not isinstance(version, int):
+        raise UserErrors("Layer YAML version must be an int")
+
+    if version == CURRENT_VERSION:
+        return
+
+    processors = registered()
+    if version not in processors:
+        raise UserErrors(f"Unsupported YAML version {version}")
+
+    while version < CURRENT_VERSION:
+        processor = processors[version]
+        processor.process(data)
+
+        new_version = data["version"]
+        if new_version == version:
+            raise RuntimeError(
+                f"YAML preprocessor for version {version} did not update the YAML version"
+            )
+
+        if new_version < version:
+            raise RuntimeError(
+                f"YAML preprocessor for version {version} must not regress the YAML version"
+            )
+
+        if new_version not in processors:
+            raise RuntimeError(
+                f"YAML preprocessor for version {version} must not return an unsupported YAML version"
+            )
+
+        version = new_version

--- a/opta/preprocessor/registry.py
+++ b/opta/preprocessor/registry.py
@@ -1,0 +1,31 @@
+from typing import Dict
+
+from opta.preprocessor.util import VersionProcessor
+from opta.preprocessor.v1 import V1
+
+RegistryType = Dict[int, VersionProcessor]
+
+_version_processors: RegistryType = {}
+
+
+def register_single(version: int, processor: VersionProcessor) -> None:
+    if version in _version_processors:
+        raise ValueError(f"Version {version} already has a registered preprocessor")
+
+    _version_processors[version] = processor
+
+
+def register(processor: VersionProcessor) -> None:
+    for version in processor.versions:
+        register_single(version, processor)
+
+
+def register_all() -> None:
+    register(V1)
+
+
+def registered() -> RegistryType:
+    if not _version_processors:
+        register_all()
+
+    return _version_processors.copy()

--- a/opta/preprocessor/util.py
+++ b/opta/preprocessor/util.py
@@ -1,0 +1,115 @@
+from typing import Any, Callable, Iterable, Optional, Union
+
+from opta.exceptions import UserErrors
+
+DEFAULT_VERSION = 1
+CURRENT_VERSION = 2
+
+Handler = Callable[[dict], None]
+
+
+class VersionProcessor:
+    """
+    Processes a layer YAML for specific versions.
+    """
+    def __init__(
+        self,
+        *,
+        versions: Union[int, Iterable[int]],
+        next_version: Optional[int] = None,
+        handlers: Iterable[Handler] = tuple(),
+    ):
+        """
+        `versions` is a single YAML version or an iterable of different versions.
+        `next_version` is the version that this processor converts to;
+            if unspecified and only a single version is given to `versions`, this defaults to the version plus one.
+        `handlers` is the list of callables that will do the processing from one version to another
+        """
+        if isinstance(versions, int):
+            versions = (versions,)
+
+        self.versions = tuple(versions)
+
+        if next_version is None:
+            if len(self.versions) > 1:
+                raise ValueError(
+                    f"must supply next_version when a {type(self).__name__} supports multiple versions"
+                )
+
+            next_version = self.versions[0] + 1
+
+        self.next_version = next_version
+        self.handlers = tuple(handlers)
+
+    def process(self, data: dict) -> None:
+        for handler in self.handlers:
+            handler(data)
+
+        data["version"] = self.next_version
+
+
+class ModuleHandler:
+    """
+    A `Handler` that handles each module in the YAML separately.
+    It can either be used by subclassing and overriding the `run` method, or passing the `handler` parameter in the constructor.
+    """
+    def __init__(self, handler: Optional[Handler] = None):
+        """
+        `handler` is the Handler that is called for each module this `ModuleHandler` processes.
+        If not passed, this class must be subclasses instead and the `run` method overridden.
+        """
+        self._handler = handler
+
+        # Validate invariants now to "fail fast" instead of waiting for the handler to actually be used
+        if not self._handler:
+            parent = ModuleHandler
+            child = self.__class__
+            if parent.run == child.run and parent.__call__ == child.__call__:
+                # No handler passed, and subclass hasn't overridden the `run` or __call__ methods.
+                raise RuntimeError("Must pass a handler if not using a child class that overrides run or __call__")
+
+
+
+    def __call__(self, data: dict) -> None:
+        """
+
+        """
+        modules = data.get("modules", [])
+        if not isinstance(modules, list):
+            raise UserErrors("Expected `modules` in layer to be list")
+
+        for idx, module in enumerate(modules):
+            if not isinstance(module, dict):
+                raise UserErrors(f"Expected `modules[{idx}]` to be dict")
+
+            if not self.should_handle(module):
+                continue
+
+            self.run(module)
+
+    def should_handle(self, module: dict) -> bool:
+        return True
+
+    def run(self, module: dict) -> None:
+        if self._handler:
+            self._handler(module)
+        else:
+            raise NotImplementedError("Child class must implement this method")
+
+
+class ModuleTypeHandler(ModuleHandler):
+    def __init__(self, types: Union[str, Iterable[str]], *args: Any, **kwargs: Any):
+        super().__init__(*args, **kwargs)
+
+        if isinstance(types, str):
+            types = (types,)
+
+        self.__types = tuple(types)
+
+    def should_handle(self, module: dict) -> bool:
+        try:
+            type = module["type"]
+        except KeyError:
+            raise UserErrors("Module type not set")
+
+        return type in self.__types

--- a/opta/preprocessor/v1.py
+++ b/opta/preprocessor/v1.py
@@ -1,0 +1,59 @@
+from string import Formatter
+
+from opta.preprocessor.util import ModuleHandler, VersionProcessor
+from opta.utils.ref import Reference, ReferenceParseError
+from opta.utils.visit import Visitor
+
+
+def reformat_interpolation_deep(data: dict) -> None:
+    """
+    Reformats all interpolated strings (`{foo}`) into the new interpolation format
+    """
+    visitor = Visitor(data)
+
+    skip_fields = [
+        Reference("type"),
+    ]
+
+    for ref, value in visitor:
+        if not ref or ref in skip_fields:
+            continue
+
+        if not isinstance(value, str):
+            continue
+
+        new_value = reformat_interpolation(value)
+        if new_value == value:
+            continue
+
+        visitor[ref] = new_value
+
+
+def reformat_interpolation(input: str) -> str:
+    formatter = Formatter()
+
+    output = []
+    for literal, field_name, format_spec, conversion in formatter.parse(input):
+        output.append(literal)
+
+        if not field_name:
+            continue
+
+        if format_spec:
+            raise ValueError("format_spec in formatted string not supported")
+
+        if conversion:
+            raise ValueError("conversion field in formatted string not supported")
+
+        try:
+            Reference.parse(field_name)
+        except ReferenceParseError:
+            raise ValueError(f"invalid reference value: {field_name}")
+
+        new_syntax = "${" + field_name + "}"
+        output.append(new_syntax)
+
+    return "".join(output)
+
+
+V1 = VersionProcessor(versions=1, handlers=[ModuleHandler(reformat_interpolation_deep)])

--- a/opta/utils/ref.py
+++ b/opta/utils/ref.py
@@ -1,0 +1,166 @@
+import functools
+import re
+from collections import abc
+from typing import Any, Iterable, Iterator, Sequence, Tuple, TypeVar, Union, overload
+
+from opta.utils.yaml import register_yaml_class
+
+_PART_REGEX = re.compile(r"[a-z]([a-z0-9_]*[a-z0-9])?", re.IGNORECASE)
+_INTERPOLATION_REGEX = re.compile(
+    r"\$\{(" + _PART_REGEX.pattern + r"(?:\." + _PART_REGEX.pattern + r")*)\}",
+    re.IGNORECASE,
+)
+
+PathElement = Union[str, int]
+TRef = TypeVar("TRef", bound="Reference")
+
+
+class ReferenceParseError(ValueError):
+    pass
+
+
+@functools.total_ordering
+class Reference(Sequence):
+    __slots__ = ("_path",)
+
+    def __init__(self, *path: PathElement, skip_validation: bool = False) -> None:
+        self._path: Tuple[PathElement, ...] = path or tuple()
+
+        if not skip_validation:
+            self._validate_path()
+
+    def __str__(self) -> str:
+        return ".".join(str(p) for p in self.path)
+
+    def __repr__(self) -> str:
+        cls = type(self).__name__
+
+        return f"{cls}(*{self._path})"
+
+    def __lt__(self, other: Any) -> bool:
+        if not isinstance(other, Reference):
+            return NotImplemented
+
+        return self._path < other.path
+
+    def __eq__(self, other: Any) -> bool:
+        if not isinstance(other, Reference):
+            return NotImplemented
+
+        return self._path == other._path
+
+    @overload
+    def __getitem__(self, idx: int) -> PathElement:
+        ...
+
+    @overload
+    def __getitem__(self: TRef, idx: slice) -> TRef:
+        ...
+
+    def __getitem__(self: TRef, idx: Union[int, slice]) -> Union[PathElement, TRef]:
+        if isinstance(idx, int):
+            return self._path[idx]
+        elif isinstance(idx, slice):
+            cls = type(self)
+
+            return cls(*self._path[idx])
+
+        raise TypeError(f"unsupported type for idx: {type(idx).__name__}")
+
+    def __iter__(self) -> Iterator[PathElement]:
+        return iter(self._path)
+
+    def __len__(self) -> int:
+        return len(self._path)
+
+    def __hash__(self) -> int:
+        return hash(str(self))
+
+    def __add__(self: TRef, other: Union["Reference", Iterable[PathElement]]) -> TRef:
+        # TODO: In python 3.10, replace this with isinstance(other, PathElement)
+        def ispathelement(x: Any) -> bool:
+            return isinstance(x, str) or isinstance(x, int)
+
+        if isinstance(other, Reference):
+            return self.join(other)
+        elif isinstance(other, abc.Iterable) and all(ispathelement(x) for x in other):
+            return self.child(*other)
+
+        return NotImplemented
+
+    def child(self: TRef, *parts: PathElement) -> TRef:
+        cls = type(self)
+
+        return cls(*self._path, *parts)
+
+    def join(self: TRef, other: "Reference") -> TRef:
+        return self.child(*other._path)
+
+    @property
+    def path(self) -> Tuple[PathElement, ...]:
+        return self._path
+
+    @classmethod
+    def parse(cls, raw: str) -> "Reference":
+        # TODO: Parse array subscript syntax
+        parts = raw.split(".")
+
+        try:
+            ref = cls(*parts)
+        except ValueError as e:
+            raise ReferenceParseError(str(e)) from e
+
+        return ref
+
+    def _validate_path(self) -> None:
+        for idx, part in enumerate(self._path):
+            if isinstance(part, int):
+                if part < 0:
+                    raise ValueError(f"Path part {idx} must be non-negative")
+            elif isinstance(part, str):
+                if not _PART_REGEX.fullmatch(part):
+                    raise ValueError(f"Path part {idx} invalid: {part}")
+            else:
+                raise TypeError(f"unsupported part type {type(part).__name__}")
+
+
+class InterpolatedReference(Reference):
+    """
+    A reference that was created using an interpoliation string. Can be serialized to/from YAML
+    """
+
+    yaml_tag = "!ref"
+
+    def __str__(self) -> str:
+        return "${%s}" % self._inner_str()
+
+    def _inner_str(self) -> str:
+        return super().__str__()
+
+    @classmethod
+    def parse(cls, raw: str) -> "InterpolatedReference":
+        match = _INTERPOLATION_REGEX.fullmatch(raw)
+        if not match:
+            raise ReferenceParseError("`raw` not an interpolated string")
+
+        return cls.parse_dotted(match[1])
+
+    @classmethod
+    def parse_dotted(cls, raw: str) -> "InterpolatedReference":
+        parsed = super().parse(raw)
+
+        # Ideally, we would just return `parsed`, but the type system makes that difficult
+        return cls(*parsed.path)
+
+    @classmethod
+    def to_yaml(cls, representer: Any, node: "InterpolatedReference") -> Any:
+        # TODO: Do we need to be able to dump this class to YAML?
+        return representer.represent_scalar(cls.yaml_tag, node._inner_str())
+
+    @classmethod
+    def from_yaml(cls, _: Any, node: Any) -> "InterpolatedReference":
+        # TODO: Should we actually have a way to parse this from yaml?
+        return cls.parse_dotted(node.value)
+
+
+register_yaml_class(InterpolatedReference)

--- a/opta/utils/visit.py
+++ b/opta/utils/visit.py
@@ -1,0 +1,154 @@
+from collections.abc import Iterable, MutableMapping, MutableSequence
+from typing import Any, Callable, Iterator, List, Optional, Tuple, Union
+
+from opta.utils.ref import PathElement, Reference
+
+Filter = Callable[[Any], bool]
+Builder = Callable[[Any], List[PathElement]]
+MutableCollection = Union[MutableSequence, MutableMapping]
+
+
+class Visitor:
+    def __init__(
+        self,
+        root: Iterable,
+        *,
+        depth_first: bool = True,
+        filter: Optional[Filter] = None,
+        builder: Optional[Builder] = None,
+    ):
+        self._root = root
+        self.depth_first = depth_first
+        self.filter: Filter = filter or (lambda _: True)
+        self.builder: Builder = builder or visit_list_or_dict
+
+    @property
+    def root(self) -> Iterable:
+        return self._root
+
+    def __iter__(self) -> Iterator[Tuple[Reference, Any]]:
+        iter = _VisitorIterator(self)
+        iter.depth_first = self.depth_first
+        iter.filter = self.filter
+        iter.builder = self.builder
+        return iter
+
+    def __getitem__(self, path: Any) -> Any:
+        if not isinstance(path, Reference):
+            raise TypeError(f"index must be of type {Reference.__qualname__}")
+
+        current: Any = self.root
+        for part in path:
+            current = current[part]
+
+        return current
+
+    def __setitem__(self, path: Reference, value: Any) -> None:
+        self.set(path, value)
+
+    def set(
+        self,
+        path: Reference,
+        value: Any,
+        *,
+        allow_missing_leaf: Optional[bool] = None,
+        fill_missing: Optional[Callable[[Reference], MutableCollection]] = None,
+    ) -> None:
+        current: Any = self.root
+        total = len(path)
+        # TODO: Should leave root unmodified if there is an error before value is set
+        for idx, part in enumerate(path):
+            # Check if this is the last piece of the path
+            if idx + 1 == total:
+                break
+
+            try:
+                next = current[part]
+            except KeyError:
+                if not fill_missing:
+                    raise
+
+                current_ref = path[0 : idx + 1]
+                next = fill_missing(current_ref)
+                current[part] = next
+
+            current = next
+
+        if part not in current:
+            if allow_missing_leaf is False or not fill_missing:
+                raise IndexError("cannot add new value")
+
+        current[part] = value
+
+
+class _VisitorIterator:
+    def __init__(self, visitor: Visitor) -> None:
+        self.visitor = visitor
+        self.to_visit: List[Reference] = []
+        self.filter: Filter = lambda _: True
+        self.builder: Builder = visit_list_or_dict
+        self.depth_first: bool = True
+
+        self._populate_to_visit()
+
+    def __iter__(self) -> Iterator[Tuple[Reference, Any]]:
+        return self
+
+    def __next__(self) -> Tuple[Reference, Any]:
+        while self.to_visit:
+            ref = self._pop_next_ref()
+            value = self.visitor[ref]
+
+            if not self.filter(value):
+                continue
+
+            self._add_children(ref, value)
+            return ref, value
+
+        raise StopIteration
+
+    def _pop_next_ref(self) -> Reference:
+        if self.depth_first:
+            return self.to_visit.pop()
+        else:
+            return self.to_visit.pop(0)
+
+    def _populate_to_visit(self) -> None:
+        """Sets up initial to_visit list"""
+
+        self._add_children(Reference(), self.visitor.root)
+
+    def _add_children(self, parent: Reference, of: Any) -> None:
+        children = self.builder(of)
+        if self.depth_first:
+            # If we are depth first, we want to put the first items last
+            children.reverse()
+
+        self.to_visit.extend(parent.child(child) for child in children)
+
+
+def visit_list_or_dict(obj: Any) -> List[PathElement]:
+    indexes: List[PathElement] = []
+    if isinstance(obj, dict):
+        indexes = list(obj.keys())
+
+    elif isinstance(obj, list):
+        indexes = list(range(len(obj)))
+
+    # Filter out non-str or int indexes
+    indexes = [idx for idx in indexes if isinstance(idx, str) or isinstance(idx, int)]
+
+    return indexes
+
+
+def fill_missing_list_or_dict(path: Reference) -> MutableCollection:
+    """
+    Returns an empty list if the last element of `path` is a an int, otherwise returns an empty dict
+    """
+
+    last = path[-1]
+
+    if isinstance(last, int):
+        return []
+
+    return {}

--- a/opta/utils/yaml.py
+++ b/opta/utils/yaml.py
@@ -1,0 +1,25 @@
+from typing import IO, Any, Set, Type
+
+from ruamel.yaml import YAML as lib_YAML
+
+_yaml_classes: Set[Type] = set()
+
+
+def YAML() -> lib_YAML:
+    y = lib_YAML()
+    y.indent(mapping=2, sequence=4, offset=2)
+
+    for cls in _yaml_classes:
+        y.register_class(cls)
+
+    return y
+
+
+def register_yaml_class(cls: Type) -> None:
+    _yaml_classes.add(cls)
+
+
+def yaml_load(f: IO) -> Any:
+    y = YAML()
+
+    return y.load(f)

--- a/tests/preprocessor/test_registry.py
+++ b/tests/preprocessor/test_registry.py
@@ -1,0 +1,33 @@
+from typing import Generator
+
+import pytest
+
+from opta.preprocessor import registry
+from opta.preprocessor.util import CURRENT_VERSION, DEFAULT_VERSION
+
+
+class TestRegistry:
+    def test_versions(self) -> None:
+        assert (
+            DEFAULT_VERSION == CURRENT_VERSION
+            or DEFAULT_VERSION in registry._version_processors
+        )
+
+    def test_version_processors(self) -> None:
+        # Make sure that all versions in dict are valid
+        for version in registry._version_processors:
+            assert 0 < version < CURRENT_VERSION
+
+        # Make sure we aren't skipping any versions
+        for version in range(1, CURRENT_VERSION):
+            assert version in registry._version_processors
+
+    @pytest.fixture(autouse=True)
+    def registered_processors(self) -> Generator:
+        old = registry._version_processors
+        registry._version_processors = {}
+        registry.register_all()
+
+        yield
+
+        registry._version_processors = old

--- a/tests/preprocessor/test_v1.py
+++ b/tests/preprocessor/test_v1.py
@@ -1,0 +1,38 @@
+from typing import Optional, Type
+
+import pytest
+
+from opta.preprocessor.v1 import reformat_interpolation
+
+
+class TestInterpolation:
+    def reformat_interpolation_assert(
+        self,
+        input: str,
+        *,
+        expected: Optional[str] = None,
+        exception_type: Optional[Type[Exception]] = None,
+        exception_message: Optional[str] = None,
+    ) -> None:
+        if exception_type:
+            with pytest.raises(exception_type) as e:
+                output = reformat_interpolation(input)
+
+            if exception_message is not None:
+                assert str(e.value) == exception_message
+        else:
+            output = reformat_interpolation(input)
+
+        assert output == expected
+
+    @pytest.mark.parametrize(
+        "input,expected",
+        [
+            ["foo", "foo"],
+            ["foo {bar}", "foo ${bar}"],
+            ["{spam} {ham}", "${spam} ${ham}"],
+            ["${foo}", "$${foo}"],
+        ],
+    )
+    def test_reformat_interpolation_good(self, input: str, expected: str) -> None:
+        self.reformat_interpolation_assert(input, expected=expected)

--- a/tests/utils/test_ref.py
+++ b/tests/utils/test_ref.py
@@ -1,0 +1,35 @@
+from opta.utils.ref import _INTERPOLATION_REGEX, _PART_REGEX, InterpolatedReference, Reference
+
+
+class TestRef:
+    def test_part_regex(self) -> None:
+        assert _PART_REGEX.fullmatch("abc") is not None
+        assert _PART_REGEX.fullmatch("a2_3") is not None
+        assert _PART_REGEX.fullmatch("1abc") is None
+
+    def test_interpolation_regex(self) -> None:
+        assert _INTERPOLATION_REGEX.fullmatch("${foo}") is not None
+        assert _INTERPOLATION_REGEX.fullmatch("${foo.bar}") is not None
+
+
+class TestInterpolatedReference:
+    def test_parse(self) -> None:
+        assert InterpolatedReference.parse("${foo.bar}") == InterpolatedReference(
+            "foo", "bar"
+        )
+
+        # TODO: Test parse exception
+
+    def test_str(self) -> None:
+        assert str(InterpolatedReference("foo", "bar")) == "${foo.bar}"
+
+
+class TestReference:
+    def test_parse(self) -> None:
+        assert Reference.parse("foo.bar") == Reference("foo", "bar")
+        # TODO: Test parse exception
+
+    def test_str(self) -> None:
+        assert str(Reference("foo", "bar")) == "foo.bar"
+
+    # TODO: Test __add__


### PR DESCRIPTION
Initial work on preprocessor. None of this has been tested, but gives us a good starting point. In the `utils` directory, `ref.py`, `visit.py` and `yaml.py` were pulled from the linker prototype.