### PR TITLE
Stateless TF Unlock for AWS and GCP

### DIFF
--- a/opta/commands/force_unlock.py
+++ b/opta/commands/force_unlock.py
@@ -32,19 +32,19 @@ def force_unlock(config: str, env: Optional[str]) -> None:
     layer.modules = [x for x in layer.modules if x.name in modules]
     gen_all(layer)
 
-    if Terraform.download_state(layer):
-        tf_lock_exists, _ = Terraform.tf_lock_details(layer)
-        if tf_lock_exists:
-            Terraform.init(layer=layer)
-            click.confirm(
-                "This will remove the lock on the remote state."
-                "\nPlease make sure that no other instance of opta command is running on this file."
-                "\nDo you still want to proceed?",
-                abort=True,
-            )
-            tf_flags.append("-force")
-            Terraform.force_unlock(layer, *tf_flags)
+    tf_lock_exists, _ = Terraform.tf_lock_details(layer)
+    if tf_lock_exists:
+        Terraform.init(layer=layer)
+        click.confirm(
+            "This will remove the lock on the remote state."
+            "\nPlease make sure that no other instance of opta command is running on this file."
+            "\nDo you still want to proceed?",
+            abort=True,
+        )
+        tf_flags.append("-force")
+        Terraform.force_unlock(layer, *tf_flags)
 
+    if Terraform.download_state(layer):
         if layer.parent is not None or "k8scluster" in modules:
             configure_kubectl(layer)
             pending_upgrade_release_list = Helm.get_helm_list(status="pending-upgrade")

--- a/opta/core/aws.py
+++ b/opta/core/aws.py
@@ -153,6 +153,16 @@ class AWS(CloudClient):
         except Exception:
             return ""
 
+    def force_delete_terraform_lock_id(self) -> None:
+        bucket = self.layer.state_storage()
+        providers = self.layer.gen_providers(0)
+        dynamodb_table = providers["terraform"]["backend"]["s3"]["dynamodb_table"]
+
+        self.__get_dynamodb(dynamodb_table).delete_item(
+            TableName=dynamodb_table,
+            Key={"LockID": {"S": f"{bucket}/{self.layer.name}"}},
+        )
+
     @staticmethod
     def get_all_versions(bucket: str, filename: str, region: str) -> List[str]:
         s3 = boto3.client("s3", config=Config(region_name=region))

--- a/opta/core/aws.py
+++ b/opta/core/aws.py
@@ -154,6 +154,9 @@ class AWS(CloudClient):
             return ""
 
     def force_delete_terraform_lock_id(self) -> None:
+        logger.info(
+            "Trying to Remove the lock forcefully. Will try deleting Dynamo DB Entry."
+        )
         bucket = self.layer.state_storage()
         providers = self.layer.gen_providers(0)
         dynamodb_table = providers["terraform"]["backend"]["s3"]["dynamodb_table"]

--- a/opta/core/gcp.py
+++ b/opta/core/gcp.py
@@ -160,4 +160,4 @@ class GCP(CloudClient):
         credentials, project_id = self.get_credentials()
         gcs_client = storage.Client(project=project_id, credentials=credentials)
         bucket_object = gcs_client.get_bucket(bucket)
-        tf_lock_blob = bucket_object.delete_blob(tf_lock_path)
+        bucket_object.delete_blob(tf_lock_path)

--- a/opta/core/gcp.py
+++ b/opta/core/gcp.py
@@ -153,3 +153,11 @@ class GCP(CloudClient):
         except Exception:  # Backwards compatibility
             logger.debug("No Terraform Lock state exists.")
             return ""
+
+    def force_delete_terraform_lock_id(self) -> None:
+        bucket = self.layer.state_storage()
+        tf_lock_path = f"{self.layer.name}/default.tflock"
+        credentials, project_id = self.get_credentials()
+        gcs_client = storage.Client(project=project_id, credentials=credentials)
+        bucket_object = gcs_client.get_bucket(bucket)
+        tf_lock_blob = bucket_object.delete_blob(tf_lock_path)

