### PR TITLE
Fixing gcp mysql which was not working

### DIFF
--- a/modules/gcp_mysql/tf_module/main.tf
+++ b/modules/gcp_mysql/tf_module/main.tf
@@ -24,7 +24,7 @@ resource "google_sql_database_instance" "instance" {
     ip_configuration {
       ipv4_enabled    = false
       private_network = data.google_compute_network.vpc.id
-      require_ssl     = true
+      require_ssl     = false
     }
     backup_configuration {
       enabled            = true


### PR DESCRIPTION
# Description
Because we set require ssl to true (the same hting which broke postgres, but which we did not fix for mysql). This is not really needed given that our dbs are in private networks only

# Safety checklist
* [x] This change is backwards compatible and safe to apply by existing users
* [x] This change will NOT lead to data loss
* [x] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
manually tested
