### PR TITLE
Updating to terraform gcp v4.X.X

### DIFF
--- a/config/registry/google/index.yaml
+++ b/config/registry/google/index.yaml
@@ -1,7 +1,7 @@
 required_providers:
   google:
     source: "hashicorp/google"
-    version: "3.90.1"
+    version: "4.5.0"
   helm:
     source: "hashicorp/helm"
     version: "2.4.1"

--- a/modules/gcp_base/gcp-base.yaml
+++ b/modules/gcp_base/gcp-base.yaml
@@ -38,9 +38,6 @@ outputs:
   - name: kms_account_key_id
     export: true
     description: The id of the [KMS](https://cloud.google.com/security-key-management) key (this is what handles encryption for redis, gke, etc...)
-  - name: kms_account_key_self_link
-    export: true
-    description: The self link of the default KMS key (sometimes things need the ID, sometimes the ARN, so we're giving both)
   - name: vpc_id
     export: true
     description: The ID of the [VPC](https://cloud.google.com/vpc/docs/vpc) we created for this environment

--- a/modules/gcp_base/tf_module/outputs.tf
+++ b/modules/gcp_base/tf_module/outputs.tf
@@ -2,10 +2,6 @@ output "kms_account_key_id" {
   value = google_kms_key_ring.keyring.id
 }
 
-output "kms_account_key_self_link" {
-  value = google_kms_key_ring.keyring.self_link
-}
-
 output "vpc_id" {
   value = google_compute_network.vpc.id
 }

--- a/modules/gcp_gcs/tf_module/variables.tf
+++ b/modules/gcp_gcs/tf_module/variables.tf
@@ -10,7 +10,7 @@ data "google_kms_key_ring" "key_ring" {
 }
 
 data "google_kms_crypto_key" "kms" {
-  key_ring = data.google_kms_key_ring.key_ring.self_link
+  key_ring = data.google_kms_key_ring.key_ring.id
   name     = "opta-${var.env_name}-${data.google_secret_manager_secret_version.kms_suffix.secret_data}"
 }
 

--- a/modules/gcp_gke/tf_module/default_node_group.tf
+++ b/modules/gcp_gke/tf_module/default_node_group.tf
@@ -29,7 +29,7 @@ resource "google_container_node_pool" "default" {
     }
 
     workload_metadata_config {
-      node_metadata = "GKE_METADATA_SERVER"
+      mode = "GKE_METADATA"
     }
     labels = {
       node_pool_name = "opta-${var.layer_name}-default"

--- a/modules/gcp_gke/tf_module/gke.tf
+++ b/modules/gcp_gke/tf_module/gke.tf
@@ -13,7 +13,7 @@ resource "google_container_cluster" "primary" {
   subnetwork            = var.private_subnet_self_link
   enable_shielded_nodes = true
   workload_identity_config {
-    identity_namespace = "${data.google_client_config.current.project}.svc.id.goog"
+    workload_pool = "${data.google_client_config.current.project}.svc.id.goog"
   }
 
   private_cluster_config {

--- a/modules/gcp_gke/tf_module/gke.tf
+++ b/modules/gcp_gke/tf_module/gke.tf
@@ -29,7 +29,7 @@ resource "google_container_cluster" "primary" {
 
   database_encryption {
     state    = "ENCRYPTED"
-    key_name = data.google_kms_crypto_key.kms.self_link
+    key_name = data.google_kms_crypto_key.kms.id
   }
 
   master_auth {

--- a/modules/gcp_gke/tf_module/iam.tf
+++ b/modules/gcp_gke/tf_module/iam.tf
@@ -14,21 +14,25 @@ resource "google_service_account" "gke_node" {
 resource "google_project_iam_member" "gke_node_log_writer" {
   role   = "roles/logging.logWriter"
   member = "serviceAccount:${google_service_account.gke_node.email}"
+  project = data.google_client_config.current.project
 }
 
 resource "google_project_iam_member" "gke_node_metric_writer" {
   role   = "roles/monitoring.metricWriter"
   member = "serviceAccount:${google_service_account.gke_node.email}"
+  project = data.google_client_config.current.project
 }
 
 resource "google_project_iam_member" "gke_node_monitoring_viewer" {
   role   = "roles/monitoring.viewer"
   member = "serviceAccount:${google_service_account.gke_node.email}"
+  project = data.google_client_config.current.project
 }
 
 resource "google_project_iam_member" "gke_node_stackdriver_writer" {
   role   = "roles/stackdriver.resourceMetadata.writer"
   member = "serviceAccount:${google_service_account.gke_node.email}"
+  project = data.google_client_config.current.project
 }
 
 resource "google_storage_bucket_iam_member" "viewer" {

--- a/modules/gcp_gke/tf_module/iam.tf
+++ b/modules/gcp_gke/tf_module/iam.tf
@@ -12,26 +12,26 @@ resource "google_service_account" "gke_node" {
 }
 
 resource "google_project_iam_member" "gke_node_log_writer" {
-  role   = "roles/logging.logWriter"
-  member = "serviceAccount:${google_service_account.gke_node.email}"
+  role    = "roles/logging.logWriter"
+  member  = "serviceAccount:${google_service_account.gke_node.email}"
   project = data.google_client_config.current.project
 }
 
 resource "google_project_iam_member" "gke_node_metric_writer" {
-  role   = "roles/monitoring.metricWriter"
-  member = "serviceAccount:${google_service_account.gke_node.email}"
+  role    = "roles/monitoring.metricWriter"
+  member  = "serviceAccount:${google_service_account.gke_node.email}"
   project = data.google_client_config.current.project
 }
 
 resource "google_project_iam_member" "gke_node_monitoring_viewer" {
-  role   = "roles/monitoring.viewer"
-  member = "serviceAccount:${google_service_account.gke_node.email}"
+  role    = "roles/monitoring.viewer"
+  member  = "serviceAccount:${google_service_account.gke_node.email}"
   project = data.google_client_config.current.project
 }
 
 resource "google_project_iam_member" "gke_node_stackdriver_writer" {
-  role   = "roles/stackdriver.resourceMetadata.writer"
-  member = "serviceAccount:${google_service_account.gke_node.email}"
+  role    = "roles/stackdriver.resourceMetadata.writer"
+  member  = "serviceAccount:${google_service_account.gke_node.email}"
   project = data.google_client_config.current.project
 }
 

--- a/modules/gcp_gke/tf_module/variables.tf
+++ b/modules/gcp_gke/tf_module/variables.tf
@@ -34,7 +34,7 @@ data "google_kms_key_ring" "key_ring" {
 }
 
 data "google_kms_crypto_key" "kms" {
-  key_ring = data.google_kms_key_ring.key_ring.self_link
+  key_ring = data.google_kms_key_ring.key_ring.id
   name     = "opta-${var.env_name}-${data.google_secret_manager_secret_version.kms_suffix.secret_data}"
 }
 

--- a/modules/gcp_nodepool/tf_module/main.tf
+++ b/modules/gcp_nodepool/tf_module/main.tf
@@ -83,7 +83,7 @@ resource "google_container_node_pool" "node_pool" {
     }
 
     workload_metadata_config {
-      node_metadata = "GKE_METADATA_SERVER"
+      mode = "GKE_METADATA"
     }
 
     labels = {

--- a/modules/gcp_nodepool/tf_module/main.tf
+++ b/modules/gcp_nodepool/tf_module/main.tf
@@ -16,26 +16,31 @@ resource "random_string" "node_pool_id" {
 resource "google_service_account" "gke_node" {
   account_id   = "opta-${var.layer_name}-${random_string.node_pool_hash.result}"
   display_name = "opta-${var.layer_name}-default-node-pool"
+  project = data.google_client_config.current.project
 }
 
 resource "google_project_iam_member" "gke_node_log_writer" {
   role   = "roles/logging.logWriter"
   member = "serviceAccount:${google_service_account.gke_node.email}"
+  project = data.google_client_config.current.project
 }
 
 resource "google_project_iam_member" "gke_node_metric_writer" {
   role   = "roles/monitoring.metricWriter"
   member = "serviceAccount:${google_service_account.gke_node.email}"
+  project = data.google_client_config.current.project
 }
 
 resource "google_project_iam_member" "gke_node_monitoring_viewer" {
   role   = "roles/monitoring.viewer"
   member = "serviceAccount:${google_service_account.gke_node.email}"
+  project = data.google_client_config.current.project
 }
 
 resource "google_project_iam_member" "gke_node_stackdriver_writer" {
   role   = "roles/stackdriver.resourceMetadata.writer"
   member = "serviceAccount:${google_service_account.gke_node.email}"
+  project = data.google_client_config.current.project
 }
 
 resource "google_storage_bucket_iam_member" "viewer" {

--- a/modules/gcp_nodepool/tf_module/main.tf
+++ b/modules/gcp_nodepool/tf_module/main.tf
@@ -16,30 +16,30 @@ resource "random_string" "node_pool_id" {
 resource "google_service_account" "gke_node" {
   account_id   = "opta-${var.layer_name}-${random_string.node_pool_hash.result}"
   display_name = "opta-${var.layer_name}-default-node-pool"
-  project = data.google_client_config.current.project
+  project      = data.google_client_config.current.project
 }
 
 resource "google_project_iam_member" "gke_node_log_writer" {
-  role   = "roles/logging.logWriter"
-  member = "serviceAccount:${google_service_account.gke_node.email}"
+  role    = "roles/logging.logWriter"
+  member  = "serviceAccount:${google_service_account.gke_node.email}"
   project = data.google_client_config.current.project
 }
 
 resource "google_project_iam_member" "gke_node_metric_writer" {
-  role   = "roles/monitoring.metricWriter"
-  member = "serviceAccount:${google_service_account.gke_node.email}"
+  role    = "roles/monitoring.metricWriter"
+  member  = "serviceAccount:${google_service_account.gke_node.email}"
   project = data.google_client_config.current.project
 }
 
 resource "google_project_iam_member" "gke_node_monitoring_viewer" {
-  role   = "roles/monitoring.viewer"
-  member = "serviceAccount:${google_service_account.gke_node.email}"
+  role    = "roles/monitoring.viewer"
+  member  = "serviceAccount:${google_service_account.gke_node.email}"
   project = data.google_client_config.current.project
 }
 
 resource "google_project_iam_member" "gke_node_stackdriver_writer" {
-  role   = "roles/stackdriver.resourceMetadata.writer"
-  member = "serviceAccount:${google_service_account.gke_node.email}"
+  role    = "roles/stackdriver.resourceMetadata.writer"
+  member  = "serviceAccount:${google_service_account.gke_node.email}"
   project = data.google_client_config.current.project
 }
 

--- a/tests/test_layer.py
+++ b/tests/test_layer.py
@@ -81,7 +81,6 @@ class TestLayer:
             "layer_name": "gcp-dummy-config",
             "parent": SimpleNamespace(
                 kms_account_key_id="${data.terraform_remote_state.parent.outputs.kms_account_key_id}",
-                kms_account_key_self_link="${data.terraform_remote_state.parent.outputs.kms_account_key_self_link}",
                 vpc_id="${data.terraform_remote_state.parent.outputs.vpc_id}",
                 vpc_self_link="${data.terraform_remote_state.parent.outputs.vpc_self_link}",
                 private_subnet_id="${data.terraform_remote_state.parent.outputs.private_subnet_id}",


### PR DESCRIPTION
# Description
Pls see https://github.com/hashicorp/terraform-provider-google/blob/master/CHANGELOG.md for breaking changes

* kms: removed self_link field from google_kms_crypto_key and google_kms_key_ring (#10424) -- changed to new values
* resourcemanager: changed the project field to Required in all google_project_iam_* resources (#10394) -- taken care of
* container: removed the workload_identity_config.0.identity_namespace field from google_container_cluster, use workload_identity_config.0.workload_pool instead (#10410) -- taken care of



# Safety checklist
* [x] This change is backwards compatible and safe to apply by existing users
* [x] This change will NOT lead to data loss
* [x] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
Ran on gcp environmet and service manually, made sure it didn't change anything
