### PR TITLE
Change the Resource Name for Ingress

### DIFF
--- a/modules/aws_k8s_service/tf_module/variables.tf
+++ b/modules/aws_k8s_service/tf_module/variables.tf
@@ -3,7 +3,8 @@ data "aws_caller_identity" "current" {}
 locals {
   uri_components = [for s in var.public_uri : {
     domain : split("/", s)[0],
-    pathPrefix : (length(split("/", s)) > 1 ? "/${join("/", slice(split("/", s), 1, length(split("/", s))))}" : "/")
+    pathPrefix : (length(split("/", s)) > 1 ? "/${join("/", slice(split("/", s), 1, length(split("/", s))))}" : "/"),
+    pathPrefixName : replace((length(split("/", s)) > 1 ? "/${join("/", slice(split("/", s), 1, length(split("/", s))))}" : "/"), "/", "")
   }]
   uppercase_image = upper(var.image)
 }

--- a/modules/azure_k8s_service/tf_module/variables.tf
+++ b/modules/azure_k8s_service/tf_module/variables.tf
@@ -12,7 +12,8 @@ data "azurerm_container_registry" "opta" {
 locals {
   uri_components = [for s in var.public_uri : {
     domain : split("/", s)[0],
-    pathPrefix : (length(split("/", s)) > 1 ? "/${join("/", slice(split("/", s), 1, length(split("/", s))))}" : "/")
+    pathPrefix : (length(split("/", s)) > 1 ? "/${join("/", slice(split("/", s), 1, length(split("/", s))))}" : "/"),
+    pathPrefixName : replace((length(split("/", s)) > 1 ? "/${join("/", slice(split("/", s), 1, length(split("/", s))))}" : "/"), "/", "")
   }]
   uppercase_image = upper(var.image)
 }

--- a/modules/gcp_k8s_service/tf_module/variables.tf
+++ b/modules/gcp_k8s_service/tf_module/variables.tf
@@ -7,7 +7,8 @@ locals {
     // We probably don't need the trim anymore but leaving this here for
     // potentional backwards compatibility
     domain : trim(split("/", s)[0], "."),
-    pathPrefix : (length(split("/", s)) > 1 ? "/${join("/", slice(split("/", s), 1, length(split("/", s))))}" : "/")
+    pathPrefix : (length(split("/", s)) > 1 ? "/${join("/", slice(split("/", s), 1, length(split("/", s))))}" : "/"),
+    pathPrefixName : replace((length(split("/", s)) > 1 ? "/${join("/", slice(split("/", s), 1, length(split("/", s))))}" : "/"), "/", "")
   }]
   layer_short     = substr(var.layer_name, 0, 12)
   module_short    = substr(var.module_name, 0, 12)

--- a/modules/local_k8s_service/tf_module/variables.tf
+++ b/modules/local_k8s_service/tf_module/variables.tf
@@ -3,7 +3,8 @@
 locals {
   uri_components = [for s in var.public_uri : {
     domain : split("/", s)[0],
-    pathPrefix : (length(split("/", s)) > 1 ? "/${join("/", slice(split("/", s), 1, length(split("/", s))))}" : "/")
+    pathPrefix : (length(split("/", s)) > 1 ? "/${join("/", slice(split("/", s), 1, length(split("/", s))))}" : "/"),
+    pathPrefixName : replace((length(split("/", s)) > 1 ? "/${join("/", slice(split("/", s), 1, length(split("/", s))))}" : "/"), "/", "")
   }]
   uppercase_image = upper(var.image)
 }

--- a/modules/opta-k8s-service-helm/templates/ingress.yaml
+++ b/modules/opta-k8s-service-helm/templates/ingress.yaml
@@ -1,9 +1,20 @@
 {{- if .Values.httpPort }}
+{{ $old_ingress_convention := false }}
+{{ $ingress_base_name := include "k8s-service.fullname" $ }}
+{{ $namespace_name := include "k8s-service.namespaceName" $ }}
+{{ $ingress_name_old_convention := "" }}
 {{- range $index, $val := .Values.uriComponents }}
+{{ $ingress_name_old_convention = print $ingress_base_name "-" $index }}
+{{ $old_ingress_convention = (lookup "networking.k8s.io/v1beta1" "Ingress" $namespace_name $ingress_name_old_convention) }}
 apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
+  {{- if $old_ingress_convention }}
   name:  {{ include "k8s-service.fullname" $ }}-{{ $index }}
+  {{- end }}
+  {{- if not $old_ingress_convention }}
+  name: { { include "k8s-service.fullname" $ } }-{{ $val.domain }}-{{ $val.pathPrefixName }}
+  {{- end }}
   namespace: {{ include "k8s-service.namespaceName" $ }}
   labels:
     {{- include "k8s-service.labels" $ | nindent 4 }}

