### PR TITLE
Expanding linkerd issuer cert lifespan to 10 years

### DIFF
--- a/modules/aws_k8s_base/tf_module/linkerd.tf
+++ b/modules/aws_k8s_base/tf_module/linkerd.tf
@@ -42,7 +42,7 @@ resource "tls_locally_signed_cert" "issuer_cert" {
   ca_key_algorithm      = tls_private_key.trustanchor_key.algorithm
   ca_private_key_pem    = tls_private_key.trustanchor_key.private_key_pem
   ca_cert_pem           = tls_self_signed_cert.trustanchor_cert.cert_pem
-  validity_period_hours = 8760
+  validity_period_hours = 87600
   is_ca_certificate     = true
 
   allowed_uses = [

--- a/modules/azure_k8s_base/tf_module/linkerd.tf
+++ b/modules/azure_k8s_base/tf_module/linkerd.tf
@@ -42,7 +42,7 @@ resource "tls_locally_signed_cert" "issuer_cert" {
   ca_key_algorithm      = tls_private_key.trustanchor_key.algorithm
   ca_private_key_pem    = tls_private_key.trustanchor_key.private_key_pem
   ca_cert_pem           = tls_self_signed_cert.trustanchor_cert.cert_pem
-  validity_period_hours = 8760
+  validity_period_hours = 87600
   is_ca_certificate     = true
 
   allowed_uses = [

--- a/modules/gcp_k8s_base/tf_module/linkerd.tf
+++ b/modules/gcp_k8s_base/tf_module/linkerd.tf
@@ -42,7 +42,7 @@ resource "tls_locally_signed_cert" "issuer_cert" {
   ca_key_algorithm      = tls_private_key.trustanchor_key.algorithm
   ca_private_key_pem    = tls_private_key.trustanchor_key.private_key_pem
   ca_cert_pem           = tls_self_signed_cert.trustanchor_cert.cert_pem
-  validity_period_hours = 8760
+  validity_period_hours = 87600
   is_ca_certificate     = true
 
   allowed_uses = [

--- a/modules/local_base/tf_module/linkerd.tf
+++ b/modules/local_base/tf_module/linkerd.tf
@@ -42,7 +42,7 @@ resource "tls_locally_signed_cert" "issuer_cert" {
   ca_key_algorithm      = tls_private_key.trustanchor_key.algorithm
   ca_private_key_pem    = tls_private_key.trustanchor_key.private_key_pem
   ca_cert_pem           = tls_self_signed_cert.trustanchor_cert.cert_pem
-  validity_period_hours = 8760
+  validity_period_hours = 87600
   is_ca_certificate     = true
 
   allowed_uses = [


### PR DESCRIPTION
# Description
Linkerd issuer certs will now live for 10 years

# Safety checklist
* [x] This change is backwards compatible and safe to apply by existing users
* [x] This change will NOT lead to data loss
* [x] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
Did whole spike, shared results with nitin
