### PR TITLE
Updated the behaviour of opta apply and destroy if auto-approve flag is provided.

### DIFF
--- a/opta/commands/apply.py
+++ b/opta/commands/apply.py
@@ -208,7 +208,7 @@ def _apply(
         existing_modules: Set[str] = set()
         first_loop = True
         for module_idx, current_modules, total_block_count in gen(
-            layer, existing_config, image_tag, image_digest, test, True
+            layer, existing_config, image_tag, image_digest, test, True, auto_approve
         ):
             if first_loop:
                 # This is set during the first iteration, since the tf file must exist.

--- a/opta/commands/destroy.py
+++ b/opta/commands/destroy.py
@@ -1,6 +1,5 @@
 import os
 import time
-from colored import attr, fg
 from pathlib import Path
 from typing import Dict, List, Optional
 
@@ -8,6 +7,7 @@ import boto3
 import click
 from azure.storage.blob import ContainerClient
 from botocore.config import Config
+from colored import attr, fg
 from google.cloud import storage  # type: ignore
 from google.cloud.exceptions import NotFound
 

--- a/opta/commands/destroy.py
+++ b/opta/commands/destroy.py
@@ -21,7 +21,7 @@ from opta.error_constants import USER_ERROR_TF_LOCK
 from opta.exceptions import UserErrors
 from opta.layer import Layer
 from opta.pre_check import pre_check
-from opta.utils import check_opta_file_exists, fmt_msg, logger
+from opta.utils import check_opta_file_exists, logger
 
 
 @click.command()

--- a/opta/commands/destroy.py
+++ b/opta/commands/destroy.py
@@ -90,13 +90,14 @@ def destroy(
 
     tf_flags: List[str] = []
     if auto_approve:
+        sleep_time = 2
         logger.info(
-            f"{fg('red')}{attr('bold')}Opta will now destroy the {attr('underlined')}{layer.name}{attr(0)}"
-            f"{fg('red')}{attr('bold')} layer.{attr(0)}\n"
-            f"{fg('red')}{attr('bold')}Sleeping for {attr('underlined')}2 secs{attr(0)}"
-            f"{fg('red')}{attr('bold')}, if user wants to abort.{attr(0)}"
+            f"{fg('green')}{attr('bold')}Opta will now destroy the {attr('underlined')}{layer.name}{attr(0)}"
+            f"{fg('green')}{attr('bold')} layer.{attr(0)}\n"
+            f"{fg('green')}{attr('bold')}Sleeping for {attr('underlined')}{sleep_time} secs{attr(0)}"
+            f"{fg('green')}{attr('bold')}, press Ctrl+C to Abort.{attr(0)}"
         )
-        time.sleep(2)
+        time.sleep(sleep_time)
         tf_flags.append("-auto-approve")
     modules = Terraform.get_existing_modules(layer)
     layer.modules = [x for x in layer.modules if x.name in modules]

--- a/opta/commands/destroy.py
+++ b/opta/commands/destroy.py
@@ -1,4 +1,6 @@
 import os
+import time
+from colored import attr, fg
 from pathlib import Path
 from typing import Dict, List, Optional
 
@@ -88,16 +90,13 @@ def destroy(
 
     tf_flags: List[str] = []
     if auto_approve:
-        # Note that for ci, you can just do "yes | opta destroy --auto-approve"
-        click.confirm(
-            fmt_msg(
-                f"""
-                Are you REALLY sure you want to run destroy with auto-approve?
-                ~Please make sure *{layer.name}* is the correct opta config.
-                """
-            ),
-            abort=True,
+        logger.info(
+            f"{fg('red')}{attr('bold')}Opta will now destroy the {attr('underlined')}{layer.name}{attr(0)}"
+            f"{fg('red')}{attr('bold')} layer.{attr(0)}\n"
+            f"{fg('red')}{attr('bold')}Sleeping for {attr('underlined')}2 secs{attr(0)}"
+            f"{fg('red')}{attr('bold')}, if user wants to abort.{attr(0)}"
         )
+        time.sleep(2)
         tf_flags.append("-auto-approve")
     modules = Terraform.get_existing_modules(layer)
     layer.modules = [x for x in layer.modules if x.name in modules]

--- a/opta/commands/destroy.py
+++ b/opta/commands/destroy.py
@@ -7,7 +7,7 @@ import boto3
 import click
 from azure.storage.blob import ContainerClient
 from botocore.config import Config
-from colored import attr, fg
+from colored import attr
 from google.cloud import storage  # type: ignore
 from google.cloud.exceptions import NotFound
 
@@ -92,10 +92,10 @@ def destroy(
     if auto_approve:
         sleep_time = 2
         logger.info(
-            f"{fg('green')}{attr('bold')}Opta will now destroy the {attr('underlined')}{layer.name}{attr(0)}"
-            f"{fg('green')}{attr('bold')} layer.{attr(0)}\n"
-            f"{fg('green')}{attr('bold')}Sleeping for {attr('underlined')}{sleep_time} secs{attr(0)}"
-            f"{fg('green')}{attr('bold')}, press Ctrl+C to Abort.{attr(0)}"
+            f"{attr('bold')}Opta will now destroy the {attr('underlined')}{layer.name}{attr(0)}"
+            f"{attr('bold')} layer.{attr(0)}\n"
+            f"{attr('bold')}Sleeping for {attr('underlined')}{sleep_time} secs{attr(0)}"
+            f"{attr('bold')}, press Ctrl+C to Abort.{attr(0)}"
         )
         time.sleep(sleep_time)
         tf_flags.append("-auto-approve")

--- a/opta/commands/force_unlock.py
+++ b/opta/commands/force_unlock.py
@@ -16,13 +16,7 @@ from opta.utils import check_opta_file_exists
 @click.option(
     "-e", "--env", default=None, help="The env to use when loading the config file."
 )
-@click.option(
-    "--auto-approve",
-    is_flag=True,
-    default=False,
-    help="Automatically approve terraform plan.",
-)
-def force_unlock(config: str, env: Optional[str], auto_approve: bool) -> None:
+def force_unlock(config: str, env: Optional[str]) -> None:
     """Force Unlocks a stuck lock on the current workspace
 
     Examples:
@@ -42,26 +36,24 @@ def force_unlock(config: str, env: Optional[str], auto_approve: bool) -> None:
         tf_lock_exists, _ = Terraform.tf_lock_details(layer)
         if tf_lock_exists:
             Terraform.init(layer=layer)
-            if not auto_approve:
-                click.confirm(
-                    "This will remove the lock on the remote state."
-                    "\nPlease make sure that no other instance of opta command is running on this file."
-                    "\nDo you still want to proceed?",
-                    abort=True,
-                )
+            click.confirm(
+                "This will remove the lock on the remote state."
+                "\nPlease make sure that no other instance of opta command is running on this file."
+                "\nDo you still want to proceed?",
+                abort=True,
+            )
             tf_flags.append("-force")
             Terraform.force_unlock(layer, *tf_flags)
 
         if layer.parent is not None or "k8scluster" in modules:
             configure_kubectl(layer)
             pending_upgrade_release_list = Helm.get_helm_list(status="pending-upgrade")
-            if not auto_approve:
-                click.confirm(
-                    "Do you also wish to Rollback the Helm releases in Pending-Upgrade State?"
-                    "\nPlease make sure that no other instance of opta command is running on this file."
-                    "\nDo you still want to proceed?",
-                    abort=True,
-                )
+            click.confirm(
+                "Do you also wish to Rollback the Helm releases in Pending-Upgrade State?"
+                "\nPlease make sure that no other instance of opta command is running on this file."
+                "\nDo you still want to proceed?",
+                abort=True,
+            )
 
             for release in pending_upgrade_release_list:
                 Helm.rollback_helm(

--- a/opta/commands/force_unlock.py
+++ b/opta/commands/force_unlock.py
@@ -16,7 +16,13 @@ from opta.utils import check_opta_file_exists
 @click.option(
     "-e", "--env", default=None, help="The env to use when loading the config file."
 )
-def force_unlock(config: str, env: Optional[str]) -> None:
+@click.option(
+    "--auto-approve",
+    is_flag=True,
+    default=False,
+    help="Automatically approve terraform plan.",
+)
+def force_unlock(config: str, env: Optional[str], auto_approve: bool) -> None:
     """Force Unlocks a stuck lock on the current workspace
 
     Examples:
@@ -36,24 +42,26 @@ def force_unlock(config: str, env: Optional[str]) -> None:
         tf_lock_exists, _ = Terraform.tf_lock_details(layer)
         if tf_lock_exists:
             Terraform.init(layer=layer)
-            click.confirm(
-                "This will remove the lock on the remote state."
-                "\nPlease make sure that no other instance of opta command is running on this file."
-                "\nDo you still want to proceed?",
-                abort=True,
-            )
+            if not auto_approve:
+                click.confirm(
+                    "This will remove the lock on the remote state."
+                    "\nPlease make sure that no other instance of opta command is running on this file."
+                    "\nDo you still want to proceed?",
+                    abort=True,
+                )
             tf_flags.append("-force")
             Terraform.force_unlock(layer, *tf_flags)
 
         if layer.parent is not None or "k8scluster" in modules:
             configure_kubectl(layer)
             pending_upgrade_release_list = Helm.get_helm_list(status="pending-upgrade")
-            click.confirm(
-                "Do you also wish to Rollback the Helm releases in Pending-Upgrade State?"
-                "\nPlease make sure that no other instance of opta command is running on this file."
-                "\nDo you still want to proceed?",
-                abort=True,
-            )
+            if not auto_approve:
+                click.confirm(
+                    "Do you also wish to Rollback the Helm releases in Pending-Upgrade State?"
+                    "\nPlease make sure that no other instance of opta command is running on this file."
+                    "\nDo you still want to proceed?",
+                    abort=True,
+                )
 
             for release in pending_upgrade_release_list:
                 Helm.rollback_helm(

--- a/opta/core/generator.py
+++ b/opta/core/generator.py
@@ -1,7 +1,7 @@
 from typing import TYPE_CHECKING, Generator, List, Optional, Tuple
 
 import click
-from colored import attr, fg
+from colored import attr
 
 from opta import gen_tf
 from opta.constants import TF_FILE_PATH
@@ -71,10 +71,10 @@ def gen(
                             image_digest = current_image_info["digest"]
                     else:
                         logger.info(
-                            f"{fg('green')}{attr('bold')}Using the existing deployment {attr('underlined')}"
+                            f"{attr('bold')}Using the existing deployment {attr('underlined')}"
                             f"(tag={current_image_info['tag']}, digest={current_image_info['digest']}).{attr(0)}\n"
-                            f"{fg('green')}{attr('bold')}If you wish to deploy another image, please use "
-                            f"{fg('green')}{attr('bold')}{attr('underlined')} opta deploy command.{attr(0)}"
+                            f"{attr('bold')}If you wish to deploy another image, please use "
+                            f"{attr('bold')}{attr('underlined')} opta deploy command.{attr(0)}"
                         )
                         image_tag = current_image_info["tag"]
                         image_digest = current_image_info["digest"]

--- a/opta/core/generator.py
+++ b/opta/core/generator.py
@@ -1,6 +1,7 @@
 from typing import TYPE_CHECKING, Generator, List, Optional, Tuple
 
 import click
+from colored import attr, fg
 
 from opta import gen_tf
 from opta.constants import TF_FILE_PATH
@@ -28,6 +29,7 @@ def gen(
     image_digest: Optional[str] = None,
     test: bool = False,
     check_image: bool = False,
+    auto_approve: bool = False,
 ) -> Generator[Tuple[int, List["Module"], int], None, None]:
     """Generate TF file based on opta config file"""
     logger.debug("Loading infra blocks")
@@ -59,11 +61,21 @@ def gen(
                     and service_module.data.get("image", "").upper() == "AUTO"
                     and not test
                 ):
-                    if click.confirm(
-                        f"WARNING There is an existing deployment (tag={current_image_info['tag']}, "
-                        f"digest={current_image_info['digest']}) and the pods will be killed as you "
-                        f"did not specify an image tag. Would you like to keep the existing deployment alive? (y/n)",
-                    ):
+                    if not auto_approve:
+                        if click.confirm(
+                            f"WARNING There is an existing deployment (tag={current_image_info['tag']}, "
+                            f"digest={current_image_info['digest']}) and the pods will be killed as you "
+                            f"did not specify an image tag. Would you like to keep the existing deployment alive?",
+                        ):
+                            image_tag = current_image_info["tag"]
+                            image_digest = current_image_info["digest"]
+                    else:
+                        logger.info(
+                            f"{fg('green')}{attr('bold')}Using the existing deployment {attr('underlined')}"
+                            f"(tag={current_image_info['tag']}, digest={current_image_info['digest']}).{attr(0)}\n"
+                            f"{fg('green')}{attr('bold')}If you wish to deploy another image, please use "
+                            f"{fg('green')}{attr('bold')}{attr('underlined')} opta deploy command.{attr(0)}"
+                        )
                         image_tag = current_image_info["tag"]
                         image_digest = current_image_info["digest"]
         layer.variables["image_tag"] = image_tag


### PR DESCRIPTION
# Description
If the `--auto-approve` flag is provided, then
`opta destroy` doesn't confirm the layer name with a User prompt, rather just gives a 2 second gap to the User to Abort.
`opta apply` in case of an existing deployment will keep the deployment alive.

# Safety checklist
* [X] This change is backwards compatible and safe to apply by existing users
* [X] This change will NOT lead to data loss
* [X] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
Tested Manually.