--- a/modules/opta-k8s-service-helm/templates/ingress.yaml
+++ b/modules/opta-k8s-service-helm/templates/ingress.yaml
@@ -4,9 +4,13 @@
 {{ $namespace_name := include "k8s-service.namespaceName" $ }}
 {{ $ingress_name_old_convention := "" }}
 {{ $ingress_name_new_convention := "" }}
+{{ $domain_pathPrefix := "" }}
+{{ $domain_pathPrefix_sha256 := "" }}
 {{- range $index, $val := .Values.uriComponents }}
 {{ $ingress_name_old_convention = print $ingress_base_name "-" $index }}
-{{ $ingress_name_new_convention = print $ingress_base_name "-" $val.domain "-" $val.pathPrefixName }}
+{{ $domain_pathPrefix = print $val.domain "-" $val.pathPrefixName }}
+{{ $domain_pathPrefix_sha256 = trunc 8 (sha256sum $domain_pathPrefix) }}
+{{ $ingress_name_new_convention = print $ingress_base_name "-" $domain_pathPrefix_sha256 }}
 {{ $old_ingress_convention = (lookup "networking.k8s.io/v1beta1" "Ingress" $namespace_name $ingress_name_old_convention) }}
 
 apiVersion: networking.k8s.io/v1beta1

--- a/modules/opta-k8s-service-helm/templates/ingress.yaml
+++ b/modules/opta-k8s-service-helm/templates/ingress.yaml
@@ -3,17 +3,20 @@
 {{ $ingress_base_name := include "k8s-service.fullname" $ }}
 {{ $namespace_name := include "k8s-service.namespaceName" $ }}
 {{ $ingress_name_old_convention := "" }}
+{{ $ingress_name_new_convention := "" }}
 {{- range $index, $val := .Values.uriComponents }}
 {{ $ingress_name_old_convention = print $ingress_base_name "-" $index }}
+{{ $ingress_name_new_convention = print $ingress_base_name "-" $val.domain "-" $val.pathPrefixName }}
 {{ $old_ingress_convention = (lookup "networking.k8s.io/v1beta1" "Ingress" $namespace_name $ingress_name_old_convention) }}
+
 apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   {{- if $old_ingress_convention }}
-  name:  {{ include "k8s-service.fullname" $ }}-{{ $index }}
+  name:  {{ $ingress_name_old_convention }}
   {{- end }}
   {{- if not $old_ingress_convention }}
-  name: { { include "k8s-service.fullname" $ } }-{{ $val.domain }}-{{ $val.pathPrefixName }}
+  name:  {{ $ingress_name_new_convention }}
   {{- end }}
   namespace: {{ include "k8s-service.namespaceName" $ }}
   labels:


### PR DESCRIPTION
# Description
Having an indexed name for Ingress resource, causes issues with Ingress Deletion in an unordered fashion. This was causing exceptions when deleting Public URIs from top to bottom, but not the other way around.

In order to avoid issues related to Preserved order for Ingress Updations, we have changed the naming convention for Ingress Resources (only applies to the new ingress resources created).

Eg:
```
public_uri:
  - "/uri1"
  - "/uri2"
```
and deleting the Ingress to **uri1** would not work simply by changing the configuration to
```
public_uri:
  - "/uri2"
```

Since Ingresses are updated in a Preserved Fashion, it will delete **uri1** and simultaneously create **uri2**. But that causes an exception because ingress for **uri2** already exists.

In order to avoid this, we are changing the naming convention of Ingress Resource from `$ingress_base_name "-" $index` to `sha256sum` of  `$ingress_base_name "-" $val.domain "-" $val.pathPrefixName`. 

This will now allow the Ingresses to be **Domain** and **Prefix Unique**, which will allow the above mentioned use case to be executed without any issues.


> This feature will not have an effect on already existing ingress but the above mentioned issue would also be persistent if someone wants to Update the Ingresses. The best way would be to just remove the public URIs from the existing configuration and apply with opta. Then add the required public URIs to the configuration and apply with opta.

# Safety checklist
* [X] This change is backwards compatible and safe to apply by existing users
* [X] This change will NOT lead to data loss
* [X] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
Tested manually. It does not affect the existing ingress resources. Screenshots for more data.


Sample Screenshots:
<img width="1792" alt="Screenshot 2022-01-10 at 11 18 02 PM" src="https://user-images.githubusercontent.com/20905988/148813874-7bdee31a-650a-4311-ad5b-aa932f41162f.png">
<img width="1792" alt="Screenshot 2022-01-10 at 11 18 11 PM" src="https://user-images.githubusercontent.com/20905988/148813880-9a52fd23-dd28-4c76-99d9-fa5dd62fa3c2.png">
<img width="1792" alt="Screenshot 2022-01-10 at 11 17 25 PM" src="https://user-images.githubusercontent.com/20905988/148813859-e4a563d6-921a-4406-9125-507fc4165d37.png">

