### PR TITLE
Update some documentation to use .yaml instead of .yml

### DIFF
--- a/modules/custom_terraform/custom-terraform.md
+++ b/modules/custom_terraform/custom-terraform.md
@@ -13,7 +13,7 @@ the opta yaml) to your module with the `path_to_module` input, and the desired i
 `terraform_inputs` input.
 
 ## Example/Demo
-Suppose you have an opta gcp environment written in `gcp-env.yml` and you want to deploy your custom terraform module
+Suppose you have an opta gcp environment written in `gcp-env.yaml` and you want to deploy your custom terraform module
 "blah" that creates something you want (in our case a vm instance). What you could do is create a service for your
 environment which uses custom-terraform to call your module (NOTE: custom-terraform doesn't need to be in an opta 
 service-- it can be in the environment too). For our example, let's say that the file structure looks like so:
@@ -21,7 +21,7 @@ service-- it can be in the environment too). For our example, let's say that the
 ```
 .
 ├── README.md
-├── gcp-env.yml
+├── gcp-env.yaml
 └── dummy-service
     ├── blah
     │   └── main.tf
@@ -33,7 +33,7 @@ The new service is written in `dummy-service/opta.yaml` and looks like this:
 ```yaml
 environments:
   - name: gcp-example
-    path: "../gcp-env.yml"
+    path: "../gcp-env.yaml"
 name: baloney
 modules:
   - type: custom-terraform

--- a/modules/lambda_function/lambda-function.md
+++ b/modules/lambda_function/lambda-function.md
@@ -105,7 +105,7 @@ additional setup, but it is encouraged to treat it as a service so that it can b
 ```yaml
 environments:
   - name: aws-example
-    path: "../aws-env.yml"
+    path: "../aws-env.yaml"
 name: testing-lambda
 modules:
   - type: lambda-function


### PR DESCRIPTION
# Description
we are updating our documentation to use .yaml instead of .yml.
(Most of the changes will be done in https://github.com/run-x/opta-docs)

# Safety checklist
* [X] This change is backwards compatible and safe to apply by existing users
* [X] This change will NOT lead to data loss
* [X] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
just a doc change
