### PR TITLE
Exclude dist folder from lint check

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -16,3 +16,4 @@ pretty = True
 show_traceback = True
 scripts_are_modules = True
 ignore_missing_imports = True
+exclude = ^dist/(.*)

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,4 +12,5 @@ exclude =
     srv/migrations
     env
     frontend/node_modules
+    dist
 black-config = pyproject.toml


### PR DESCRIPTION
# Description
Ignore local `dist` directory when running lint checks.
Prevent these kind of errors:

```
pipenv run flake8 .                                            
./dist/opta/hcl2/lark_parser.py:7:1: E302 expected 2 blank lines, found 1
./dist/opta/hcl2/lark_parser.py:8:3: E111 indentation is not a multiple of 4
./dist/opta/hcl2/lark_parser.py:9:1: W391 blank line at end of file

```

```
pipenv run mypy .
modules/aws_dns/tests/test_aws_dns.py: error: Duplicate module named "test_aws_dns" (also at "./dist/opta/modules/aws_dns/tests/test_aws_dns.py")
modules/aws_dns/tests/test_aws_dns.py: note: Are you missing an __init__.py? Alternatively, consider using --exclude to avoid checking one of them.
```



# Safety checklist
* [X] This change is backwards compatible and safe to apply by existing users
* [X] This change will NOT lead to data loss
* [X] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
```
./scripts/lint.py 
[2022-01-05 11:13:57] [INFO] Running JSON schema check...
checking module schemas...
checking config schemas...
[2022-01-05 11:13:58] [INFO] Running py checks...
[2022-01-05 11:13:58] [INFO] pipenv run isort --check-only .        && pipenv run black --check .        && pipenv run flake8 .        && pipenv run mypy .
Skipped 6 files
All done! ✨ 🍰 ✨
170 files would be left unchanged.
Success: no issues found in 170 source files
```
