### PR TITLE
Renamed local env org_name to local instead of opta

### DIFF
--- a/opta/commands/local_flag.py
+++ b/opta/commands/local_flag.py
@@ -21,7 +21,7 @@ def _handle_local_flag(config: str, test: bool = False) -> str:
         yaml.safe_dump(
             {
                 "name": "localopta",
-                "org_name": "opta",
+                "org_name": "local",
                 "providers": {"local": {}},
                 "modules": [{"type": "local-base"}],
             },


### PR DESCRIPTION
# Description


# Safety checklist
* [ Sort off ] This change is backwards compatible and safe to apply by existing users
* [ X] This change will NOT lead to data loss
* [X ] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
Manual

About the backward compatible: Little issue only when in the end the user wants to remove the kind cluster he will run the manual command rather than opta destroy for that time
