### PR TITLE
Destroy persistent volumes when destroying a service

### DIFF
--- a/modules/base.py
+++ b/modules/base.py
@@ -252,6 +252,15 @@ class K8sServiceModuleProcessor(ModuleProcessor):
             key = "module_local_k8s_service"
         return {key: math.ceil((min_containers + max_containers) / 2)}
 
+    def post_delete(self, module_idx: int) -> None:
+        # Helm doesn't delete PVC https://github.com/helm/helm/issues/5156
+        if self.module.data.get("persistent_storage", False):
+            kubernetes.delete_persistent_volume_claims(
+                namespace=self.layer.name, opta_managed=True, async_req=True
+            )
+
+        super(K8sServiceModuleProcessor, self).post_delete(module_idx)
+
     def _extra_ports_controller(self) -> None:
         reconcile_nginx_extra_ports()
 

--- a/opta/core/kubernetes.py
+++ b/opta/core/kubernetes.py
@@ -439,7 +439,7 @@ def delete_persistent_volume_claims(
 
     claims = list_persistent_volume_claims(namespace=namespace, opta_managed=opta_managed)
     if not claims:
-        logger.info(
+        logger.debug(
             f"No persistent volume claim (opta_managed: {opta_managed}) found in namespace '{namespace}', skipping persistent volume cleanup"
         )
         return

--- a/opta/core/kubernetes.py
+++ b/opta/core/kubernetes.py
@@ -13,12 +13,14 @@ from kubernetes.client import (
     AppsV1Api,
     CoreV1Api,
     V1ConfigMap,
+    V1DeleteOptions,
     V1Deployment,
     V1DeploymentList,
     V1Event,
     V1Namespace,
     V1ObjectMeta,
     V1ObjectReference,
+    V1PersistentVolumeClaim,
     V1Pod,
     V1Secret,
     V1SecretList,
@@ -358,6 +360,99 @@ def list_namespaces() -> None:
     except ApiException as e:
         if e.reason == "Unauthorized" or e.status == 401:
             raise UserErrors("User does not have access to Kubernetes Cluster.")
+
+
+def list_persistent_volume_claims(
+    *, namespace: Optional[str] = None, opta_managed: bool = False
+) -> List[V1PersistentVolumeClaim]:
+    """list_persistent_volume_claims
+
+    list objects of kind PersistentVolumeClaim
+
+    :param str namespace: namespace to search in. If not set, search all namespaces
+    :param bool opta_managed: filter to only returned objects managed by opta
+    """
+    load_kube_config()
+    v1 = CoreV1Api()
+
+    if namespace:
+        claims = v1.list_namespaced_persistent_volume_claim(namespace)
+    else:
+        claims = v1.list_persistent_volume_claim_for_all_namespaces()
+
+    # Filter out any claims that are not managed by opta
+    claim_items = claims.items
+    if opta_managed:
+        claim_items = [
+            claim for claim in claim_items if claim.metadata.name.startswith("opta-")
+        ]
+
+    return claim_items
+
+
+def delete_persistent_volume_claim(
+    namespace: str, name: str, async_req: bool = False
+) -> None:
+    """delete_persistent_volume_claim
+
+    delete a PersistentVolumeClaim
+
+    This method makes a synchronous HTTP request by default. To make an
+    asynchronous HTTP request, please pass async_req=True
+
+    :param str namespace: namespace where the PersistentVolumeClaim is located
+    :param str name: name of the PersistentVolumeClaim (required)
+    :param bool async_req: execute request asynchronously
+    """
+    load_kube_config()
+    v1 = CoreV1Api()
+
+    try:
+        options = V1DeleteOptions(grace_period_seconds=5)
+        v1.delete_collection_namespaced_persistent_volume_claim(
+            namespace=namespace,
+            field_selector=f"metadata.name={name}",
+            async_req=async_req,
+            body=options,
+        )
+    except ApiException as e:
+        if e.status == 404:
+            # not found = nothing to delete
+            return None
+        raise e
+
+
+def delete_persistent_volume_claims(
+    namespace: str, opta_managed: bool = True, async_req: bool = True
+) -> None:
+    """delete_persistent_volume_claims
+
+    Delete Persistent Volume Claims for a given namespace
+
+    This method makes a synchronous HTTP request by default. To make an
+    asynchronous HTTP request, please pass async_req=True
+
+    :param str namespace: namespace to search for the Persistent Volume Claims
+    :param bool opta_managed: filter to only delete objects managed by opta
+    :param bool async_req: execute request asynchronously
+    """
+
+    claims = list_persistent_volume_claims(namespace=namespace, opta_managed=opta_managed)
+    if not claims:
+        logger.info(
+            f"No persistent volume claim (opta_managed: {opta_managed}) found in namespace '{namespace}', skipping persistent volume cleanup"
+        )
+        return
+
+    logger.info(f"Deleting persistent volumes in namespace '{namespace}'")
+
+    # delete the PVCs
+    # Note: when deleting the PVC, the PV are automatically deleted
+    for claim in claims:
+        logger.info(f"Deleting persistent volume claim '{claim.metadata.name}'")
+        delete_persistent_volume_claim(
+            namespace, claim.metadata.name, async_req=async_req
+        )
 
 
 def list_services(*, namespace: Optional[str] = None) -> List[V1Service]:

--- a/tests/core/test_kubernetes.py
+++ b/tests/core/test_kubernetes.py
@@ -449,7 +449,7 @@ class TestKubernetes:
             return_value=[mocked_claim_opta1, mocked_claim_opta2],
         )
 
-        # call with no parameter, expect delete VPC namespaced method called for one PVC only
+        # call with no parameter, expect list PVC method called and 2 delete PVC calls
         namespace = "hello"
         delete_persistent_volume_claims(
             namespace=namespace, opta_managed=True, async_req=True

--- a/tests/core/test_kubernetes.py
+++ b/tests/core/test_kubernetes.py
@@ -2,13 +2,23 @@ import datetime
 from subprocess import DEVNULL, CompletedProcess
 
 import pytz
-from kubernetes.client import ApiException, CoreV1Api, V1Event, V1EventList, V1Pod
+from kubernetes.client import (
+    ApiException,
+    CoreV1Api,
+    V1Event,
+    V1EventList,
+    V1PersistentVolumeClaim,
+    V1PersistentVolumeClaimList,
+    V1Pod,
+)
 from kubernetes.watch import Watch
 from pytest_mock import MockFixture
 
 from opta.core.kubernetes import (
     configure_kubectl,
+    delete_persistent_volume_claims,
     get_required_path_executables,
+    list_persistent_volume_claims,
     tail_module_log,
     tail_namespace_events,
     tail_pod_log,
@@ -386,3 +396,84 @@ class TestKubernetes:
                 mocker.call(16),
             ]
         )
+
+    def test_list_persistent_volume_claims(self, mocker: MockFixture) -> None:
+        mocked_core_v1_api = mocker.Mock(spec=CoreV1Api)
+        mocker.patch("opta.core.kubernetes.CoreV1Api", return_value=mocked_core_v1_api)
+        mocked_claim_opta = mocker.Mock(spec=V1PersistentVolumeClaim)
+        mocked_claim_opta.metadata = mocker.Mock()
+        mocked_claim_opta.metadata.name = "opta-claim-0"
+
+        mocked_claim_non_opta = mocker.Mock(spec=V1PersistentVolumeClaim)
+        mocked_claim_non_opta.metadata = mocker.Mock()
+        mocked_claim_non_opta.metadata.name = "my-org-claim-0"
+
+        mocked_claim_list = mocker.Mock(spec=V1PersistentVolumeClaimList)
+        mocked_claim_list.items = [mocked_claim_opta, mocked_claim_non_opta]
+
+        mocked_core_v1_api.list_persistent_volume_claim_for_all_namespaces.return_value = (
+            mocked_claim_list
+        )
+        mocked_core_v1_api.list_namespaced_persistent_volume_claim.return_value = (
+            mocked_claim_list
+        )
+
+        # call with no parameter, expect all_namespaces method called
+        results = list_persistent_volume_claims()
+        mocked_core_v1_api.list_persistent_volume_claim_for_all_namespaces.assert_called_once_with()
+        assert len(results) == 2
+
+        # call with namespace, expect namespaced method called
+        results = list_persistent_volume_claims(namespace="hello")
+        mocked_core_v1_api.list_namespaced_persistent_volume_claim.assert_called_once_with(
+            "hello"
+        )
+
+        # check opta_managed filtering works
+        results = list_persistent_volume_claims(opta_managed=True)
+        assert len(results) == 1
+
+    def test_delete_persistent_volume_claims(self, mocker: MockFixture) -> None:
+        mocked_core_v1_api = mocker.Mock(spec=CoreV1Api)
+        mocker.patch("opta.core.kubernetes.CoreV1Api", return_value=mocked_core_v1_api)
+        mocked_claim_opta1 = mocker.Mock(spec=V1PersistentVolumeClaim)
+        mocked_claim_opta1.metadata = mocker.Mock()
+        mocked_claim_opta1.metadata.name = "opta-claim-1"
+
+        mocked_claim_opta2 = mocker.Mock(spec=V1PersistentVolumeClaim)
+        mocked_claim_opta2.metadata = mocker.Mock()
+        mocked_claim_opta2.metadata.name = "opta-claim-2"
+
+        mocked_list_persistent_volume_claims = mocker.patch(
+            "opta.core.kubernetes.list_persistent_volume_claims",
+            return_value=[mocked_claim_opta1, mocked_claim_opta2],
+        )
+
+        # call with no parameter, expect delete VPC namespaced method called for one PVC only
+        namespace = "hello"
+        delete_persistent_volume_claims(
+            namespace=namespace, opta_managed=True, async_req=True
+        )
+        mocked_list_persistent_volume_claims.assert_called_once_with(
+            namespace="hello", opta_managed=True
+        )
+
+        mocked_core_v1_api.delete_collection_namespaced_persistent_volume_claim.assert_has_calls(
+            [
+                mocker.call(
+                    namespace="hello",
+                    field_selector="metadata.name=opta-claim-1",
+                    async_req=True,
+                    body=mocker.ANY,
+                ),
+                mocker.call(
+                    namespace="hello",
+                    field_selector="metadata.name=opta-claim-2",
+                    async_req=True,
+                    body=mocker.ANY,
+                ),
+            ]
+        )
+
+        # pv are automatically deleted by k8s after deleting the claim, not by opta
+        mocked_core_v1_api.assert_not_called()

--- a/tests/core/test_kubernetes.py
+++ b/tests/core/test_kubernetes.py
@@ -400,6 +400,7 @@ class TestKubernetes:
     def test_list_persistent_volume_claims(self, mocker: MockFixture) -> None:
         mocked_core_v1_api = mocker.Mock(spec=CoreV1Api)
         mocker.patch("opta.core.kubernetes.CoreV1Api", return_value=mocked_core_v1_api)
+        mocker.patch("opta.core.kubernetes.load_kube_config")
         mocked_claim_opta = mocker.Mock(spec=V1PersistentVolumeClaim)
         mocked_claim_opta.metadata = mocker.Mock()
         mocked_claim_opta.metadata.name = "opta-claim-0"
@@ -436,6 +437,7 @@ class TestKubernetes:
     def test_delete_persistent_volume_claims(self, mocker: MockFixture) -> None:
         mocked_core_v1_api = mocker.Mock(spec=CoreV1Api)
         mocker.patch("opta.core.kubernetes.CoreV1Api", return_value=mocked_core_v1_api)
+        mocker.patch("opta.core.kubernetes.load_kube_config")
         mocked_claim_opta1 = mocker.Mock(spec=V1PersistentVolumeClaim)
         mocked_claim_opta1.metadata = mocker.Mock()
         mocked_claim_opta1.metadata.name = "opta-claim-1"

--- a/tests/fixtures/sample_opta_files/service.yaml
+++ b/tests/fixtures/sample_opta_files/service.yaml
@@ -1,0 +1,9 @@
+environments:
+  - name: staging
+    path: "../dummy_data/dummy_config_parent.yaml"
+name: app
+modules:
+  - type: k8s-service
+    name: app
+    image: AUTO
+

--- a/tests/fixtures/sample_opta_files/service_persistent_storage.yaml
+++ b/tests/fixtures/sample_opta_files/service_persistent_storage.yaml
@@ -1,0 +1,12 @@
+environments:
+  - name: staging
+    path: "../dummy_data/dummy_config_parent.yaml"
+name: app
+modules:
+  - type: k8s-service
+    name: app
+    image: AUTO
+    persistent_storage:
+      - path: "/my-pv"
+        size: 1 # 1 GB
+

--- a/tests/test_layer.py
+++ b/tests/test_layer.py
@@ -7,6 +7,7 @@ import pytest
 from pytest_mock import MockFixture
 
 from modules.base import ModuleProcessor
+from opta.core.terraform import Terraform
 from opta.exceptions import UserErrors
 from opta.layer import Layer
 
@@ -443,3 +444,41 @@ class TestLayer:
 
         assert layer.name == "app"
         assert layer.parent.name == "dummy-parent"
+
+    def test_service_persistent_storage(self, mocker: MockFixture):
+
+        mocker.patch("opta.core.terraform.nice_run")
+        mocker.patch("opta.core.terraform.AWS")
+        mocked_delete_persistent_volume_claims = mocker.patch(
+            "opta.core.kubernetes.delete_persistent_volume_claims"
+        )
+
+        Terraform.destroy_all(
+            Layer.load_from_yaml(
+                os.path.join(
+                    os.path.dirname(os.path.dirname(__file__)),
+                    "tests",
+                    "fixtures",
+                    "sample_opta_files",
+                    "service.yaml",
+                ),
+                None,
+            )
+        )
+        # check if delete pvc was NOT called
+        mocked_delete_persistent_volume_claims.assert_not_called()
+
+        Terraform.destroy_all(
+            Layer.load_from_yaml(
+                os.path.join(
+                    os.path.dirname(os.path.dirname(__file__)),
+                    "tests",
+                    "fixtures",
+                    "sample_opta_files",
+                    "service_persistent_storage.yaml",
+                ),
+                None,
+            )
+        )
+        # check if delete pvc was called
+        mocked_delete_persistent_volume_claims.assert_called_once()


### PR DESCRIPTION
# Description
Some context:
- Kubernetes API: _PersistentVolumes associated with the Pods' PersistentVolume Claims are not deleted when the Pods, or StatefulSet are deleted._ https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#stable-storage
- Helm is consistent with k8s, it doesn't delete PVC when deleting a StatefulSet https://github.com/helm/helm/issues/3313
- Currently Opta uses Helm to uninstall a service, so the persistent volumes are always kept.

How do developer usually solve this issue?
- Manually delete these resources (as suggested by k8s documentation)
- (or) Configure a `post-delete` [hook](https://helm.sh/docs/topics/charts_hooks/) in helm. [example](https://github.com/helm/helm/issues/5137)
- (or) Use this kubernetes 1.23 alpha feature: PersistentVolumeClaim retention https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#persistentvolumeclaim-retention

How can we support it with Opta?
1. Configure a `post-delete` hook in helm.
    - Complexity with getting helm to run kubectl with the necessary permission, see https://github.com/helm/helm/issues/5137
2. Configure a `local-exec` in terraform running kubectl when destroy is invoked
    - This would become a shell script to maintain/test
3. Configure a opta `post_delete` hook when the k8s service module processor
    - This is would be a first-class citizen support with opta, python change

This PR implements 3.



# Safety checklist
* [X] This change is backwards compatible and safe to apply by existing users
* [N] This change will NOT lead to data loss
    - **Previously we would keep the PVC and PV, and the underlying storage (EBS, PersistentDisk) when doing `opta destroy` on a service file. With this change, destroy would delete the PVC and PV and their underlying storage**
    - cc @NitinAgg  Proposal (not implemented with this PR): If this needs to be backward compatible, we could have a new field in `persistent_storage` to define the claim retention policy (to mirror https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#persistentvolumeclaim-retention)
ex:
```yaml
    persistent_storage:
      - path: "/my-pv"
        size: 1 # 1 GB
        retention_policy: [Retain/Delete] # default could be Retain for backward compatibility
```
* [X] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
- added new unit tests
- tested with AWS, EBS is deleted
- tested with GCP, Persistent Disk is deleted

Example of Opta destroy ouput:
```
Destroy complete! Resources: 5 destroyed.

Deleting persistent volumes in namespace 'hellopv'
Deleting persistent volume claim 'opta-persistent-0-hellopv-hellopv-k8s-service-0'
```