--- a/opta/core/gcp.py
+++ b/opta/core/gcp.py
@@ -155,6 +155,9 @@ class GCP(CloudClient):
             return ""
 
     def force_delete_terraform_lock_id(self) -> None:
+        logger.info(
+            "Trying to Remove the lock forcefully. Will try deleting TF Lock File."
+        )
         bucket = self.layer.state_storage()
         tf_lock_path = f"{self.layer.name}/default.tflock"
         credentials, project_id = self.get_credentials()

--- a/opta/core/terraform.py
+++ b/opta/core/terraform.py
@@ -952,11 +952,24 @@ class Terraform:
             print("Terraform Lock Id could not be found.")
             return
 
-        nice_run(
-            ["terraform", "force-unlock", *tf_flags, lock_id],
-            use_asyncio_nice_run=True,
-            check=True,
-        )
+        try:
+            nice_run(
+                ["terraform", "force-unlock", *tf_flags, lock_id],
+                use_asyncio_nice_run=True,
+                check=True,
+            )
+        except Exception as e:
+            logger.info("An exception occured while removing the Terraform Lock. Trying to Remove the lock forcefully.")
+            cls.force_delete_terraform_lock(layer, e)
+
+    @classmethod
+    def force_delete_terraform_lock(cls, layer: "Layer", exception: Exception) -> None:
+        if layer.cloud == 'aws':
+            AWS(layer).force_delete_terraform_lock_id()
+        elif layer.cloud == 'google':
+            GCP(layer).force_delete_terraform_lock_id()
+        else:
+            raise exception
 
     @classmethod
     def tf_lock_details(cls, layer: "Layer") -> Tuple[bool, str]:
@@ -1057,3 +1070,7 @@ def fetch_terraform_state_resources(layer: "Layer") -> dict:
         resources_dict[address]["name"] = resource.get("name", "")
 
     return resources_dict
+
+
+# 09190a7d-d4e5-a4e5-b22f-a94f36e93f11
+# 09190a7d-d4e5-a4e5-b22f-a94f36e93f11

--- a/opta/core/terraform.py
+++ b/opta/core/terraform.py
@@ -336,7 +336,9 @@ class Terraform:
         region = layer.root().providers["aws"]["region"]
         s3 = boto3.client("s3", config=Config(region_name=region))
         try:
-            s3.get_bucket_encryption(Bucket=bucket,)
+            s3.get_bucket_encryption(
+                Bucket=bucket,
+            )
         except ClientError as e:
             if e.response["Error"]["Code"] == "NoSuchBucket":
                 return False
@@ -344,7 +346,12 @@ class Terraform:
         return True
 
     @classmethod
-    def plan(cls, *tf_flags: str, quiet: Optional[bool] = False, layer: "Layer",) -> None:
+    def plan(
+        cls,
+        *tf_flags: str,
+        quiet: Optional[bool] = False,
+        layer: "Layer",
+    ) -> None:
         cls.init(quiet, layer=layer)
         kwargs = cls.insert_extra_env(layer)
         if quiet:
@@ -495,7 +502,9 @@ class Terraform:
         elif layer.cloud == "local":
             try:
                 tf_file = os.path.join(
-                    cls.get_local_opta_dir(), "tfstate", f"{layer.name}",
+                    cls.get_local_opta_dir(),
+                    "tfstate",
+                    f"{layer.name}",
                 )
                 if os.path.exists(tf_file):
                     copyfile(tf_file, state_file)
@@ -781,7 +790,10 @@ class Terraform:
             )
             time.sleep(120)
         service = discovery.build(
-            "cloudresourcemanager", "v1", credentials=credentials, static_discovery=False,
+            "cloudresourcemanager",
+            "v1",
+            credentials=credentials,
+            static_discovery=False,
         )
         request = service.projects().get(projectId=project_id)
         response = request.execute()
@@ -805,7 +817,9 @@ class Terraform:
         dynamodb = boto3.client("dynamodb", config=Config(region_name=region))
         iam = boto3.client("iam", config=Config(region_name=region))
         try:
