### PR TITLE
Silence analytics errors: amplitude, datadog

### DIFF
--- a/opta/amplitude.py
+++ b/opta/amplitude.py
@@ -99,18 +99,23 @@ class AmplitudeClient:
         headers = {"Content-Type": "application/json", "Accept": "*/*"}
 
         if os.environ.get(OPTA_DISABLE_REPORTING) is None:
-            r = post(
-                "https://api2.amplitude.com/2/httpapi",
-                params={},
-                headers=headers,
-                json=body,
-            )
-            if r.status_code != codes.ok:
-                raise Exception(
-                    "Hey, we're trying to send some analytics over to our devs for the "
-                    f"product usage and we got a {r.status_code} response back. Could "
-                    "you pls email over to our dev team about this and tell them of the "
-                    f"failure with the aforementioned code and this response body: {r.text}"
+            try:
+                r = post(
+                    "https://api2.amplitude.com/2/httpapi",
+                    params={},
+                    headers=headers,
+                    json=body,
+                )
+                if r.status_code != codes.ok:
+                    raise Exception(
+                        "Hey, we're trying to send some analytics over to our devs for the "
+                        f"product usage and we got a {r.status_code} response back. Could "
+                        "you pls email over to our dev team about this and tell them of the "
+                        f"failure with the aforementioned code and this response body: {r.text}"
+                    )
+            except Exception as err:
+                logger.debug(
+                    f"Unexpected error when connecting to amplitude {err=}, {type(err)=}"
                 )
 
 


### PR DESCRIPTION
# Description
Silence errors related to amplitude, datadog.
To see these errors, use the debug flag.

# Safety checklist
* [X] This change is backwards compatible and safe to apply by existing users
* [X] This change will NOT lead to data loss
* [X] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?

ran locally with and without the fix and made sure these messages are gone with this fix:
```
HTTPSConnectionPool(host='api2.amplitude.com', port=443): Max retries exceeded with url: /2/httpapi (Caused by NewConnectionError('<urllib3.connection.HTTPSConnection object at 0x1190e3700>: Failed to establish a new connection: [Errno 61] Connection refused'))
...
requests.exceptions.ConnectionError: HTTPSConnectionPool(host='browser-http-intake.logs.datadoghq.com', port=443): Max retries exceeded with url: /v1/input/pub40d867605951d2a30fb8020e193ee7e5?opta_version=&ddsource=cli&user_id=remydewolf%40gmail.com&device_id=f4%3Ad4%3A88%3A76%3A45%3A8d&os_name=posix&platform=Darwin&os_version=Darwin+Kernel+Version+21.0.1%3A+Tue+Sep+14+20%3A56%3A24+PDT+2021%3B+root%3Axnu-8019.30.61~4%2FRELEASE_ARM64_T6000&session_id=1641408650735 (Caused by NewConnectionError('<urllib3.connection.HTTPSConnection object at 0x1232bb040>: Failed to establish a new connection: [Errno 61] Connection refused'))
```

to see them, enable the debug flag
```
DEBUG: Unexpected error when connecting to amplitude err=ConnectionError(MaxRetryError("HTTPSConnectionPool(host='api2.amplitude.com', port=443): Max retries exceeded with url: /2/httpapi (Caused by NewConnectionError('<urllib3.connection.HTTPSConnection object at 0x10e0a0580>: Failed to establish a new connection: [Errno 61] Connection refused'))")), type(err)=<class 'requests.exceptions.ConnectionError'>
...
DEBUG: Unexpected error when connecting to datadog: err=ConnectionError(MaxRetryError("HTTPSConnectionPool(host='browser-http-intake.logs.datadoghq.com', port=443): Max retries exceeded with url: /v1/input/pub40d867605951d2a30fb8020e193ee7e5?opta_version=&ddsource=cli&user_id=remydewolf%40gmail.com&device_id=f4%3Ad4%3A88%3A76%3A45%3A8d&os_name=posix&platform=Darwin&os_version=Darwin+Kernel+Version+21.0.1%3A+Tue+Sep+14+20%3A56%3A24+PDT+2021%3B+root%3Axnu-8019.30.61~4%2FRELEASE_ARM64_T6000&session_id=1641408722365 (Caused by NewConnectionError('<urllib3.connection.HTTPSConnection object at 0x102304f70>: Failed to establish a new connection: [Errno 61] Connection refused'))")), type(err)=<class 'requests.exceptions.ConnectionError'>
```
