### PR TITLE
Support alternate y(a)ml extension for environment path

### DIFF
--- a/opta/layer.py
+++ b/opta/layer.py
@@ -7,7 +7,6 @@ import re
 import shutil
 import tempfile
 from datetime import datetime
-from os import path
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, Dict, FrozenSet, Iterable, List, Optional, Set, Tuple, TypedDict
@@ -32,7 +31,7 @@ from opta.crash_reporter import CURRENT_CRASH_REPORTER
 from opta.exceptions import UserErrors
 from opta.module import Module
 from opta.plugins.derived_providers import DerivedProviders
-from opta.utils import deep_merge, hydrate, logger, yaml
+from opta.utils import check_opta_file_exists, deep_merge, hydrate, logger, yaml
 from opta.utils.dependencies import validate_installed_path_executables
 
 PROCESSOR_DICT: Dict[str, str] = {
@@ -188,17 +187,16 @@ class Layer:
 
             git.Repo.clone_from(git_url, t, branch=branch, depth=1)
             config_path = os.path.join(t, file_path)
-            with open(config_path) as f:
-                config_string = f.read()
-            conf = yaml.load(config_string)
-        elif path.exists(config):
-            config_path = config
-            logger.debug(f"Loaded the following configfile:\n{open(config_path).read()}")
-            with open(config_path) as f:
-                config_string = f.read()
-            conf = yaml.load(config_string)
         else:
-            raise UserErrors(f"File {config} not found")
+            config_path = config
+
+        # this will make sure that the file exist and support alternate y(a)ml extension
+        config_path = check_opta_file_exists(config_path, prompt=False)
+
+        with open(config_path) as f:
+            config_string = f.read()
+        logger.debug(f"Loaded the following configfile:\n{config_string}")
+        conf = yaml.load(config_string)
 
         conf["original_spec"] = config_string
         conf["path"] = config_path

--- a/opta/utils/__init__.py
+++ b/opta/utils/__init__.py
@@ -216,7 +216,9 @@ def alternate_yaml_extension(config_path: str) -> Tuple[str, bool]:
     return config_path, False
 
 
-def check_opta_file_exists(config_path: str) -> str:
+# Return the existing opta file, if not found it checks the alternate y(a)ml extension
+# If still not found, it prompts the user or raise a UserErrors
+def check_opta_file_exists(config_path: str, prompt: bool = True) -> str:
     if not os.path.exists(config_path):
         # try alternate y(a)ml extension
         alternate_yaml, changed = alternate_yaml_extension(config_path)
@@ -234,12 +236,15 @@ def check_opta_file_exists(config_path: str) -> str:
         """
             )
         )
-        prompt_config_path = click.prompt(
-            "Enter a Configuration Path (Empty String will exit)",
-            default="",
-            type=click.STRING,
-            show_default=False,
-        )
+        if prompt:
+            prompt_config_path = click.prompt(
+                "Enter a Configuration Path (Empty String will exit)",
+                default="",
+                type=click.STRING,
+                show_default=False,
+            )
+        else:
+            raise UserErrors("Could not find file {}".format(config_path))
 
         if not prompt_config_path:
             logger.info("Exiting...")

--- a/tests/fixtures/sample_opta_files/service_env_alternate_ext.yaml
+++ b/tests/fixtures/sample_opta_files/service_env_alternate_ext.yaml
@@ -1,0 +1,9 @@
+environments:
+  - name: staging
+    # this should work by using the .yaml file
+    path: "../dummy_data/dummy_config_parent.yml"
+name: app
+modules:
+  - type: k8s-service
+    name: app
+    image: AUTO

--- a/tests/fixtures/sample_opta_files/service_github_repo_env.yaml
+++ b/tests/fixtures/sample_opta_files/service_github_repo_env.yaml
@@ -1,0 +1,9 @@
+environments:
+  - name: staging
+    path: "git@github.com:run-x/runx-infra.git//staging/opta-gcp.yml?ref=main"
+    variables: {}
+name: app
+modules:
+  - type: k8s-service
+    name: app
+    image: AUTO

--- a/tests/fixtures/sample_opta_files/service_missing_env_file.yaml
+++ b/tests/fixtures/sample_opta_files/service_missing_env_file.yaml
@@ -1,0 +1,9 @@
+environments:
+  - name: staging
+    path: "opta-not-found.yml"
+name: app
+modules:
+  - type: k8s-service
+    name: app
+    image: AUTO
+

--- a/tests/test_layer.py
+++ b/tests/test_layer.py
@@ -383,3 +383,64 @@ class TestLayer:
         for opta_module, processor in PROCESSOR_DICT.items():
             module_class = get_processor_class(opta_module)
             assert module_class.__name__ == processor
+
+    def test_service_missing_env_file(self):
+        with pytest.raises(UserErrors) as exception:
+            Layer.load_from_yaml(
+                os.path.join(
+                    os.path.dirname(os.path.dirname(__file__)),
+                    "tests",
+                    "fixtures",
+                    "sample_opta_files",
+                    "service_missing_env_file.yaml",
+                ),
+                None,
+            )
+        assert "Could not find file" in str(exception.value)
+        assert "opta-not-found.yml" in str(exception.value)
+
+    def test_service_env_alternate_ext(self):
+        # reference an env file using .yml but the file on the disk is .yaml
+        layer = Layer.load_from_yaml(
+            os.path.join(
+                os.path.dirname(os.path.dirname(__file__)),
+                "tests",
+                "fixtures",
+                "sample_opta_files",
+                "service_env_alternate_ext.yaml",
+            ),
+            None,
+        )
+        assert layer.name == "app"
+        assert layer.parent.name == "dummy-parent"
+
+    def test_service_github_repo_env(self, mocker: MockFixture):
+        mocker.patch("git.Repo.clone_from")
+        git_repo_mocked = mocker.patch("git.Repo.clone_from")
+        service_github_repo_env = os.path.join(
+            os.path.dirname(os.path.dirname(__file__)),
+            "tests",
+            "fixtures",
+            "sample_opta_files",
+            "service_github_repo_env.yaml",
+        )
+        # use local file for parent instead of cloning a github repo
+        dummy_config_parent = os.path.join(
+            os.path.dirname(os.path.dirname(__file__)),
+            "tests",
+            "fixtures",
+            "dummy_data",
+            "dummy_config_parent.yaml",
+        )
+        mocker.patch(
+            "opta.layer.check_opta_file_exists",
+            side_effect=[service_github_repo_env, dummy_config_parent],
+        )
+
+        layer = Layer.load_from_yaml(service_github_repo_env, None,)
+        git_repo_mocked.assert_called_once_with(
+            "git@github.com:run-x/runx-infra.git", mocker.ANY, branch="main", depth=1
+        )
+
+        assert layer.name == "app"
+        assert layer.parent.name == "dummy-parent"


### PR DESCRIPTION
# Description
Following #553, the next step is to rename our opta files in all our repos from `.yml` to `.yaml`.
The problem we will face is that there are many files that reference environment files in other repos. When renaming them we would break their links.

ex:
1. we rename https://github.com/run-x/runx-infra/blob/main/staging/opta.yml to opta.yaml
2. it will break the test-service which references `git@github.com:run-x/runx-infra.git//staging/opta.yml?ref=main"` ([here]
3. this will break the CI check: CI / deploy_test_service

If some users have multiple github repos to store their opta files, they might run into a similar issue.

This PR will address this issue by supporting both yaml/yml extension for the environment path.

ex:
1. we rename https://github.com/run-x/runx-infra/blob/main/staging/opta.yml to opta.yaml
2. the test-service is not yet changed and still references `git@github.com:run-x/runx-infra.git//staging/opta.yml?ref=main"` ([here]
3. CI / deploy_test_service: will work because it will try `git@github.com:run-x/runx-infra.git//staging/opta.yaml` if `git@github.com:run-x/runx-infra.git//staging/opta.yml` is not found.


# Safety checklist
* [X] This change is backwards compatible and safe to apply by existing users
* [X] This change will NOT lead to data loss
* [X] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
This change could be tested by adding a few unit tests included in this PR.