-            s3.get_bucket_encryption(Bucket=bucket_name,)
+            s3.get_bucket_encryption(
+                Bucket=bucket_name,
+            )
         except ClientError as e:
             if e.response["Error"]["Code"] == "AuthFailure":
                 raise UserErrors(
@@ -829,7 +843,9 @@ class Terraform:
                 )
             logger.debug("S3 bucket for terraform state not found, creating a new one")
             if region == "us-east-1":
-                s3.create_bucket(Bucket=bucket_name,)
+                s3.create_bucket(
+                    Bucket=bucket_name,
+                )
             else:
                 s3.create_bucket(
                     Bucket=bucket_name,
@@ -858,7 +874,8 @@ class Terraform:
                 },
             )
             s3.put_bucket_versioning(
-                Bucket=bucket_name, VersioningConfiguration={"Status": "Enabled"},
+                Bucket=bucket_name,
+                VersioningConfiguration={"Status": "Enabled"},
             )
             s3.put_bucket_lifecycle(
                 Bucket=bucket_name,
@@ -903,7 +920,9 @@ class Terraform:
             )
         # Create the service linked roles
         try:
-            iam.create_service_linked_role(AWSServiceName="autoscaling.amazonaws.com",)
+            iam.create_service_linked_role(
+                AWSServiceName="autoscaling.amazonaws.com",
+            )
         except ClientError as e:
             if e.response["Error"]["Code"] != "InvalidInput":
                 raise UserErrors(
@@ -959,9 +978,7 @@ class Terraform:
                 check=True,
             )
         except Exception as e:
-            logger.info(
-                "An exception occured while removing the Terraform Lock. Trying to Remove the lock forcefully."
-            )
+            logger.info("An exception occured while removing the Terraform Lock.")
             cls.force_delete_terraform_lock(layer, e)
 
     @classmethod

--- a/opta/core/terraform.py
+++ b/opta/core/terraform.py
@@ -336,9 +336,7 @@ class Terraform:
         region = layer.root().providers["aws"]["region"]
         s3 = boto3.client("s3", config=Config(region_name=region))
         try:
-            s3.get_bucket_encryption(
-                Bucket=bucket,
-            )
+            s3.get_bucket_encryption(Bucket=bucket,)
         except ClientError as e:
             if e.response["Error"]["Code"] == "NoSuchBucket":
                 return False
@@ -346,12 +344,7 @@ class Terraform:
         return True
 
     @classmethod
-    def plan(
-        cls,
-        *tf_flags: str,
-        quiet: Optional[bool] = False,
-        layer: "Layer",
-    ) -> None:
+    def plan(cls, *tf_flags: str, quiet: Optional[bool] = False, layer: "Layer",) -> None:
         cls.init(quiet, layer=layer)
         kwargs = cls.insert_extra_env(layer)
         if quiet:
@@ -502,9 +495,7 @@ class Terraform:
         elif layer.cloud == "local":
             try:
                 tf_file = os.path.join(
-                    cls.get_local_opta_dir(),
-                    "tfstate",
-                    f"{layer.name}",
+                    cls.get_local_opta_dir(), "tfstate", f"{layer.name}",
                 )
                 if os.path.exists(tf_file):
                     copyfile(tf_file, state_file)
@@ -790,10 +781,7 @@ class Terraform:
             )
             time.sleep(120)
         service = discovery.build(
-            "cloudresourcemanager",
-            "v1",
-            credentials=credentials,
-            static_discovery=False,
+            "cloudresourcemanager", "v1", credentials=credentials, static_discovery=False,
         )
         request = service.projects().get(projectId=project_id)
         response = request.execute()
@@ -817,9 +805,7 @@ class Terraform:
         dynamodb = boto3.client("dynamodb", config=Config(region_name=region))
         iam = boto3.client("iam", config=Config(region_name=region))
         try:
-            s3.get_bucket_encryption(
-                Bucket=bucket_name,
-            )
+            s3.get_bucket_encryption(Bucket=bucket_name,)
         except ClientError as e:
             if e.response["Error"]["Code"] == "AuthFailure":
                 raise UserErrors(
@@ -843,9 +829,7 @@ class Terraform:
                 )
             logger.debug("S3 bucket for terraform state not found, creating a new one")
             if region == "us-east-1":
