### PR TITLE
Now we will only verify semver if we have the old semver

### DIFF
--- a/opta/commands/apply.py
+++ b/opta/commands/apply.py
@@ -197,7 +197,7 @@ def _apply(
 
     existing_config: Optional[StructuredConfig] = cloud_client.get_remote_config()
     old_semver_string = (
-        "0.0.1"
+        ""
         if existing_config is None
         else existing_config.get("opta_version", "0.0.1").strip("v")
     )

--- a/opta/constants.py
+++ b/opta/constants.py
@@ -1,6 +1,6 @@
 import os
 import time
-from typing import Dict
+from typing import Dict, Tuple
 
 from ruamel.yaml import YAML
 
@@ -30,8 +30,12 @@ SESSION_ID = int(time.time() * 1000)
 # caused by opta version upgrade. The key is the first version that the warning is for. So if you have a
 # warning for versions 0.1.0, 0.2.0, 0.4.0, and 0.5.0, and the user used to have version 0.2.0, but now has version
 # 0.5.0, then they will see warnings for 0.4.0, and 0.5.0
-UPGRADE_WARNINGS: Dict[str, str] = {
-    "0.21.0": "If you are applying to an AWS environment, this upgrade will cause a 5 min downtime for "
+UPGRADE_WARNINGS: Dict[Tuple[str, str, str], str] = {
+    (
+        "0.21.0",
+        "aws",
+        "aws-dns",
+    ): "If you are applying to an AWS environment, this upgrade will cause a 5 min downtime for "
     "any public traffic, as this will replace the network load balancer with a new, superior-managed one"
     "(old one will stick around, but should be manually deleted). Opta-internal references, like "
     "those for the opta managed dns, will be switched to new load balancer automatically, but this may cause "

--- a/opta/constants.py
+++ b/opta/constants.py
@@ -34,7 +34,7 @@ UPGRADE_WARNINGS: Dict[Tuple[str, str, str], str] = {
     (
         "0.21.0",
         "aws",
-        "aws-dns",
+        "aws-k8s-base",
     ): "If you are applying to an AWS environment, this upgrade will cause a 5 min downtime for "
     "any public traffic, as this will replace the network load balancer with a new, superior-managed one"
     "(old one will stick around, but should be manually deleted). Opta-internal references, like "

--- a/tests/commands/test_apply.py
+++ b/tests/commands/test_apply.py
@@ -50,6 +50,9 @@ def mocked_layer(mocker: MockFixture) -> Any:
     mocked_layer_class.load_from_yaml.return_value = mocked_layer
     mocked_layer.parent = None
     mocked_layer.original_spec = ""
+    mocked_module = mocker.Mock()
+    mocked_module.aliased_type = "dummy"
+    mocked_layer.modules = [mocked_module]
 
     return mocked_layer
 
@@ -200,12 +203,12 @@ def test_fail_on_2_azs(mocker: MockFixture, mocked_layer: Any) -> None:
 
 
 def test_verify_semver_all_good(mocker: MockFixture, mocked_layer: Any) -> None:
-    _verify_semver("0.1.0", "0.2.0")
+    _verify_semver("0.1.0", "0.2.0", mocked_layer)
 
 
 def test_verify_semver_older_version(mocker: MockFixture, mocked_layer: Any) -> None:
     with pytest.raises(UserErrors):
-        _verify_semver("0.2.0", "0.1.0")
+        _verify_semver("0.2.0", "0.1.0", mocked_layer)
 
 
 def test_verify_semver_upgrade_warning(mocker: MockFixture, mocked_layer: Any) -> None:
@@ -214,9 +217,10 @@ def test_verify_semver_upgrade_warning(mocker: MockFixture, mocked_layer: Any) -
     mocked_confirm = mocker.Mock()
     mocked_click.confirm = mocked_confirm
     with patch(
-        "opta.commands.apply.UPGRADE_WARNINGS", {"0.2.0": "blah", "0.3.0": "baloney"}
+        "opta.commands.apply.UPGRADE_WARNINGS",
+        {("0.2.0", "aws", "dummy"): "blah", ("0.3.0", "aws", "dummy"): "baloney"},
     ):
-        _verify_semver("0.1.0", "0.3.0")
+        _verify_semver("0.1.0", "0.3.0", mocked_layer)
     mocked_logger.info.assert_has_calls(
         [mocker.call(mocker.ANY), mocker.call(mocker.ANY)]
     )


### PR DESCRIPTION
# Description

This means we only show version upgrade warnings if we know what the old version is, as in the _verify_semver function the first lines are
```python
def _verify_semver(old_semver_string: str, current_semver_string: str) -> None:
    if old_semver_string in [DEV_VERSION, ""] or current_semver_string in [
        DEV_VERSION,
        "",
    ]:
        return

````



# Safety checklist
* [x] This change is backwards compatible and safe to apply by existing users
* [x] This change will NOT lead to data loss
* [x] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
n/a
