### PR TITLE
Hide Update kube-config command STDOUT

### DIFF
--- a/opta/core/kubernetes.py
+++ b/opta/core/kubernetes.py
@@ -1,7 +1,7 @@
 import base64
 import datetime
 import time
-from subprocess import DEVNULL
+from subprocess import DEVNULL  # nosec
 from threading import Thread
 from typing import TYPE_CHECKING, Dict, FrozenSet, List, Optional, Set, Tuple
 

--- a/opta/core/kubernetes.py
+++ b/opta/core/kubernetes.py
@@ -1,6 +1,7 @@
 import base64
 import datetime
 import time
+from subprocess import DEVNULL
 from threading import Thread
 from typing import TYPE_CHECKING, Dict, FrozenSet, List, Optional, Set, Tuple
 
@@ -134,7 +135,9 @@ def _gcp_configure_kubectl(layer: "Layer") -> None:
             "get-credentials",
             cluster_name,
             f"--region={env_gcp_region}",
-        ]
+        ],
+        stdout=DEVNULL,
+        check=True,
     )
 
 
@@ -164,6 +167,7 @@ def _azure_configure_kubectl(layer: "Layer") -> None:
             "--admin",
             "--overwrite-existing",
         ],
+        stdout=DEVNULL,
         check=True,
     )
 
@@ -225,7 +229,9 @@ def _aws_configure_kubectl(layer: "Layer") -> None:
             cluster_name,
             "--region",
             env_aws_region,
-        ]
+        ],
+        stdout=DEVNULL,
+        check=True,
     )
 
 

--- a/tests/core/test_kubernetes.py
+++ b/tests/core/test_kubernetes.py
@@ -1,5 +1,5 @@
 import datetime
-from subprocess import CompletedProcess
+from subprocess import DEVNULL, CompletedProcess
 
 import pytz
 from kubernetes.client import ApiException, CoreV1Api, V1Event, V1EventList, V1Pod
@@ -69,6 +69,7 @@ class TestKubernetes:
                         "--admin",
                         "--overwrite-existing",
                     ],
+                    stdout=DEVNULL,
                     check=True,
                 ),
             ]
@@ -125,7 +126,9 @@ class TestKubernetes:
                         "mocked_cluster_name",
                         "--region",
                         "us-east-1",
-                    ]
+                    ],
+                    stdout=DEVNULL,
+                    check=True,
                 ),
             ]
         )


### PR DESCRIPTION
# Description
Send the Standard output from update kube-config for different Cloud providers to DEVNULL.

# Safety checklist
* [ ] This change is backwards compatible and safe to apply by existing users
* [ ] This change will NOT lead to data loss
* [ ] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
Tested Manually on AWS Cloud Provider. Hides the Update kube-config outputs.