-                s3.create_bucket(
-                    Bucket=bucket_name,
-                )
+                s3.create_bucket(Bucket=bucket_name,)
             else:
                 s3.create_bucket(
                     Bucket=bucket_name,
@@ -874,8 +858,7 @@ class Terraform:
                 },
             )
             s3.put_bucket_versioning(
-                Bucket=bucket_name,
-                VersioningConfiguration={"Status": "Enabled"},
+                Bucket=bucket_name, VersioningConfiguration={"Status": "Enabled"},
             )
             s3.put_bucket_lifecycle(
                 Bucket=bucket_name,
@@ -920,9 +903,7 @@ class Terraform:
             )
         # Create the service linked roles
         try:
-            iam.create_service_linked_role(
-                AWSServiceName="autoscaling.amazonaws.com",
-            )
+            iam.create_service_linked_role(AWSServiceName="autoscaling.amazonaws.com",)
         except ClientError as e:
             if e.response["Error"]["Code"] != "InvalidInput":
                 raise UserErrors(

--- a/opta/core/terraform.py
+++ b/opta/core/terraform.py
@@ -959,14 +959,16 @@ class Terraform:
                 check=True,
             )
         except Exception as e:
-            logger.info("An exception occured while removing the Terraform Lock. Trying to Remove the lock forcefully.")
+            logger.info(
+                "An exception occured while removing the Terraform Lock. Trying to Remove the lock forcefully."
+            )
             cls.force_delete_terraform_lock(layer, e)
 
     @classmethod
     def force_delete_terraform_lock(cls, layer: "Layer", exception: Exception) -> None:
-        if layer.cloud == 'aws':
+        if layer.cloud == "aws":
             AWS(layer).force_delete_terraform_lock_id()
-        elif layer.cloud == 'google':
+        elif layer.cloud == "google":
             GCP(layer).force_delete_terraform_lock_id()
         else:
             raise exception
@@ -1070,7 +1072,3 @@ def fetch_terraform_state_resources(layer: "Layer") -> dict:
         resources_dict[address]["name"] = resource.get("name", "")
 
     return resources_dict
-
-
-# 09190a7d-d4e5-a4e5-b22f-a94f36e93f11
-# 09190a7d-d4e5-a4e5-b22f-a94f36e93f11

--- a/tests/core/test_aws.py
+++ b/tests/core/test_aws.py
@@ -54,3 +54,19 @@ class TestAWS:
             ],
             Key={"LockID": {"S": f"{aws_layer.state_storage()}/{aws_layer.name}"}},
         )
+
+    def test_force_delete_terraform_lock_id(
+        self, mocker: MockFixture, aws_layer: Mock
+    ) -> None:
+        mock_dynamodb_client_instance = mocker.Mock(spec=DynamoDBClient)
+        mocker.patch(
+            "opta.core.aws.boto3.client", return_value=mock_dynamodb_client_instance
+        )
+        mock_aws = AWS(aws_layer)
+        mock_aws.force_delete_terraform_lock_id()
+        mock_dynamodb_client_instance.delete_item.assert_called_once_with(
+            TableName=aws_layer.gen_providers(0)["terraform"]["backend"]["s3"][
+                "dynamodb_table"
+            ],
+            Key={"LockID": {"S": f"{aws_layer.state_storage()}/{aws_layer.name}"}},
+        )


### PR DESCRIPTION
# Description
A special case, where the TF Lock gets created even before the State is stored in the Buckets. 
For this we are forcefully removing the TF Lock.
- AWS: Manually deleting the entry created in `Dynamo DB`.
- GCP: Manually deleting the `.tflock` file created.

Thanks @juandiegopalomino  for pointing out the issue.

# Safety checklist
* [x] This change is backwards compatible and safe to apply by existing users
* [x] This change will NOT lead to data loss
* [x] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
This has been manually tested.
