### PR TITLE
Massively sped up kubectl config operations through caching

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -53,7 +53,7 @@ google-api-python-client = ">=2.0.2,<2.1.0"
 oauth2client = ">=4.1.3,<4.2.0"
 google-cloud-storage = ">=1.36.2,<1.37.0"
 google-auth = ">=1.27.1,<1.28"
-boto3-stubs = {version = ">=1.17.44.0,<1.18", extras = ["essential", "ssm", "route53", "acm", "elbv2", "sesv2", "autoscaling", "logs"]}
+boto3-stubs = {version = ">=1.17.44.0,<1.18", extras = ["essential", "ssm", "route53", "acm", "elbv2", "sesv2", "autoscaling", "logs", "eks"]}
 pyOpenSSL = ">=20.0.1,<20.1"
 semver = "~=2.13.0"
 dnspython = "2.1.0"
@@ -61,6 +61,7 @@ docker = "5.0.0"
 tabulate = "0.8.9"
 types-tabulate = "0.8.2"
 psutil = "5.8.0"
+google-cloud-container = ">=2.10.1,<3"
 
 [requires]
 python_version = "3.8"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "2e6f8a44c73d3521a3c44f654cabf9ef801f83678fe75fa62ee02bcce19eec33"
+            "sha256": "49f0cf632a3ddda23346d51b63eb2c30e63dc5a31a9cbe60874732e83e1fb65d"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -32,10 +32,10 @@
         },
         "azure-core": {
             "hashes": [
-                "sha256:21d06311c9c373e394ed9f9db035306773334a0181932e265889eca34d778d17",
-                "sha256:5e5df1850ef6eff2b481a4a5fefa7d73ec74b6a2e0b27b179341f73f655fa4bf"
+                "sha256:3d70e9ec64de92dfae330c15bc69085caceb2d83813ef6c01cc45326f2a4be83",
+                "sha256:88d2db5cf9a135a7287dc45fdde6b96f9ca62c9567512a3bb3e20e322ce7deb2"
             ],
-            "version": "==1.20.1"
+            "version": "==1.21.1"
         },
         "azure-identity": {
             "hashes": [
@@ -94,16 +94,17 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:20a5109a37414a52c55d2048388f02cb7cf46fc0ca7be08b3bf81f4c5c053feb",
-                "sha256:e2b5ce2679424a6c2bfc2ee4bb42d9100c8c08b21eff8d74cff85a7243a76d7b"
+                "sha256:1e72294b042651ab27a3b6a9eea2810fc8faab5be52b0876f9f5b55f5fd9e101",
+                "sha256:4110e8a1790842d1f818363b83c5f72dea4bdd980c46df1540814c4a79d72884"
             ],
             "index": "pypi",
-            "version": "==1.20.10"
+            "version": "==1.20.33"
         },
         "boto3-stubs": {
             "extras": [
                 "acm",
                 "autoscaling",
+                "eks",
                 "elbv2",
                 "essential",
                 "logs",
@@ -120,19 +121,19 @@
         },
         "botocore": {
             "hashes": [
-                "sha256:0adda9a4a95221027312eaaee0ec9fe2239fb2f285fced3ddca54b1310b864ee",
-                "sha256:11670d3ac14eed1122e0154a7e1563c2c270beef43996466f8d11fbf5cf31611"
+                "sha256:8faeda0da14a3cb5df8005052527cc0263181adad6bdbfedbe20079c72973c2c",
+                "sha256:9be1ea775e6de420a5873dff42108a1843e9137a52ef98c926dad56a8152ef2f"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==1.23.10"
+            "version": "==1.23.33"
         },
         "botocore-stubs": {
             "hashes": [
-                "sha256:7e24c8b61e0a7f9812a19de90d2098d7ae12bca9dab532761fbf821c4d457f29",
-                "sha256:c85d2635a01014617f455a2e337e64a8d4786b4c9011726c520b5f6abc839c8e"
+                "sha256:b3add754023b60069838b4da18fe6320f54918d3d239ba2a9a7b58874c12f065",
+                "sha256:d069aa64806191b72824a7babe7e64f1854d3dcd3cd73a9c40d2fd4f7443bbd2"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==1.23.10"
+            "version": "==1.23.33"
         },
         "cachetools": {
             "hashes": [
@@ -206,11 +207,11 @@
         },
         "charset-normalizer": {
             "hashes": [
-                "sha256:e019de665e2bcf9c2b64e2e5aa025fa991da8720daa3c1138cadd2fd1856aed0",
-                "sha256:f7af805c321bfa1ce6714c51f254e0d5bb5e5834039bc17db7ebe3a4cec9492b"
+                "sha256:876d180e9d7432c5d1dfd4c5d26b72f099d503e8fcc0feb7532c9289be60fcbd",
+                "sha256:cb957888737fc0bbcd78e3df769addb41fd1ff8cf950dc9e7ad7793f1bf44455"
             ],
             "markers": "python_version >= '3'",
-            "version": "==2.0.7"
+            "version": "==2.0.10"
         },
         "click": {
             "hashes": [
@@ -252,30 +253,29 @@
         },
         "cryptography": {
             "hashes": [
-                "sha256:2049f8b87f449fc6190350de443ee0c1dd631f2ce4fa99efad2984de81031681",
-                "sha256:231c4a69b11f6af79c1495a0e5a85909686ea8db946935224b7825cfb53827ed",
-                "sha256:24469d9d33217ffd0ce4582dfcf2a76671af115663a95328f63c99ec7ece61a4",
-                "sha256:2deab5ec05d83ddcf9b0916319674d3dae88b0e7ee18f8962642d3cde0496568",
-                "sha256:494106e9cd945c2cadfce5374fa44c94cfadf01d4566a3b13bb487d2e6c7959e",
-                "sha256:4c702855cd3174666ef0d2d13dcc879090aa9c6c38f5578896407a7028f75b9f",
-                "sha256:52f769ecb4ef39865719aedc67b4b7eae167bafa48dbc2a26dd36fa56460507f",
-                "sha256:5c49c9e8fb26a567a2b3fa0343c89f5d325447956cc2fc7231c943b29a973712",
-                "sha256:684993ff6f67000a56454b41bdc7e015429732d65a52d06385b6e9de6181c71e",
-                "sha256:6fbbbb8aab4053fa018984bb0e95a16faeb051dd8cca15add2a27e267ba02b58",
-                "sha256:8982c19bb90a4fa2aad3d635c6d71814e38b643649b4000a8419f8691f20ac44",
-                "sha256:9511416e85e449fe1de73f7f99b21b3aa04fba4c4d335d30c486ba3756e3a2a6",
-                "sha256:97199a13b772e74cdcdb03760c32109c808aff7cd49c29e9cf4b7754bb725d1d",
-                "sha256:a776bae1629c8d7198396fd93ec0265f8dd2341c553dc32b976168aaf0e6a636",
-                "sha256:aa94d617a4cd4cdf4af9b5af65100c036bce22280ebb15d8b5262e8273ebc6ba",
-                "sha256:b17d83b3d1610e571fedac21b2eb36b816654d6f7496004d6a0d32f99d1d8120",
-                "sha256:d73e3a96c38173e0aa5646c31bf8473bc3564837977dd480f5cbeacf1d7ef3a3",
-                "sha256:d91bc9f535599bed58f6d2e21a2724cb0c3895bf41c6403fe881391d29096f1d",
-                "sha256:ef216d13ac8d24d9cd851776662f75f8d29c9f2d05cdcc2d34a18d32463a9b0b",
-                "sha256:f6a5a85beb33e57998dc605b9dbe7deaa806385fdf5c4810fb849fcd04640c81",
-                "sha256:f92556f94e476c1b616e6daec5f7ddded2c082efa7cee7f31c7aeda615906ed8"
+                "sha256:0a817b961b46894c5ca8a66b599c745b9a3d9f822725221f0e0fe49dc043a3a3",
+                "sha256:2d87cdcb378d3cfed944dac30596da1968f88fb96d7fc34fdae30a99054b2e31",
+                "sha256:30ee1eb3ebe1644d1c3f183d115a8c04e4e603ed6ce8e394ed39eea4a98469ac",
+                "sha256:391432971a66cfaf94b21c24ab465a4cc3e8bf4a939c1ca5c3e3a6e0abebdbcf",
+                "sha256:39bdf8e70eee6b1c7b289ec6e5d84d49a6bfa11f8b8646b5b3dfe41219153316",
+                "sha256:4caa4b893d8fad33cf1964d3e51842cd78ba87401ab1d2e44556826df849a8ca",
+                "sha256:53e5c1dc3d7a953de055d77bef2ff607ceef7a2aac0353b5d630ab67f7423638",
+                "sha256:596f3cd67e1b950bc372c33f1a28a0692080625592ea6392987dba7f09f17a94",
+                "sha256:5d59a9d55027a8b88fd9fd2826c4392bd487d74bf628bb9d39beecc62a644c12",
+                "sha256:6c0c021f35b421ebf5976abf2daacc47e235f8b6082d3396a2fe3ccd537ab173",
+                "sha256:73bc2d3f2444bcfeac67dd130ff2ea598ea5f20b40e36d19821b4df8c9c5037b",
+                "sha256:74d6c7e80609c0f4c2434b97b80c7f8fdfaa072ca4baab7e239a15d6d70ed73a",
+                "sha256:7be0eec337359c155df191d6ae00a5e8bbb63933883f4f5dffc439dac5348c3f",
+                "sha256:94ae132f0e40fe48f310bba63f477f14a43116f05ddb69d6fa31e93f05848ae2",
+                "sha256:bb5829d027ff82aa872d76158919045a7c1e91fbf241aec32cb07956e9ebd3c9",
+                "sha256:ca238ceb7ba0bdf6ce88c1b74a87bffcee5afbfa1e41e173b1ceb095b39add46",
+                "sha256:ca28641954f767f9822c24e927ad894d45d5a1e501767599647259cbf030b903",
+                "sha256:e0344c14c9cb89e76eb6a060e67980c9e35b3f36691e15e1b7a9e58a0a6c6dc3",
+                "sha256:ebc15b1c22e55c4d5566e3ca4db8689470a0ca2babef8e3a9ee057a8b82ce4b1",
+                "sha256:ec63da4e7e4a5f924b90af42eddf20b698a70e58d86a72d943857c4c6045b3ee"
             ],
             "markers": "python_full_version >= '3.6.0'",
-            "version": "==36.0.0"
+            "version": "==36.0.1"
         },
         "dnspython": {
             "hashes": [
@@ -295,11 +295,11 @@
         },
         "docutils": {
             "hashes": [
-                "sha256:6c9a32514c7aea91b507093d695e4fefcd68112237155ac8ab039962c6bc88bb",
-                "sha256:803900c9fb1ab4a0ec549a51ac3949f545497cec0b40805ba702bc1986e1fe1b"
+                "sha256:23010f129180089fbcd3bc08cfefccb3b890b0050e1ca00c867036e9d161b98c",
+                "sha256:679987caf361a7539d76e584cbeddc311e3aee937877c87346f31debc63e9d06"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==0.18.1b0"
+            "version": "==0.18.1"
         },
         "email-validator": {
             "hashes": [
@@ -325,11 +325,11 @@
         },
         "getmac": {
             "hashes": [
-                "sha256:2e4aef2dd6c3befccd7cf9e18badddd24ab1992b928e2e811d415ed47137c547",
-                "sha256:d501d20b71856248cfa07a8758192e86a01077910afb8b659a89946c4d52d368"
+                "sha256:6e38f9023b9792f53ef982cce6be65d84fea656be87100ab2f2d0376563af486",
+                "sha256:95f5cbdf521a1045e3073f546a523d2adb2933f2ce647450c0a4b5c358ca85ca"
             ],
             "index": "pypi",
-            "version": "==0.8.2"
+            "version": "==0.8.3"
         },
         "gitdb": {
             "hashes": [
@@ -341,22 +341,22 @@
         },
         "gitpython": {
             "hashes": [
-                "sha256:dc0a7f2f697657acc8d7f89033e8b1ea94dd90356b2983bca89dc8d2ab3cc647",
-                "sha256:df83fdf5e684fef7c6ee2c02fc68a5ceb7e7e759d08b694088d0cacb4eba59e5"
+                "sha256:26ac35c212d1f7b16036361ca5cff3ec66e11753a0d677fb6c48fa4e1a9dd8d6",
+                "sha256:fc8868f63a2e6d268fb25f481995ba185a85a66fcad126f039323ff6635669ee"
             ],
             "index": "pypi",
-            "version": "==3.1.24"
+            "version": "==3.1.26"
         },
         "google-api-core": {
             "extras": [
                 "grpc"
             ],
             "hashes": [
-                "sha256:c77ffc8b4981b44efdb9d68431fd96d21dbd39545c29552bbe79b9b7dd2c3689",
-                "sha256:ed59c6a695a81f601e4ba0f37ca9dbde3c43b3309e161a1a8946f266db4a0c4e"
+                "sha256:6815207a8b422e9da42c200681603f304b25f98c98b675a9db9fdc3717e44280",
+                "sha256:85d2074f2c8f9c07e614d7f978767d71ceb7d40647814ef4236d3a0ef671ee75"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
-            "version": "==1.31.4"
+            "version": "==1.31.5"
         },
         "google-api-python-client": {
             "hashes": [
@@ -380,6 +380,14 @@
                 "sha256:a07c39fd632becacd3f07718dfd6021bf396978f03ad3ce4321d060015cc30ac"
             ],
             "version": "==0.1.0"
+        },
+        "google-cloud-container": {
+            "hashes": [
+                "sha256:500f51e2d4e4bc36153a758a6bfdaf6e1d10b8216fddac572c7bb25ff27bd41b",
+                "sha256:939970cd09384dde6d6f6758b03648fd8f52fe5c2f83f73300575f7e4e3b2ee0"
+            ],
+            "index": "pypi",
+            "version": "==2.10.1"
         },
         "google-cloud-core": {
             "hashes": [
@@ -467,11 +475,11 @@
                 "grpc"
             ],
             "hashes": [
-                "sha256:a88ee8903aa0a81f6c3cec2d5cf62d3c8aa67c06439b0496b49048fb1854ebf4",
-                "sha256:f6d561ab8fb16b30020b940e2dd01cd80082f4762fa9f3ee670f4419b4b8dbd0"
+                "sha256:a4031d6ec6c2b1b6dc3e0be7e10a1bd72fb0b18b07ef9be7b51f2c1004ce2437",
+                "sha256:e54345a2add15dc5e1a7891c27731ff347b4c33765d79b5ed7026a6c0c7cbcae"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==1.53.0"
+            "version": "==1.54.0"
         },
         "grpc-google-iam-v1": {
             "hashes": [
@@ -481,52 +489,52 @@
         },
         "grpcio": {
             "hashes": [
-                "sha256:0209f30741de1875413f40e89bec9c647e7afad4a3549a6a1682c1ee23da68ca",
-                "sha256:06d5364e85e0fa50ee68bffd9c93a6aff869a91c68f1fd7ba1b944e063a0ff9f",
-                "sha256:17433f7eb01737240581b33fbc2eae7b7fa6d3429571782580bceaf05ec56cb8",
-                "sha256:21aa4a111b3381d3dd982a3df62348713b29f651aa9f6dfbc9415adbfe28d2ba",
-                "sha256:2956da789d74fc35d2c869b3aa45dbf41c5d862c056ca8b5e35a688347ede809",
-                "sha256:29fc36c99161ff307c8ca438346b2e36f81dac5ecdbabc983d0b255d7913fb19",
-                "sha256:2aba7f93671ec971c5c70db81633b49a2f974aa09a2d811aede344a32bad1896",
-                "sha256:2b264cf303a22c46f8d455f42425c546ad6ce22f183debb8d64226ddf1e039f4",
-                "sha256:3a13953e12dc40ee247b5fe6ef22b5fac8f040a76b814a11bf9f423e82402f28",
-                "sha256:47ab65be9ba7a0beee94bbe2fb1dd03cb7832db9df4d1f8fae215a16b3edeb5e",
-                "sha256:4a8f2c7490fe3696e0cdd566e2f099fb91b51bc75446125175c55581c2f7bc11",
-                "sha256:53e10d07e541073eb9a84d49ecffb831c3cbb970bcd8cd8de8431e935bf66c2e",
-                "sha256:5441d343602ce10ba48fcb36bb5de197a15a01dc9ee0f71c2a73cd5cd3d7f5ac",
-                "sha256:59163b8d2e0d85f0ecbee52b348f867eec7e0f909177564fb3956363f7e616e5",
-                "sha256:5b9f0c4822e3a52a1663a315752c6bbdbed0ec15a660d3e64137335acbb5b7ce",
-                "sha256:603d71de14ab1f1fd1254b69ceda73545943461b1f51f82fda9477503330b6ea",
-                "sha256:64f2b3e6474e2ad865478b64f0850d15842acbb2623de5f78a60ceabe00c63e0",
-                "sha256:65720d2bf05e2b78c4bffe372f13c41845bae5658fd3f5dd300c374dd240e5cb",
-                "sha256:6655df5f31664bac4cd6c9b52f389fd92cd10025504ad83685038f47e11e29d8",
-                "sha256:66f910b6324ae69625e63db2eb29d833c307cfa36736fe13d2f841656c5f658f",
-                "sha256:6b69726d7bbb633133c1b0d780b1357aa9b7a7f714fead6470bab1feb8012806",
-                "sha256:6e5eec67909795f7b1ff2bd941bd6c2661ca5217ea9c35003d73314100786f60",
-                "sha256:6ef72f0abdb89fb7c366a99e04823ecae5cda9f762f2234f42fc280447277cd6",
-                "sha256:76b5fa4c6d88f804456e763461cf7a1db38b200669f1ba00c579014ab5aa7965",
-                "sha256:7742606ac2bc03ed10360f4f630e0cc01dce864fe63557254e9adea21bb51416",
-                "sha256:7a3c9b8e13365529f9426d4754085e8a9c2ad718a41a46a97e4e30e87bb45eae",
-                "sha256:8e8cd9909fdd232ecffb954936fd90c935ebe0b5fce36c88813f8247ce54019c",
-                "sha256:a6f9ed5320b93c029615b75f6c8caf2c76aa6545d8845f3813908892cfc5f84e",
-                "sha256:b4d7115ee08a36f3f50a6233bd78280e40847e078d2a5bb39c0ab0db4490d58f",
-                "sha256:b74bbac7e039cf23ed0c8edd820c31e90a52a22e28a03d45274a0956addde8d2",
-                "sha256:b781f412546830be55644f7c48251d30860f4725981862d4a1ea322f80d9cd34",
-                "sha256:bf916ee93ea2fd52b5286ed4e19cbbde5e82754914379ea91dc5748550df3b4e",
-                "sha256:d08ce780bbd8d1a442d855bd681ed0f7483c65d2c8ed83701a9ea4f13678411f",
-                "sha256:d1451a8c0c01c5b5fdfeb8f777820cb277fb5d797d972f57a41bb82483c44a79",
-                "sha256:d58b3774ee2084c31aad140586a42e18328d9823959ca006a0b85ad7937fe405",
-                "sha256:d6c0b159b38fcc3bbc3331105197c1f58ac0d294eb83910d136a325a85def88f",
-                "sha256:d7f66eb220898787d7821a7931e35ae2512ed74f79f75adcd7ea2fb3119ca87d",
-                "sha256:d92c1721c7981812d0f42dfc8248b15d3b6a2ea79eb8870776364423de2aa245",
-                "sha256:e2d9c6690d4c88cd51ee395d7ba5bd1d26d7c37e94cb59e7fd62ff21ecaf891d",
-                "sha256:e62140c46d8125927c673c72c960cb387c02b2a1a3c6985a8b0a3914d27c0018",
-                "sha256:ea3560ffbfe08327024380508190103937fef25e355d2259f8b5c003a0732f55",
-                "sha256:f2e3f250e5398bf474c6e140df1b67494bf1e31c5277b5bf93841a564cbc22d0",
-                "sha256:f385e40846ff81d1c6dce98dcc192c7988a46540758804c4a2e6da5a0e3e3e05",
-                "sha256:f721b42a20d886c03d9b1f461b228cdaf02ccf6c4550e263f7fd3ce3ff19a8f1"
+                "sha256:0110310eff07bb69782f53b7a947490268c4645de559034c43c0a635612e250f",
+                "sha256:01f4b887ed703fe82ebe613e1d2dadea517891725e17e7a6134dcd00352bd28c",
+                "sha256:04239e8f71db832c26bbbedb4537b37550a39d77681d748ab4678e58dd6455d6",
+                "sha256:08cf25f2936629db062aeddbb594bd76b3383ab0ede75ef0461a3b0bc3a2c150",
+                "sha256:0aa8285f284338eb68962fe1a830291db06f366ea12f213399b520c062b01f65",
+                "sha256:0e731f660e1e68238f56f4ce11156f02fd06dc58bc7834778d42c0081d4ef5ad",
+                "sha256:0edbfeb6729aa9da33ce7e28fb7703b3754934115454ae45e8cc1db601756fd3",
+                "sha256:124e718faf96fe44c98b05f3f475076be8b5198bb4c52a13208acf88a8548ba9",
+                "sha256:138f57e3445d4a48d9a8a5af1538fdaafaa50a0a3c243f281d8df0edf221dc02",
+                "sha256:17b75f220ee6923338155b4fcef4c38802b9a57bc57d112c9599a13a03e99f8d",
+                "sha256:1898f999383baac5fcdbdef8ea5b1ef204f38dc211014eb6977ac6e55944d738",
+                "sha256:1f16725a320460435a8a5339d8b06c4e00d307ab5ad56746af2e22b5f9c50932",
+                "sha256:2f96142d0abc91290a63ba203f01649e498302b1b6007c67bad17f823ecde0cf",
+                "sha256:31e6e489ccd8f08884b9349a39610982df48535881ec34f05a11c6e6b6ebf9d0",
+                "sha256:45401d00f2ee46bde75618bf33e9df960daa7980e6e0e7328047191918c98504",
+                "sha256:47b6821238d8978014d23b1132713dac6c2d72cbb561cf257608b1673894f90a",
+                "sha256:4b4a7152187a49767a47d1413edde2304c96f41f7bc92cc512e230dfd0fba095",
+                "sha256:50cfb7e1067ee5e00b8ab100a6b7ea322d37ec6672c0455106520b5891c4b5f5",
+                "sha256:5449ae564349e7a738b8c38583c0aad954b0d5d1dd3cea68953bfc32eaee11e3",
+                "sha256:577e024c8dd5f27cd98ba850bc4e890f07d4b5942e5bc059a3d88843a2f48f66",
+                "sha256:57f1aeb65ed17dfb2f6cd717cc109910fe395133af7257a9c729c0b9604eac10",
+                "sha256:594aaa0469f4fca7773e80d8c27bf1298e7bbce5f6da0f084b07489a708f16ab",
+                "sha256:6620a5b751b099b3b25553cfc03dfcd873cda06f9bb2ff7e9948ac7090e20f05",
+                "sha256:6e463b4aa0a6b31cf2e57c4abc1a1b53531a18a570baeed39d8d7b65deb16b7e",
+                "sha256:735d9a437c262ab039d02defddcb9f8f545d7009ae61c0114e19dda3843febe5",
+                "sha256:772b943f34374744f70236bbbe0afe413ed80f9ae6303503f85e2b421d4bca92",
+                "sha256:77ef653f966934b3bfdd00e4f2064b68880eb40cf09b0b99edfa5ee22a44f559",
+                "sha256:80398e9fb598060fa41050d1220f5a2440fe74ff082c36dda41ac3215ebb5ddd",
+                "sha256:8b2b9dc4d7897566723b77422e11c009a0ebd397966b165b21b89a62891a9fdf",
+                "sha256:a4b4543e13acb4806917d883d0f70f21ba93b29672ea81f4aaba14821aaf9bb0",
+                "sha256:a4e786a8ee8b30b25d70ee52cda6d1dbba2a8ca2f1208d8e20ed8280774f15c8",
+                "sha256:ade8b79a6b6aea68adb9d4bfeba5d647667d842202c5d8f3ba37ac1dc8e5c09c",
+                "sha256:af78ac55933811e6a25141336b1f2d5e0659c2f568d44d20539b273792563ca7",
+                "sha256:af9c3742f6c13575c0d4147a8454da0ff5308c4d9469462ff18402c6416942fe",
+                "sha256:b8cc936a29c65ab39714e1ba67a694c41218f98b6e2a64efb83f04d9abc4386b",
+                "sha256:bdf41550815a831384d21a498b20597417fd31bd084deb17d31ceb39ad9acc79",
+                "sha256:c354017819201053d65212befd1dcb65c2d91b704d8977e696bae79c47cd2f82",
+                "sha256:c36f418c925a41fccada8f7ae9a3d3e227bfa837ddbfddd3d8b0ac252d12dda9",
+                "sha256:cbc9b83211d905859dcf234ad39d7193ff0f05bfc3269c364fb0d114ee71de59",
+                "sha256:e95b5d62ec26d0cd0b90c202d73e7cb927c369c3358e027225239a4e354967dc",
+                "sha256:f11d05402e0ac3a284443d8a432d3dfc76a6bd3f7b5858cddd75617af2d7bd9b",
+                "sha256:fa26a8bbb3fe57845acb1329ff700d5c7eaf06414c3e15f4cb8923f3a466ef64",
+                "sha256:fb7229fa2a201a0c377ff3283174ec966da8f9fd7ffcc9a92f162d2e7fc9025b",
+                "sha256:fdac966699707b5554b815acc272d81e619dd0999f187cd52a61aef075f870ee"
             ],
-            "version": "==1.42.0"
+            "version": "==1.43.0"
         },
         "httplib2": {
             "hashes": [
@@ -546,26 +554,18 @@
         },
         "importlib-metadata": {
             "hashes": [
-                "sha256:53ccfd5c134223e497627b9815d5030edf77d2ed573922f7a0b8f8bb81a1c100",
-                "sha256:75bdec14c397f528724c1bfd9709d660b33a4d2e77387a3358f20b848bb5e5fb"
+                "sha256:92a8b58ce734b2a4494878e0ecf7d79ccd7a128b5fc6014c401e0b61f006f0f6",
+                "sha256:b7cf7d3fef75f1e4c80a96ca660efbd51473d7e8f39b5ab9210febc7809012a4"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==4.8.2"
+            "markers": "python_version >= '3.7'",
+            "version": "==4.10.0"
         },
         "isodate": {
             "hashes": [
-                "sha256:2e364a3d5759479cdb2d37cce6b9376ea504db2ff90252a2e5b7cc89cc9ff2d8",
-                "sha256:aa4d33c06640f5352aca96e4b81afd8ab3b47337cc12089822d6f322ac772c81"
+                "sha256:0751eece944162659049d35f4f549ed815792b38793f07cf73381c1c87cbed96",
+                "sha256:48c5881de7e8b0a0d648cb024c8062dc84e7b840ed81e864c7614fd3c127bde9"
             ],
-            "version": "==0.6.0"
-        },
-        "jeepney": {
-            "hashes": [
-                "sha256:1b5a0ea5c0e7b166b2f5895b91a08c14de8915afda4407fb5022a195224958ac",
-                "sha256:fa9e232dfa0c498bd0b8a3a73b8d8a31978304dcef0515adc859d4e096f96f4f"
-            ],
-            "markers": "sys_platform == 'linux'",
-            "version": "==0.7.1"
+            "version": "==0.6.1"
         },
         "jmespath": {
             "hashes": [
@@ -577,11 +577,11 @@
         },
         "keyring": {
             "hashes": [
-                "sha256:6334aee6073db2fb1f30892697b1730105b5e9a77ce7e61fca6b435225493efe",
-                "sha256:bd2145a237ed70c8ce72978b497619ddfcae640b6dcf494402d5143e37755c6e"
+                "sha256:9012508e141a80bd1c0b6778d5c610dd9f8c464d75ac6774248500503f972fb9",
+                "sha256:b0d28928ac3ec8e42ef4cc227822647a19f1d544f21f96457965dc01cf555261"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==23.2.1"
+            "markers": "python_version >= '3.7'",
+            "version": "==23.5.0"
         },
         "kubernetes": {
             "hashes": [
@@ -599,11 +599,11 @@
         },
         "libcst": {
             "hashes": [
-                "sha256:0dcfc4c050ec4474f3406e4f92862678eeca97a9a2ad62261ade01c1438bd7ce",
-                "sha256:a277b1f240d41d564bda4f1d6a36682435e7bb17bf903567279ef255b0c89bc7"
+                "sha256:2e1f77fbaaff93b889376c92f588b718edbdc21f956abbe27d10dfd1ff2d76c3",
+                "sha256:330f9082a309bad808e283e80845a843200303bb256690185b98ca458a62c4f8"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==0.3.22"
+            "version": "==0.3.23"
         },
         "msal": {
             "hashes": [
@@ -614,10 +614,10 @@
         },
         "msal-extensions": {
             "hashes": [
-                "sha256:5523dfa15da88297e90d2e73486c8ef875a17f61ea7b7e2953a300432c2e7861",
-                "sha256:a530c2d620061822f2ced8e29da301bc928b146970df635c852907423e8ddddc"
+                "sha256:89df9c0237e1adf16938fa58575db59c2bb9de04a83ffb0452c8dfc79031f717",
+                "sha256:d9029af70f2cbdc5ad7ecfed61cb432ebe900484843ccf72825445dbfe62d311"
             ],
-            "version": "==0.3.0"
+            "version": "==0.3.1"
         },
         "msrest": {
             "hashes": [
@@ -635,73 +635,80 @@
         },
         "mypy-boto3-autoscaling": {
             "hashes": [
-                "sha256:63babec396e6d7d821a7537748580254ee11af4e49b4b2b2c6b2e8e52ca967e6",
-                "sha256:bd54230521676ed736264ff9f782016b8617453f121c755cc4b26befe5648b47"
+                "sha256:470d51985240c9ccb5f7899c1913a84cc6496e03e6caf88505d46fb75a37b7ef",
+                "sha256:fdc67f00f8b55c307d3184288d5fa3ef6cdc05a020a78ff3b9e85f5f2a566ed1"
             ],
-            "version": "==1.20.1"
+            "version": "==1.20.14"
         },
         "mypy-boto3-cloudformation": {
             "hashes": [
-                "sha256:1dd812d3015a5b3f1f1e28b0addae32010e3febc9917de8eaa11f7fa629a4c76",
-                "sha256:4b5ff3795588bcd5479ef6167fcf33371a03f5d795bbe1e22487e89d4f2b1329"
+                "sha256:57052da7bf7e2eb966e4bda37be9828be7f11fdc67337bd59bbfb98d8e222319",
+                "sha256:763b2d69eda46ac05cd533efba26fc1854e627a1cb844bfd941d88201d325953"
             ],
-            "version": "==1.20.10"
+            "version": "==1.20.11"
         },
         "mypy-boto3-dynamodb": {
             "hashes": [
-                "sha256:3aa686949deb6254d3797d40ba5423a387f8aec7060b8cf542e2df2a2f4bd26d",
-                "sha256:f82e4a82ca6492e415d3c44103790bccf51c95804a44416feddd19baa1054a70"
+                "sha256:80b39a75b42937ed15ce6d333ede77f4b03273627b46999e6068383e7ae8b6dc",
+                "sha256:c01bf21384993adb7fdb57451826cbc6bee6c8602276295d9aee6d930f9e908a"
             ],
-            "version": "==1.20.4"
+            "version": "==1.20.18"
         },
         "mypy-boto3-ec2": {
             "hashes": [
-                "sha256:06855fc03bd8ea3d99e2b93e602796a429d697904fbf9afac2fd11452f5413f5",
-                "sha256:5286a0403557968474b9e14039ad05047764557f19555c23f4bb61f64e210019"
+                "sha256:c591060f17a2631e36ea487f4b9395509aef2d589d880d940e2cdcb08747fab3",
+                "sha256:ca33c24e1ad6cc1f06f86de0795bf7d79ff3951a5e83817500485ec4e8ddbe22"
             ],
-            "version": "==1.20.6"
+            "version": "==1.20.33"
+        },
+        "mypy-boto3-eks": {
+            "hashes": [
+                "sha256:2291f6a4236c37c8efa81ec8c42505a53c1bb100947fab9048b49fd5e9ed234c",
+                "sha256:e37063321c5694b668722464e0c4bbf5a20cd464a78568f3747bce6457c53e0b"
+            ],
+            "version": "==1.20.29"
         },
         "mypy-boto3-elbv2": {
             "hashes": [
-                "sha256:8bc79af33c569f64ad9588a0b1416b35a311a7e05a3fa7d89ac02a2bbf38cd11",
-                "sha256:b14dc362d845c2b4d4b2bdb4fa650f6cf4e31303657cea4ff6046492f582a3fa"
+                "sha256:35be9f8a27254d0bc512a2d5a6fb8d13a3abc9ec29a81104473f20a7f5432a3f",
+                "sha256:e8da09406091b20fca4c914aa891080367b57d11d4a0c6eb3e095fadee24193e"
             ],
-            "version": "==1.20.1"
+            "version": "==1.20.12"
         },
         "mypy-boto3-lambda": {
             "hashes": [
-                "sha256:a5d4586792400c6b9d0d0b82ff5f2b2eaccc148fe388c0ed51378e279ccffa1a",
-                "sha256:e64e7f9c727dca716713116d5c7f1c825c1964374d4e4eeea513beeddae73620"
+                "sha256:26513ac4bfe815ec1b05ab10ba10afe7c274397dcbadd4953a7e32a169503b35",
+                "sha256:8245c9ff98af11c58c713261049825c00a13648eeca00369ea80140b56e6ecba"
             ],
-            "version": "==1.20.10"
+            "version": "==1.20.13"
         },
         "mypy-boto3-logs": {
             "hashes": [
-                "sha256:11ad54e4b1daf63334c8006e2fe3749e142580f7a47701758f11372da4c15341",
-                "sha256:e2cb94da2c228c96577dd92e49a363fd4dc761f8a615516ae1960f113a48715f"
+                "sha256:3babd25794cc23af0840a78058d2cbbb0505b9c69dc0d19133352650d4ef729c",
+                "sha256:900214d741383a33a6edf04e0a2f9983bbd0f1cae245aa14bc8a7765764c49ed"
             ],
-            "version": "==1.20.1"
+            "version": "==1.20.22"
         },
         "mypy-boto3-rds": {
             "hashes": [
-                "sha256:b471c03bc5f8ee6adbd4c7ee0404dee2001994f1d28eb514264e2ce25afd6588",
-                "sha256:d6c10fa2a91399b9d1841f15598942df1d6aab6921186c1166540e80897d3fb7"
+                "sha256:2521d5d7256c9f89ebcfcdaea4a513ea640451b9cc22873256238dd65baae6ef",
+                "sha256:68ec3ac89f3009cb741db29133b93514414206edb198194f3e064a650b5bece1"
             ],
-            "version": "==1.20.1"
+            "version": "==1.20.33"
         },
         "mypy-boto3-route53": {
             "hashes": [
-                "sha256:20a968db08a4baed6ef47e7b978e3dec7c164dc162cd16c09e16d82314009206",
-                "sha256:931a1da8c25d83260f690648d11351207d39657993bce9537ade04dad1f79622"
+                "sha256:0bd644235c7f808e08fffed88eb965025f4bed89a53689906f930e9752eceeb3",
+                "sha256:b0c260be2c8a8d72b17c753e518b8a44f1cb85e9feea2a2dce5bbedf8b6348f9"
             ],
-            "version": "==1.20.1"
+            "version": "==1.20.21"
         },
         "mypy-boto3-s3": {
             "hashes": [
-                "sha256:44276f3efb51c5299652882b348df28da376667303fedfd49d40fca0b9146d9d",
-                "sha256:4675a50e25e8974ef8822920f22e38f6bc7810d1bb01cee4cfd94c8b5dab92ec"
+                "sha256:85ac23d06f9d0d794f60041b4c4f271d2bb8f5a83375c963e4a9e73e51ba9ca5",
+                "sha256:aa68c9740b79932d47ce20db6e5470a03f51be252360a49a6fed6beec5d71484"
             ],
-            "version": "==1.20.1"
+            "version": "==1.20.28"
         },
         "mypy-boto3-sesv2": {
             "hashes": [
@@ -712,17 +719,17 @@
         },
         "mypy-boto3-sqs": {
             "hashes": [
-                "sha256:b1113241704a1015c63add947654571a8b67ade7895fd11a79282b9a1d65b5bc",
-                "sha256:b12c71cbad7976aa83dcb2c41c227dc5b520555bf2022c825044568be3e45f82"
+                "sha256:0956b4fdc56f58a1666fb540a6c921e433d4d88b91914d1c73812985ea60a21d",
+                "sha256:1c284553d0269b4379a6e9e18ff86e7dc8798c9b5a78db667ae78591779ffeb4"
             ],
-            "version": "==1.20.1"
+            "version": "==1.20.12"
         },
         "mypy-boto3-ssm": {
             "hashes": [
-                "sha256:9903d65fcbe59db9b393fa3aa1801583dbe4421d571a35d13297fd5a19467e1c",
-                "sha256:f0b186a5dff17a0d225d78ea5fcf7d840b2235f95b0e0188f9ffb5bbc3bd3b60"
+                "sha256:14c8e8da6eb4fccd609cc3dbcc3a52cbd7b986ed1ecce15829fbae76c9c7150b",
+                "sha256:1f14fb62988a5dd3a4fed8110c240a14220d807565c9e58f47515849f2c639c2"
             ],
-            "version": "==1.20.6"
+            "version": "==1.20.16"
         },
         "mypy-extensions": {
             "hashes": [
@@ -773,26 +780,26 @@
         },
         "pick": {
             "hashes": [
-                "sha256:03f13d4f5bfe74db4b969fb74c0ef110ec443978419d6c0f1f375a0d49539034",
-                "sha256:f32c8bd0fd943490c29e461a8168f4ac267247aaa6a7fc9dd327f97832842b5f"
+                "sha256:594f96c205d75bff889f4cee40d87fe50d2a477ff937c9cf6b3a9d4feb44e7f8",
+                "sha256:faffd2ba4c5409d22cad366b4e8892fd26ebedcd4d3fd5e98562914279208da7"
             ],
             "index": "pypi",
-            "version": "==1.0.0"
+            "version": "==1.2.0"
         },
         "pkginfo": {
             "hashes": [
-                "sha256:65175ffa2c807220673a41c371573ac9a1ea1b19ffd5eef916278f428319934f",
-                "sha256:bb55a6c017d50f2faea5153abc7b05a750e7ea7ae2cbb7fb3ad6f1dcf8d40988"
+                "sha256:542e0d0b6750e2e21c20179803e40ab50598d8066d51097a0e382cba9eb02bff",
+                "sha256:c24c487c6a7f72c66e816ab1796b96ac6c3d14d49338293d2141664330b55ffc"
             ],
-            "version": "==1.8.1"
+            "version": "==1.8.2"
         },
         "portalocker": {
             "hashes": [
-                "sha256:34cb36c618d88bcd9079beb36dcdc1848a3e3d92ac4eac59055bdeafc39f9d4a",
-                "sha256:6d6f5de5a3e68c4dd65a98ec1babb26d28ccc5e770e07b672d65d5a35e4b2d8a"
+                "sha256:75cfe02f702737f1726d83e04eedfa0bda2cc5b974b1ceafb8d6b42377efbd5f",
+                "sha256:d8c9f7c542e768dbef006a3e49875046ca170d2d41ca712080719110bd066cc4"
             ],
-            "markers": "platform_system != 'Windows'",
-            "version": "==1.7.1"
+            "markers": "python_version >= '3.5' and platform_system != 'Windows'",
+            "version": "==2.3.2"
         },
         "prompt-toolkit": {
             "hashes": [
@@ -812,67 +819,73 @@
         },
         "protobuf": {
             "hashes": [
-                "sha256:038daf4fa38a7e818dd61f51f22588d61755160a98db087a046f80d66b855942",
-                "sha256:28ccea56d4dc38d35cd70c43c2da2f40ac0be0a355ef882242e8586c6d66666f",
-                "sha256:36d90676d6f426718463fe382ec6274909337ca6319d375eebd2044e6c6ac560",
-                "sha256:3cd0458870ea7d1c58e948ac8078f6ba8a7ecc44a57e03032ed066c5bb318089",
-                "sha256:5935c8ce02e3d89c7900140a8a42b35bc037ec07a6aeb61cc108be8d3c9438a6",
-                "sha256:615b426a177780ce381ecd212edc1e0f70db8557ed72560b82096bd36b01bc04",
-                "sha256:62a8e4baa9cb9e064eb62d1002eca820857ab2138440cb4b3ea4243830f94ca7",
-                "sha256:655264ed0d0efe47a523e2255fc1106a22f6faab7cc46cfe99b5bae085c2a13e",
-                "sha256:6e8ea9173403219239cdfd8d946ed101f2ab6ecc025b0fda0c6c713c35c9981d",
-                "sha256:71b0250b0cfb738442d60cab68abc166de43411f2a4f791d31378590bfb71bd7",
-                "sha256:74f33edeb4f3b7ed13d567881da8e5a92a72b36495d57d696c2ea1ae0cfee80c",
-                "sha256:77d2fadcf369b3f22859ab25bd12bb8e98fb11e05d9ff9b7cd45b711c719c002",
-                "sha256:8b30a7de128c46b5ecb343917d9fa737612a6e8280f440874e5cc2ba0d79b8f6",
-                "sha256:8e51561d72efd5bd5c91490af1f13e32bcba8dab4643761eb7de3ce18e64a853",
-                "sha256:a529e7df52204565bcd33738a7a5f288f3d2d37d86caa5d78c458fa5fabbd54d",
-                "sha256:b691d996c6d0984947c4cf8b7ae2fe372d99b32821d0584f0b90277aa36982d3",
-                "sha256:d80f80eb175bf5f1169139c2e0c5ada98b1c098e2b3c3736667f28cbbea39fc8",
-                "sha256:d83e1ef8cb74009bebee3e61cc84b1c9cd04935b72bca0cbc83217d140424995",
-                "sha256:d8919368410110633717c406ab5c97e8df5ce93020cfcf3012834f28b1fab1ea",
-                "sha256:db3532d9f7a6ebbe2392041350437953b6d7a792de10e629c1e4f5a6b1fe1ac6",
-                "sha256:e7b24c11df36ee8e0c085e5b0dc560289e4b58804746fb487287dda51410f1e2",
-                "sha256:e7e8d2c20921f8da0dea277dfefc6abac05903ceac8e72839b2da519db69206b",
-                "sha256:e813b1c9006b6399308e917ac5d298f345d95bb31f46f02b60cd92970a9afa17",
-                "sha256:fd390367fc211cc0ffcf3a9e149dfeca78fecc62adb911371db0cec5c8b7472d"
+                "sha256:1291a0a7db7d792745c99d4657b4c5c4942695c8b1ac1bfb993a34035ec123f7",
+                "sha256:18c40a1b8721026a85187640f1786d52407dc9c1ba8ec38accb57a46e84015f6",
+                "sha256:1cb2ed66aac593adbf6dca4f07cd7ee7e2958b17bbc85b2cc8bc564ebeb258ec",
+                "sha256:2acd7ca329be544d1a603d5f13a4e34a3791c90d651ebaf130ba2e43ae5397c6",
+                "sha256:2cddcbcc222f3144765ccccdb35d3621dc1544da57a9aca7e1944c1a4fe3db11",
+                "sha256:397d82f1c58b76445469c8c06b8dee1ff67b3053639d054f52599a458fac9bc6",
+                "sha256:3bf3a07d17ba3511fe5fa916afb7351f482ab5dbab5afe71a7a384274a2cd550",
+                "sha256:3f80a3491eaca767cdd86cb8660dc778f634b44abdb0dffc9b2a8e8d0cd617d0",
+                "sha256:49677e5e9c7ea1245a90c2e8a00d304598f22ea3aa0628f0e0a530a9e70665fa",
+                "sha256:544fe9705189b249380fae07952d220c97f5c6c9372a6f936cc83a79601dcb70",
+                "sha256:6202df8ee8457cb00810c6e76ced480f22a1e4e02c899a14e7b6e6e1de09f938",
+                "sha256:84bf3aa3efb00dbe1c7ed55da0f20800b0662541e582d7e62b3e1464d61ed365",
+                "sha256:898bda9cd37ec0c781b598891e86435de80c3bfa53eb483a9dac5a11ec93e942",
+                "sha256:8ad761ef3be34c8bdc7285bec4b40372a8dad9e70cfbdc1793cd3cf4c1a4ce74",
+                "sha256:8ceaf5fdb72c8e1fcb7be9f2b3b07482ce058a3548180c0bdd5c7e4ac5e14165",
+                "sha256:a9401d96552befcc7311f5ef8f0fa7dba0ef5fd805466b158b141606cd0ab6a8",
+                "sha256:af7238849fa79285d448a24db686517570099739527a03c9c2971cce99cc5ae2",
+                "sha256:afa8122de8064fd577f49ae9eef433561c8ace97a0a7b969d56e8b1d39b5d177",
+                "sha256:b53519b2ebec70cfe24b4ddda21e9843f0918d7c3627a785393fb35d402ab8ad",
+                "sha256:c781402ed5396ab56358d7b866d78c03a77cbc26ba0598d8bb0ac32084b1a257",
+                "sha256:d975a6314fbf5c524d4981e24294739216b5fb81ef3c14b86fb4b045d6690907",
+                "sha256:df2ba379ee42427e8fcc6a0a76843bff6efb34ef5266b17f95043939b5e25b69",
+                "sha256:e54b8650e849ee8e95e481024bff92cf98f5ec61c7650cb838d928a140adcb63",
+                "sha256:e765e6dfbbb02c55e4d6d1145743401a84fc0b508f5a81b2c5a738cf86353139",
+                "sha256:ef02d112c025e83db5d1188a847e358beab3e4bbfbbaf10eaf69e67359af51b2",
+                "sha256:f6d4b5b7595a57e69eb7314c67bef4a3c745b4caf91accaf72913d8e0635111b"
             ],
             "markers": "python_version >= '3.1'",
-            "version": "==3.19.1"
+            "version": "==3.19.3"
         },
         "psutil": {
             "hashes": [
-                "sha256:0066a82f7b1b37d334e68697faba68e5ad5e858279fd6351c8ca6024e8d6ba64",
-                "sha256:02b8292609b1f7fcb34173b25e48d0da8667bc85f81d7476584d889c6e0f2131",
-                "sha256:0ae6f386d8d297177fd288be6e8d1afc05966878704dad9847719650e44fc49c",
-                "sha256:0c9ccb99ab76025f2f0bbecf341d4656e9c1351db8cc8a03ccd62e318ab4b5c6",
-                "sha256:0dd4465a039d343925cdc29023bb6960ccf4e74a65ad53e768403746a9207023",
-                "sha256:12d844996d6c2b1d3881cfa6fa201fd635971869a9da945cf6756105af73d2df",
-                "sha256:1bff0d07e76114ec24ee32e7f7f8d0c4b0514b3fae93e3d2aaafd65d22502394",
-                "sha256:245b5509968ac0bd179287d91210cd3f37add77dad385ef238b275bad35fa1c4",
-                "sha256:28ff7c95293ae74bf1ca1a79e8805fcde005c18a122ca983abf676ea3466362b",
-                "sha256:36b3b6c9e2a34b7d7fbae330a85bf72c30b1c827a4366a07443fc4b6270449e2",
-                "sha256:52de075468cd394ac98c66f9ca33b2f54ae1d9bff1ef6b67a212ee8f639ec06d",
-                "sha256:5da29e394bdedd9144c7331192e20c1f79283fb03b06e6abd3a8ae45ffecee65",
-                "sha256:61f05864b42fedc0771d6d8e49c35f07efd209ade09a5afe6a5059e7bb7bf83d",
-                "sha256:6223d07a1ae93f86451d0198a0c361032c4c93ebd4bf6d25e2fb3edfad9571ef",
-                "sha256:6323d5d845c2785efb20aded4726636546b26d3b577aded22492908f7c1bdda7",
-                "sha256:6ffe81843131ee0ffa02c317186ed1e759a145267d54fdef1bc4ea5f5931ab60",
-                "sha256:74f2d0be88db96ada78756cb3a3e1b107ce8ab79f65aa885f76d7664e56928f6",
-                "sha256:74fb2557d1430fff18ff0d72613c5ca30c45cdbfcddd6a5773e9fc1fe9364be8",
-                "sha256:90d4091c2d30ddd0a03e0b97e6a33a48628469b99585e2ad6bf21f17423b112b",
-                "sha256:90f31c34d25b1b3ed6c40cdd34ff122b1887a825297c017e4cbd6796dd8b672d",
-                "sha256:99de3e8739258b3c3e8669cb9757c9a861b2a25ad0955f8e53ac662d66de61ac",
-                "sha256:c6a5fd10ce6b6344e616cf01cc5b849fa8103fbb5ba507b6b2dee4c11e84c935",
-                "sha256:ce8b867423291cb65cfc6d9c4955ee9bfc1e21fe03bb50e177f2b957f1c2469d",
-                "sha256:d225cd8319aa1d3c85bf195c4e07d17d3cd68636b8fc97e6cf198f782f99af28",
-                "sha256:ea313bb02e5e25224e518e4352af4bf5e062755160f77e4b1767dd5ccb65f876",
-                "sha256:ea372bcc129394485824ae3e3ddabe67dc0b118d262c568b4d2602a7070afdb0",
-                "sha256:f4634b033faf0d968bb9220dd1c793b897ab7f1189956e1aa9eae752527127d3",
-                "sha256:fcc01e900c1d7bee2a37e5d6e4f9194760a93597c97fee89c4ae51701de03563"
+                "sha256:072664401ae6e7c1bfb878c65d7282d4b4391f1bc9a56d5e03b5a490403271b5",
+                "sha256:1070a9b287846a21a5d572d6dddd369517510b68710fca56b0e9e02fd24bed9a",
+                "sha256:1d7b433519b9a38192dfda962dd8f44446668c009833e1429a52424624f408b4",
+                "sha256:3151a58f0fbd8942ba94f7c31c7e6b310d2989f4da74fcbf28b934374e9bf841",
+                "sha256:32acf55cb9a8cbfb29167cd005951df81b567099295291bcfd1027365b36591d",
+                "sha256:3611e87eea393f779a35b192b46a164b1d01167c9d323dda9b1e527ea69d697d",
+                "sha256:3d00a664e31921009a84367266b35ba0aac04a2a6cad09c550a89041034d19a0",
+                "sha256:4e2fb92e3aeae3ec3b7b66c528981fd327fb93fd906a77215200404444ec1845",
+                "sha256:539e429da49c5d27d5a58e3563886057f8fc3868a5547b4f1876d9c0f007bccf",
+                "sha256:55ce319452e3d139e25d6c3f85a1acf12d1607ddedea5e35fb47a552c051161b",
+                "sha256:58c7d923dc209225600aec73aa2c4ae8ea33b1ab31bc11ef8a5933b027476f07",
+                "sha256:7336292a13a80eb93c21f36bde4328aa748a04b68c13d01dfddd67fc13fd0618",
+                "sha256:742c34fff804f34f62659279ed5c5b723bb0195e9d7bd9907591de9f8f6558e2",
+                "sha256:7641300de73e4909e5d148e90cc3142fb890079e1525a840cf0dfd39195239fd",
+                "sha256:76cebf84aac1d6da5b63df11fe0d377b46b7b500d892284068bacccf12f20666",
+                "sha256:7779be4025c540d1d65a2de3f30caeacc49ae7a2152108adeaf42c7534a115ce",
+                "sha256:7d190ee2eaef7831163f254dc58f6d2e2a22e27382b936aab51c835fc080c3d3",
+                "sha256:8293942e4ce0c5689821f65ce6522ce4786d02af57f13c0195b40e1edb1db61d",
+                "sha256:869842dbd66bb80c3217158e629d6fceaecc3a3166d3d1faee515b05dd26ca25",
+                "sha256:90a58b9fcae2dbfe4ba852b57bd4a1dded6b990a33d6428c7614b7d48eccb492",
+                "sha256:9b51917c1af3fa35a3f2dabd7ba96a2a4f19df3dec911da73875e1edaf22a40b",
+                "sha256:b2237f35c4bbae932ee98902a08050a27821f8f6dfa880a47195e5993af4702d",
+                "sha256:c3400cae15bdb449d518545cbd5b649117de54e3596ded84aacabfbb3297ead2",
+                "sha256:c51f1af02334e4b516ec221ee26b8fdf105032418ca5a5ab9737e8c87dafe203",
+                "sha256:cb8d10461c1ceee0c25a64f2dd54872b70b89c26419e147a05a10b753ad36ec2",
+                "sha256:d62a2796e08dd024b8179bd441cb714e0f81226c352c802fca0fd3f89eeacd94",
+                "sha256:df2c8bd48fb83a8408c8390b143c6a6fa10cb1a674ca664954de193fdcab36a9",
+                "sha256:e5c783d0b1ad6ca8a5d3e7b680468c9c926b804be83a3a8e95141b05c39c9f64",
+                "sha256:e9805fed4f2a81de98ae5fe38b75a74c6e6ad2df8a5c479594c7629a1fe35f56",
+                "sha256:ea42d747c5f71b5ccaa6897b216a7dadb9f52c72a0fe2b872ef7d3e1eacf3ba3",
+                "sha256:ef216cc9feb60634bda2f341a9559ac594e2eeaadd0ba187a4c2eb5b5d40b91c",
+                "sha256:ff0d41f8b3e9ebb6b6110057e40019a432e96aae2008951121ba4e56040b84f3"
             ],
             "index": "pypi",
-            "version": "==5.8.0"
+            "version": "==5.9.0"
         },
         "pyasn1": {
             "hashes": [
@@ -920,11 +933,11 @@
         },
         "pygments": {
             "hashes": [
-                "sha256:b8e67fe6af78f492b3c4b3e2970c0624cbf08beb1e493b2c99b9fa1b67a20380",
-                "sha256:f398865f7eb6874156579fdf36bc840a03cab64d1cde9e93d68f46a425ec52c6"
+                "sha256:44238f1b60a76d78fc8ca0528ee429702aae011c265fe6a8dd8b63049ae41c65",
+                "sha256:4e426f72023d88d03b2fa258de560726ce890ff3b630f88c21cbb8b2503b8c6a"
             ],
             "markers": "python_version >= '3.5'",
-            "version": "==2.10.0"
+            "version": "==2.11.2"
         },
         "pyinquirer": {
             "hashes": [
@@ -1024,30 +1037,46 @@
         },
         "readme-renderer": {
             "hashes": [
-                "sha256:3286806450d9961d6e3b5f8a59f77e61503799aca5155c8d8d40359b4e1e1adc",
-                "sha256:8299700d7a910c304072a7601eafada6712a5b011a20139417e1b1e9f04645d8"
+                "sha256:a50a0f2123a4c1145ac6f420e1a348aafefcc9211c846e3d51df05fe3d865b7d",
+                "sha256:b512beafa6798260c7d5af3e1b1f097e58bfcd9a575da7c4ddd5e037490a5b85"
             ],
-            "version": "==30.0"
+            "markers": "python_version >= '3.6'",
+            "version": "==32.0"
         },
         "regex": {
             "hashes": [
+                "sha256:0416f7399e918c4b0e074a0f66e5191077ee2ca32a0f99d4c187a62beb47aa05",
                 "sha256:05b7d6d7e64efe309972adab77fc2af8907bb93217ec60aa9fe12a0dad35874f",
                 "sha256:0617383e2fe465732af4509e61648b77cbe3aee68b6ac8c0b6fe934db90be5cc",
                 "sha256:07856afef5ffcc052e7eccf3213317fbb94e4a5cd8177a2caa69c980657b3cb4",
+                "sha256:0f594b96fe2e0821d026365f72ac7b4f0b487487fb3d4aaf10dd9d97d88a9737",
+                "sha256:139a23d1f5d30db2cc6c7fd9c6d6497872a672db22c4ae1910be22d4f4b2068a",
                 "sha256:162abfd74e88001d20cb73ceaffbfe601469923e875caf9118333b1a4aaafdc4",
                 "sha256:2207ae4f64ad3af399e2d30dde66f0b36ae5c3129b52885f1bffc2f05ec505c8",
+                "sha256:2409b5c9cef7054dde93a9803156b411b677affc84fca69e908b1cb2c540025d",
+                "sha256:2fee3ed82a011184807d2127f1733b4f6b2ff6ec7151d83ef3477f3b96a13d03",
                 "sha256:30ab804ea73972049b7a2a5c62d97687d69b5a60a67adca07eb73a0ddbc9e29f",
+                "sha256:3598893bde43091ee5ca0a6ad20f08a0435e93a69255eeb5f81b85e81e329264",
                 "sha256:3b5df18db1fccd66de15aa59c41e4f853b5df7550723d26aa6cb7f40e5d9da5a",
                 "sha256:3c5fb32cc6077abad3bbf0323067636d93307c9fa93e072771cf9a64d1c0f3ef",
                 "sha256:416c5f1a188c91e3eb41e9c8787288e707f7d2ebe66e0a6563af280d9b68478f",
+                "sha256:42b50fa6666b0d50c30a990527127334d6b96dd969011e843e726a64011485da",
                 "sha256:432bd15d40ed835a51617521d60d0125867f7b88acf653e4ed994a1f8e4995dc",
+                "sha256:473e67837f786404570eae33c3b64a4b9635ae9f00145250851a1292f484c063",
                 "sha256:4aaa4e0705ef2b73dd8e36eeb4c868f80f8393f5f4d855e94025ce7ad8525f50",
+                "sha256:50a7ddf3d131dc5633dccdb51417e2d1910d25cbcf842115a3a5893509140a3a",
+                "sha256:529801a0d58809b60b3531ee804d3e3be4b412c94b5d267daa3de7fadef00f49",
                 "sha256:537ca6a3586931b16a85ac38c08cc48f10fc870a5b25e51794c74df843e9966d",
                 "sha256:53db2c6be8a2710b359bfd3d3aa17ba38f8aa72a82309a12ae99d3c0c3dcd74d",
                 "sha256:5537f71b6d646f7f5f340562ec4c77b6e1c915f8baae822ea0b7e46c1f09b733",
+                "sha256:563d5f9354e15e048465061509403f68424fef37d5add3064038c2511c8f5e00",
+                "sha256:5d408a642a5484b9b4d11dea15a489ea0928c7e410c7525cd892f4d04f2f617b",
+                "sha256:61600a7ca4bcf78a96a68a27c2ae9389763b5b94b63943d5158f2a377e09d29a",
                 "sha256:6650f16365f1924d6014d2ea770bde8555b4a39dc9576abb95e3cd1ff0263b36",
                 "sha256:666abff54e474d28ff42756d94544cdfd42e2ee97065857413b72e8a2d6a6345",
                 "sha256:68a067c11463de2a37157930d8b153005085e42bcb7ad9ca562d77ba7d1404e0",
+                "sha256:6e1d2cc79e8dae442b3fa4a26c5794428b98f81389af90623ffcc650ce9f6732",
+                "sha256:74cbeac0451f27d4f50e6e8a8f3a52ca074b5e2da9f7b505c4201a57a8ed6286",
                 "sha256:780b48456a0f0ba4d390e8b5f7c661fdd218934388cde1a974010a965e200e12",
                 "sha256:788aef3549f1924d5c38263104dae7395bf020a42776d5ec5ea2b0d3d85d6646",
                 "sha256:7ee1227cf08b6716c85504aebc49ac827eb88fcc6e51564f010f11a406c0a667",
@@ -1057,24 +1086,34 @@
                 "sha256:9345b6f7ee578bad8e475129ed40123d265464c4cfead6c261fd60fc9de00bcf",
                 "sha256:93a5051fcf5fad72de73b96f07d30bc29665697fb8ecdfbc474f3452c78adcf4",
                 "sha256:962b9a917dd7ceacbe5cd424556914cb0d636001e393b43dc886ba31d2a1e449",
+                "sha256:96fc32c16ea6d60d3ca7f63397bff5c75c5a562f7db6dec7d412f7c4d2e78ec0",
                 "sha256:98ba568e8ae26beb726aeea2273053c717641933836568c2a0278a84987b2a1a",
                 "sha256:a3feefd5e95871872673b08636f96b61ebef62971eab044f5124fb4dea39919d",
+                "sha256:a955b747d620a50408b7fdf948e04359d6e762ff8a85f5775d907ceced715129",
                 "sha256:b43c2b8a330a490daaef5a47ab114935002b13b3f9dc5da56d5322ff218eeadb",
                 "sha256:b483c9d00a565633c87abd0aaf27eb5016de23fed952e054ecc19ce32f6a9e7e",
+                "sha256:b9ed0b1e5e0759d6b7f8e2f143894b2a7f3edd313f38cf44e1e15d360e11749b",
                 "sha256:ba05430e819e58544e840a68b03b28b6d328aff2e41579037e8bab7653b37d83",
+                "sha256:ca49e1ab99593438b204e00f3970e7a5f70d045267051dfa6b5f4304fcfa1dbf",
                 "sha256:ca5f18a75e1256ce07494e245cdb146f5a9267d3c702ebf9b65c7f8bd843431e",
+                "sha256:cd410a1cbb2d297c67d8521759ab2ee3f1d66206d2e4328502a487589a2cb21b",
+                "sha256:ce298e3d0c65bd03fa65ffcc6db0e2b578e8f626d468db64fdf8457731052942",
                 "sha256:d5ca078bb666c4a9d1287a379fe617a6dccd18c3e8a7e6c7e1eb8974330c626a",
+                "sha256:d5fd67df77bab0d3f4ea1d7afca9ef15c2ee35dfb348c7b57ffb9782a6e4db6e",
                 "sha256:da1a90c1ddb7531b1d5ff1e171b4ee61f6345119be7351104b67ff413843fe94",
                 "sha256:dba70f30fd81f8ce6d32ddeef37d91c8948e5d5a4c63242d16a2b2df8143aafc",
+                "sha256:dc07f021ee80510f3cd3af2cad5b6a3b3a10b057521d9e6aaeb621730d320c5a",
                 "sha256:dd33eb9bdcfbabab3459c9ee651d94c842bc8a05fabc95edf4ee0c15a072495e",
                 "sha256:e0538c43565ee6e703d3a7c3bdfe4037a5209250e8502c98f20fea6f5fdf2965",
                 "sha256:e1f54b9b4b6c53369f40028d2dd07a8c374583417ee6ec0ea304e710a20f80a0",
                 "sha256:e32d2a2b02ccbef10145df9135751abea1f9f076e67a4e261b05f24b94219e36",
+                "sha256:e6096b0688e6e14af6a1b10eaad86b4ff17935c49aa774eac7c95a57a4e8c296",
                 "sha256:e71255ba42567d34a13c03968736c5d39bb4a97ce98188fafb27ce981115beec",
                 "sha256:ed2e07c6a26ed4bea91b897ee2b0835c21716d9a469a96c3e878dc5f8c55bb23",
                 "sha256:eef2afb0fd1747f33f1ee3e209bce1ed582d1896b240ccc5e2697e3275f037c7",
                 "sha256:f23222527b307970e383433daec128d769ff778d9b29343fb3496472dc20dabe",
                 "sha256:f341ee2df0999bfdf7a95e448075effe0db212a59387de1a70690e4acb03d4c6",
+                "sha256:f5be7805e53dafe94d295399cfbe5227f39995a997f4fd8539bf3cbdc8f47ca8",
                 "sha256:f7f325be2804246a75a4f45c72d4ce80d2443ab815063cdf70ee8fb2ca59ee1b",
                 "sha256:f8af619e3be812a2059b212064ea7a640aff0568d972cd1b9e920837469eb3cb",
                 "sha256:fa8c626d6441e2d04b6ee703ef2d1e17608ad44c7cb75258c09dd42bacdfc64b",
@@ -1085,11 +1124,11 @@
         },
         "requests": {
             "hashes": [
-                "sha256:6c1246513ecd5ecd4528a0906f910e8f0f9c6b8ec72030dc9fd154dc1a6efd24",
-                "sha256:b8aa58f8cf793ffd8782d3d8cb19e66ef36f7aba4353eec859e74678b01b07a7"
+                "sha256:68d7c56fd5a8999887728ef304a6d12edc7be74f1cfa47714fc8b414525c9a61",
+                "sha256:f22fa1e554c9ddfd16e6e41ac79759e17be9e492b3587efa038054674760e72d"
             ],
             "index": "pypi",
-            "version": "==2.26.0"
+            "version": "==2.27.1"
         },
         "requests-mock": {
             "extras": [
@@ -1118,10 +1157,11 @@
         },
         "rfc3986": {
             "hashes": [
-                "sha256:270aaf10d87d0d4e095063c65bf3ddbc6ee3d0b226328ce21e036f946e421835",
-                "sha256:a86d6e1f5b1dc238b218b012df0aa79409667bb209e58da56d0b94704e712a97"
+                "sha256:50b1502b60e289cb37883f3dfd34532b8873c7de9f49bb546641ce9cbd256ebd",
+                "sha256:97aacf9dbd4bfd829baad6e6309fa6573aaf1be3f6fa735c8ab05e46cecb261c"
             ],
-            "version": "==1.5.0"
+            "markers": "python_version >= '3.7'",
+            "version": "==2.0.0"
         },
         "rich": {
             "hashes": [
@@ -1133,28 +1173,32 @@
         },
         "rsa": {
             "hashes": [
-                "sha256:78f9a9bf4e7be0c5ded4583326e7461e3a3c5aae24073648b4bdfa797d78c9d2",
-                "sha256:9d689e6ca1b3038bc82bf8d23e944b6b6037bc02301a574935b2dd946e0353b9"
+                "sha256:5c6bd9dc7a543b7fe4304a631f8a8a3b674e2bbfc49c2ae96200cdbe55df6b17",
+                "sha256:95c5d300c4e879ee69708c428ba566c59478fd653cc3a22243eeb8ed846950bb"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==4.7.2"
+            "version": "==4.8"
         },
         "ruamel.yaml": {
             "hashes": [
-                "sha256:9751de4cbb57d4bfbf8fc394e125ed4a2f170fbff3dc3d78abf50be85924f8be",
-                "sha256:9af3ec5d7f8065582f3aa841305465025d0afd26c5fb54e15b964e11838fc74f"
+                "sha256:4b8a33c1efb2b443a93fcaafcfa4d2e445f8e8c29c528d9f5cdafb7cc9e4004c",
+                "sha256:810eef9c46523a3f77479c66267a4708255ebe806a2d540078408c2227f011af"
             ],
             "index": "pypi",
-            "version": "==0.17.17"
+            "version": "==0.17.20"
         },
         "ruamel.yaml.clib": {
             "hashes": [
                 "sha256:0847201b767447fc33b9c235780d3aa90357d20dd6108b92be544427bea197dd",
+                "sha256:1070ba9dd7f9370d0513d649420c3b362ac2d687fe78c6e888f5b12bf8bc7bee",
                 "sha256:1866cf2c284a03b9524a5cc00daca56d80057c5ce3cdc86a52020f4c720856f0",
+                "sha256:221eca6f35076c6ae472a531afa1c223b9c29377e62936f61bc8e6e8bdc5f9e7",
                 "sha256:31ea73e564a7b5fbbe8188ab8b334393e06d997914a4e184975348f204790277",
                 "sha256:3fb9575a5acd13031c57a62cc7823e5d2ff8bc3835ba4d94b921b4e6ee664104",
                 "sha256:4ff604ce439abb20794f05613c374759ce10e3595d1867764dd1ae675b85acbd",
+                "sha256:6e7be2c5bcb297f5b82fee9c665eb2eb7001d1050deaba8471842979293a80b0",
                 "sha256:72a2b8b2ff0a627496aad76f37a652bcef400fd861721744201ef1b45199ab78",
+                "sha256:77df077d32921ad46f34816a9a16e6356d8100374579bc35e15bab5d4e9377de",
                 "sha256:78988ed190206672da0f5d50c61afef8f67daa718d614377dcd5e3ed85ab4a99",
                 "sha256:7b2927e92feb51d830f531de4ccb11b320255ee95e791022555971c466af4527",
                 "sha256:7f7ecb53ae6848f959db6ae93bdff1740e651809780822270eab111500842a84",
@@ -1171,7 +1215,7 @@
                 "sha256:dc6a613d6c74eef5a14a214d433d06291526145431c3b964f5e16529b1842bed",
                 "sha256:de9c6b8a1ba52919ae919f3ae96abb72b994dd0350226e28f3686cb4f142165c"
             ],
-            "markers": "python_version < '3.10' and platform_python_implementation == 'CPython'",
+            "markers": "python_version < '3.11' and platform_python_implementation == 'CPython'",
             "version": "==0.2.6"
         },
         "s3transfer": {
@@ -1181,14 +1225,6 @@
             ],
             "markers": "python_version >= '3.6'",
             "version": "==0.5.0"
-        },
-        "secretstorage": {
-            "hashes": [
-                "sha256:422d82c36172d88d6a0ed5afdec956514b189ddbfb72fefab0c8a1cee4eaf71f",
-                "sha256:fd666c51a6bf200643495a04abb261f83229dcb6fd8472ec393df7ffc8b6f195"
-            ],
-            "markers": "sys_platform == 'linux'",
-            "version": "==3.3.1"
         },
         "semver": {
             "hashes": [
@@ -1248,72 +1284,79 @@
         },
         "twine": {
             "hashes": [
-                "sha256:4caad5ef4722e127b3749052fcbffaaf71719b19d4fd4973b29c469957adeba2",
-                "sha256:916070f8ecbd1985ebed5dbb02b9bda9a092882a96d7069d542d4fc0bb5c673c"
+                "sha256:28460a3db6b4532bde6a5db6755cf2dce6c5020bada8a641bb2c5c7a9b1f35b8",
+                "sha256:8c120845fc05270f9ee3e9d7ebbed29ea840e41f48cd059e04733f7e1d401345"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==3.6.0"
+            "version": "==3.7.1"
         },
         "types-cryptography": {
             "hashes": [
-                "sha256:07ff76c1fd78724adf3b774bb78928a35b010ec0b29caaf5c959d3b233a2b82d",
-                "sha256:cf1b981597c482828d3ea84bcbe3fbd695cf178cd32b60cd09944f4dbe914746"
+                "sha256:1a81e18c2456f996d10b2410d16fbdc6f19653131e4ce0e09978015e9207c476",
+                "sha256:aab189d3a63453fba48a9e5937f354ed8d4d2151c0aef44dc813cdcce631f375"
             ],
-            "version": "==3.3.8"
+            "version": "==3.3.12"
         },
         "types-enum34": {
             "hashes": [
-                "sha256:55c44c44f193636ed82f1cb68a9a632e1ea7096724f024c25e015976809df339",
-                "sha256:b6d55d7c91867bd2fd6fc90651d91629c98b27cb26df11b1db658ae7a72bb768"
+                "sha256:22a08eacf89a1b71b2b770321b6940abe12afd6214c12917c4f119c935ff732a",
+                "sha256:a1e1dcb80ae9d5a86c69ac7fcd65aec529541faaedffb3b2c840b0cbed8fbd61"
             ],
-            "version": "==1.1.1"
+            "version": "==1.1.2"
         },
         "types-ipaddress": {
             "hashes": [
-                "sha256:9d0a642526c4a1f87ee9ae29d91b93f708508b891d038db2e1c9f06219383516",
-                "sha256:dc5540c7fd8d4b3ffe8461bc01f27513c0abe5f2088e491218bd0a98a0b4584e"
+                "sha256:b3f29a5e1dabab9ec00c75654b53b07251f731d57295097c72c864524a31034d",
+                "sha256:cb5eb3ad21acea538a1b404bbe2c43a7ba918e56d94c7399730cfece01b0a947"
             ],
-            "version": "==1.0.1"
+            "version": "==1.0.2"
         },
         "types-pyopenssl": {
             "hashes": [
-                "sha256:5e90537575e6e7eacd8eea5389bd55402c8a636330e83e384be036b2394e31d9",
-                "sha256:70217c7b611409d96803150f1e50eae83514c715e913c5f02c657fd9d9c0fb6a"
+                "sha256:43ddd1a1864c644acd3eb3a9652868418ec1642c3b73326c0e04e9e9c8463cbb",
+                "sha256:6f16e31f35873d94d0ad521dbca062f7023c2685226216d5464c7cdf92a4ee5f"
             ],
             "index": "pypi",
-            "version": "==21.0.0"
+            "version": "==21.0.3"
         },
         "types-pytz": {
             "hashes": [
-                "sha256:86a61967834dceeaaf98b6902ed8357efdd262bb8afcaf4bc8ccecf748592778",
-                "sha256:b5027e5de50a4c978cd60ca16849d934d44c44ebd7d29cf13ada009efaa9feef"
+                "sha256:101da53091013bb07403468c20d36930d749d3918054ac46f9c1bfc607dadf7d",
+                "sha256:ccfa2ed29f816e3de2f882541c06ad2791f808a79cfe38265411820190999f0f"
             ],
             "index": "pypi",
-            "version": "==2021.3.0"
+            "version": "==2021.3.4"
         },
         "types-pyyaml": {
             "hashes": [
-                "sha256:2e27b0118ca4248a646101c5c318dc02e4ca2866d6bc42e84045dbb851555a76",
-                "sha256:d5b318269652e809b5c30a5fe666c50159ab80bfd41cd6bafe655bf20b29fcba"
+                "sha256:6ea4eefa8579e0ce022f785a62de2bcd647fad4a81df5cf946fd67e4b059920b",
+                "sha256:8b50294b55a9db89498cdc5a65b1b4545112b6cd1cf4465bd693d828b0282a17"
             ],
             "index": "pypi",
-            "version": "==6.0.1"
+            "version": "==6.0.3"
         },
         "types-requests": {
             "hashes": [
-                "sha256:809b5dcd3c408ac39d11d593835b6aff32420b3e7ddb79c7f3e823330f040466",
-                "sha256:df5ec8c34b413a42ebb38e4f96bdeb68090b875bdfcc5138dc82989c95445883"
+                "sha256:9c9390b18b222956155af6678570f452edafa3bb94bd5a4efe67da1105aa128c",
+                "sha256:a67dc1a8512312b8cb89f3ba95f9a0e69ef3436ae77c9bd4f328cd88f17adda2"
             ],
             "index": "pypi",
-            "version": "==2.26.0"
+            "version": "==2.27.5"
         },
         "types-tabulate": {
             "hashes": [
-                "sha256:7c28ca3b35f13eedefdc2cddc0b73e4b3e67b353174d9294a0687c558d1d1d85",
-                "sha256:f815bdcaa227777517edea91dcac85effe03f58dd350c7e19b8019f4fb14dacc"
+                "sha256:03f283bf384ea121b7b6a58afb38f4def97f30704fca13a0da686936b0f392ac",
+                "sha256:a7289b809220dfbb6d8816a8dcc25bdf82b91b47288225afb2c3f296e0417c7f"
             ],
             "index": "pypi",
-            "version": "==0.8.3"
+            "version": "==0.8.5"
+        },
+        "types-urllib3": {
+            "hashes": [
+                "sha256:35c17be09e1bcef3b1e2101c5172b97cdb78330915973c741f4c1979d8405ef9",
+                "sha256:61a0099899b1472bfbae8ee6ad196950aac46705b99216188aa962ad1e514ed5"
+            ],
+            "version": "==1.26.4"
         },
         "typing-extensions": {
             "hashes": [
@@ -1342,11 +1385,11 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:4987c65554f7a2dbf30c18fd48778ef124af6fab771a377103da0585e2336ece",
-                "sha256:c4fdf4019605b6e5423637e01bc9fe4daef873709a7973e195ceba0a62bbc844"
+                "sha256:000ca7f471a233c2251c6c7023ee85305721bfdf18621ebff4fd17a8653427ed",
+                "sha256:0e7c33d9a63e7ddfcb86780aac87befc2fbddf46c58dbb487e0855f7ceec283c"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4.0'",
-            "version": "==1.26.7"
+            "version": "==1.26.8"
         },
         "wcwidth": {
             "hashes": [
@@ -1364,11 +1407,11 @@
         },
         "websocket-client": {
             "hashes": [
-                "sha256:0133d2f784858e59959ce82ddac316634229da55b498aac311f1620567a710ec",
-                "sha256:8dfb715d8a992f5712fff8c843adae94e22b22a99b2c5e6b0ec4a1a981cc4e0d"
+                "sha256:1315816c0acc508997eb3ae03b9d3ff619c9d12d544c9a9b553704b1cc4f6af5",
+                "sha256:2eed4cc58e4d65613ed6114af2f380f7910ff416fc8c46947f6e76b6815f56c0"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==1.2.1"
+            "version": "==1.2.3"
         },
         "yamale": {
             "hashes": [
@@ -1380,11 +1423,11 @@
         },
         "zipp": {
             "hashes": [
-                "sha256:71c644c5369f4a6e07636f0aa966270449561fcea2e3d6747b8d23efaa9d7832",
-                "sha256:9fe5ea21568a0a70e50f273397638d39b03353731e6cbbb3fd8502a33fec40bc"
+                "sha256:9f50f446828eb9d45b267433fd3e9da8d801f614129124863f9c51ebceafb87d",
+                "sha256:b47250dd24f92b7dd6a0a8fc5244da14608f3ca90a5efcd37a3b1642fac9a375"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==3.6.0"
+            "markers": "python_version >= '3.7'",
+            "version": "==3.7.0"
         }
     },
     "develop": {
@@ -1412,11 +1455,11 @@
         },
         "attrs": {
             "hashes": [
-                "sha256:149e90d6d8ac20db7a955ad60cf0e6881a3f20d37096140088356da6c716b0b1",
-                "sha256:ef6aaac3ca6cd92904cdd0d83f629a15f18053ec84e6432106f7a4d04ae4f5fb"
+                "sha256:2d27e3784d7a565d36ab851fe94887c5eccd6a463168875832a1be79c82828b4",
+                "sha256:626ba8234211db98e869df76230a137c4c40a12d72445c45d5f5b716f076e2fd"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==21.2.0"
+            "version": "==21.4.0"
         },
         "bandit": {
             "hashes": [
@@ -1519,11 +1562,11 @@
         },
         "charset-normalizer": {
             "hashes": [
-                "sha256:e019de665e2bcf9c2b64e2e5aa025fa991da8720daa3c1138cadd2fd1856aed0",
-                "sha256:f7af805c321bfa1ce6714c51f254e0d5bb5e5834039bc17db7ebe3a4cec9492b"
+                "sha256:876d180e9d7432c5d1dfd4c5d26b72f099d503e8fcc0feb7532c9289be60fcbd",
+                "sha256:cb957888737fc0bbcd78e3df769addb41fd1ff8cf950dc9e7ad7793f1bf44455"
             ],
             "markers": "python_version >= '3'",
-            "version": "==2.0.7"
+            "version": "==2.0.10"
         },
         "click": {
             "hashes": [
@@ -1546,56 +1589,56 @@
                 "toml"
             ],
             "hashes": [
-                "sha256:046647b96969fda1ae0605f61288635209dd69dcd27ba3ec0bf5148bc157f954",
-                "sha256:06d009e8a29483cbc0520665bc46035ffe9ae0e7484a49f9782c2a716e37d0a0",
-                "sha256:0cde7d9fe2fb55ff68ebe7fb319ef188e9b88e0a3d1c9c5db7dd829cd93d2193",
-                "sha256:1de9c6f5039ee2b1860b7bad2c7bc3651fbeb9368e4c4d93e98a76358cdcb052",
-                "sha256:24ed38ec86754c4d5a706fbd5b52b057c3df87901a8610d7e5642a08ec07087e",
-                "sha256:27a3df08a855522dfef8b8635f58bab81341b2fb5f447819bc252da3aa4cf44c",
-                "sha256:310c40bed6b626fd1f463e5a83dba19a61c4eb74e1ac0d07d454ebbdf9047e9d",
-                "sha256:3348865798c077c695cae00da0924136bb5cc501f236cfd6b6d9f7a3c94e0ec4",
-                "sha256:35b246ae3a2c042dc8f410c94bcb9754b18179cdb81ff9477a9089dbc9ecc186",
-                "sha256:3f546f48d5d80a90a266769aa613bc0719cb3e9c2ef3529d53f463996dd15a9d",
-                "sha256:586d38dfc7da4a87f5816b203ff06dd7c1bb5b16211ccaa0e9788a8da2b93696",
-                "sha256:5d3855d5d26292539861f5ced2ed042fc2aa33a12f80e487053aed3bcb6ced13",
-                "sha256:610c0ba11da8de3a753dc4b1f71894f9f9debfdde6559599f303286e70aeb0c2",
-                "sha256:62646d98cf0381ffda301a816d6ac6c35fc97aa81b09c4c52d66a15c4bef9d7c",
-                "sha256:66af99c7f7b64d050d37e795baadf515b4561124f25aae6e1baa482438ecc388",
-                "sha256:675adb3b3380967806b3cbb9c5b00ceb29b1c472692100a338730c1d3e59c8b9",
-                "sha256:6e5a8c947a2a89c56655ecbb789458a3a8e3b0cbf4c04250331df8f647b3de59",
-                "sha256:7a39590d1e6acf6a3c435c5d233f72f5d43b585f5be834cff1f21fec4afda225",
-                "sha256:80cb70264e9a1d04b519cdba3cd0dc42847bf8e982a4d55c769b9b0ee7cdce1e",
-                "sha256:82fdcb64bf08aa5db881db061d96db102c77397a570fbc112e21c48a4d9cb31b",
-                "sha256:8492d37acdc07a6eac6489f6c1954026f2260a85a4c2bb1e343fe3d35f5ee21a",
-                "sha256:94f558f8555e79c48c422045f252ef41eb43becdd945e9c775b45ebfc0cbd78f",
-                "sha256:958ac66272ff20e63d818627216e3d7412fdf68a2d25787b89a5c6f1eb7fdd93",
-                "sha256:95a58336aa111af54baa451c33266a8774780242cab3704b7698d5e514840758",
-                "sha256:96129e41405887a53a9cc564f960d7f853cc63d178f3a182fdd302e4cab2745b",
-                "sha256:97ef6e9119bd39d60ef7b9cd5deea2b34869c9f0b9777450a7e3759c1ab09b9b",
-                "sha256:98d44a8136eebbf544ad91fef5bd2b20ef0c9b459c65a833c923d9aa4546b204",
-                "sha256:9d2c2e3ce7b8cc932a2f918186964bd44de8c84e2f9ef72dc616f5bb8be22e71",
-                "sha256:a300b39c3d5905686c75a369d2a66e68fd01472ea42e16b38c948bd02b29e5bd",
-                "sha256:a34fccb45f7b2d890183a263578d60a392a1a218fdc12f5bce1477a6a68d4373",
-                "sha256:a4d48e42e17d3de212f9af44f81ab73b9378a4b2b8413fd708d0d9023f2bbde4",
-                "sha256:af45eea024c0e3a25462fade161afab4f0d9d9e0d5a5d53e86149f74f0a35ecc",
-                "sha256:ba6125d4e55c0b8e913dad27b22722eac7abdcb1f3eab1bd090eee9105660266",
-                "sha256:bc1ee1318f703bc6c971da700d74466e9b86e0c443eb85983fb2a1bd20447263",
-                "sha256:c18725f3cffe96732ef96f3de1939d81215fd6d7d64900dcc4acfe514ea4fcbf",
-                "sha256:c8e9c4bcaaaa932be581b3d8b88b677489975f845f7714efc8cce77568b6711c",
-                "sha256:cc799916b618ec9fd00135e576424165691fec4f70d7dc12cfaef09268a2478c",
-                "sha256:cd2d11a59afa5001ff28073ceca24ae4c506da4355aba30d1e7dd2bd0d2206dc",
-                "sha256:d0a595a781f8e186580ff8e3352dd4953b1944289bec7705377c80c7e36c4d6c",
-                "sha256:d3c5f49ce6af61154060640ad3b3281dbc46e2e0ef2fe78414d7f8a324f0b649",
-                "sha256:d9a635114b88c0ab462e0355472d00a180a5fbfd8511e7f18e4ac32652e7d972",
-                "sha256:e5432d9c329b11c27be45ee5f62cf20a33065d482c8dec1941d6670622a6fb8f",
-                "sha256:eab14fdd410500dae50fd14ccc332e65543e7b39f6fc076fe90603a0e5d2f929",
-                "sha256:ebcc03e1acef4ff44f37f3c61df478d6e469a573aa688e5a162f85d7e4c3860d",
-                "sha256:fae3fe111670e51f1ebbc475823899524e3459ea2db2cb88279bbfb2a0b8a3de",
-                "sha256:fd92ece726055e80d4e3f01fff3b91f54b18c9c357c48fcf6119e87e2461a091",
-                "sha256:ffa545230ca2ad921ad066bf8fd627e7be43716b6e0fcf8e32af1b8188ccb0ab"
+                "sha256:01774a2c2c729619760320270e42cd9e797427ecfddd32c2a7b639cdc481f3c0",
+                "sha256:03b20e52b7d31be571c9c06b74746746d4eb82fc260e594dc662ed48145e9efd",
+                "sha256:0a7726f74ff63f41e95ed3a89fef002916c828bb5fcae83b505b49d81a066884",
+                "sha256:1219d760ccfafc03c0822ae2e06e3b1248a8e6d1a70928966bafc6838d3c9e48",
+                "sha256:13362889b2d46e8d9f97c421539c97c963e34031ab0cb89e8ca83a10cc71ac76",
+                "sha256:174cf9b4bef0db2e8244f82059a5a72bd47e1d40e71c68ab055425172b16b7d0",
+                "sha256:17e6c11038d4ed6e8af1407d9e89a2904d573be29d51515f14262d7f10ef0a64",
+                "sha256:215f8afcc02a24c2d9a10d3790b21054b58d71f4b3c6f055d4bb1b15cecce685",
+                "sha256:22e60a3ca5acba37d1d4a2ee66e051f5b0e1b9ac950b5b0cf4aa5366eda41d47",
+                "sha256:2641f803ee9f95b1f387f3e8f3bf28d83d9b69a39e9911e5bfee832bea75240d",
+                "sha256:276651978c94a8c5672ea60a2656e95a3cce2a3f31e9fb2d5ebd4c215d095840",
+                "sha256:3f7c17209eef285c86f819ff04a6d4cbee9b33ef05cbcaae4c0b4e8e06b3ec8f",
+                "sha256:3feac4084291642165c3a0d9eaebedf19ffa505016c4d3db15bfe235718d4971",
+                "sha256:49dbff64961bc9bdd2289a2bda6a3a5a331964ba5497f694e2cbd540d656dc1c",
+                "sha256:4e547122ca2d244f7c090fe3f4b5a5861255ff66b7ab6d98f44a0222aaf8671a",
+                "sha256:5829192582c0ec8ca4a2532407bc14c2f338d9878a10442f5d03804a95fac9de",
+                "sha256:5d6b09c972ce9200264c35a1d53d43ca55ef61836d9ec60f0d44273a31aa9f17",
+                "sha256:600617008aa82032ddeace2535626d1bc212dfff32b43989539deda63b3f36e4",
+                "sha256:619346d57c7126ae49ac95b11b0dc8e36c1dd49d148477461bb66c8cf13bb521",
+                "sha256:63c424e6f5b4ab1cf1e23a43b12f542b0ec2e54f99ec9f11b75382152981df57",
+                "sha256:6dbc1536e105adda7a6312c778f15aaabe583b0e9a0b0a324990334fd458c94b",
+                "sha256:6e1394d24d5938e561fbeaa0cd3d356207579c28bd1792f25a068743f2d5b282",
+                "sha256:86f2e78b1eff847609b1ca8050c9e1fa3bd44ce755b2ec30e70f2d3ba3844644",
+                "sha256:8bdfe9ff3a4ea37d17f172ac0dff1e1c383aec17a636b9b35906babc9f0f5475",
+                "sha256:8e2c35a4c1f269704e90888e56f794e2d9c0262fb0c1b1c8c4ee44d9b9e77b5d",
+                "sha256:92b8c845527eae547a2a6617d336adc56394050c3ed8a6918683646328fbb6da",
+                "sha256:9365ed5cce5d0cf2c10afc6add145c5037d3148585b8ae0e77cc1efdd6aa2953",
+                "sha256:9a29311bd6429be317c1f3fe4bc06c4c5ee45e2fa61b2a19d4d1d6111cb94af2",
+                "sha256:9a2b5b52be0a8626fcbffd7e689781bf8c2ac01613e77feda93d96184949a98e",
+                "sha256:a4bdeb0a52d1d04123b41d90a4390b096f3ef38eee35e11f0b22c2d031222c6c",
+                "sha256:a9c8c4283e17690ff1a7427123ffb428ad6a52ed720d550e299e8291e33184dc",
+                "sha256:b637c57fdb8be84e91fac60d9325a66a5981f8086c954ea2772efe28425eaf64",
+                "sha256:bf154ba7ee2fd613eb541c2bc03d3d9ac667080a737449d1a3fb342740eb1a74",
+                "sha256:c254b03032d5a06de049ce8bca8338a5185f07fb76600afff3c161e053d88617",
+                "sha256:c332d8f8d448ded473b97fefe4a0983265af21917d8b0cdcb8bb06b2afe632c3",
+                "sha256:c7912d1526299cb04c88288e148c6c87c0df600eca76efd99d84396cfe00ef1d",
+                "sha256:cfd9386c1d6f13b37e05a91a8583e802f8059bebfccde61a418c5808dea6bbfa",
+                "sha256:d5d2033d5db1d58ae2d62f095e1aefb6988af65b4b12cb8987af409587cc0739",
+                "sha256:dca38a21e4423f3edb821292e97cec7ad38086f84313462098568baedf4331f8",
+                "sha256:e2cad8093172b7d1595b4ad66f24270808658e11acf43a8f95b41276162eb5b8",
+                "sha256:e3db840a4dee542e37e09f30859f1612da90e1c5239a6a2498c473183a50e781",
+                "sha256:edcada2e24ed68f019175c2b2af2a8b481d3d084798b8c20d15d34f5c733fa58",
+                "sha256:f467bbb837691ab5a8ca359199d3429a11a01e6dfb3d9dcc676dc035ca93c0a9",
+                "sha256:f506af4f27def639ba45789fa6fde45f9a217da0be05f8910458e4557eed020c",
+                "sha256:f614fc9956d76d8a88a88bb41ddc12709caa755666f580af3a688899721efecd",
+                "sha256:f9afb5b746781fc2abce26193d1c817b7eb0e11459510fba65d2bd77fe161d9e",
+                "sha256:fb8b8ee99b3fffe4fd86f4c81b35a6bf7e4462cba019997af2fe679365db0c49"
             ],
             "index": "pypi",
-            "version": "==6.1.2"
+            "version": "==6.2"
         },
         "deprecated": {
             "hashes": [
@@ -1607,10 +1650,10 @@
         },
         "distlib": {
             "hashes": [
-                "sha256:c8b54e8454e5bf6237cc84c20e8264c3e991e824ef27e8f1e81049867d861e31",
-                "sha256:d982d0751ff6eaaab5e2ec8e691d949ee80eddf01a62eaa96ddb11531fe16b05"
+                "sha256:6564fe0a8f51e734df6333d08b8b94d4ea8ee6b99b5ed50613f731fd4089f34b",
+                "sha256:e4b58818180336dc9c529bfb9a0b58728ffc09ad92027a3f30b7cd91e3458579"
             ],
-            "version": "==0.3.3"
+            "version": "==0.3.4"
         },
         "flake8": {
             "hashes": [
@@ -1630,11 +1673,11 @@
         },
         "gitpython": {
             "hashes": [
-                "sha256:dc0a7f2f697657acc8d7f89033e8b1ea94dd90356b2983bca89dc8d2ab3cc647",
-                "sha256:df83fdf5e684fef7c6ee2c02fc68a5ceb7e7e759d08b694088d0cacb4eba59e5"
+                "sha256:26ac35c212d1f7b16036361ca5cff3ec66e11753a0d677fb6c48fa4e1a9dd8d6",
+                "sha256:fc8868f63a2e6d268fb25f481995ba185a85a66fcad126f039323ff6635669ee"
             ],
             "index": "pypi",
-            "version": "==3.1.24"
+            "version": "==3.1.26"
         },
         "idna": {
             "hashes": [
@@ -1676,32 +1719,29 @@
         },
         "mypy": {
             "hashes": [
-                "sha256:088cd9c7904b4ad80bec811053272986611b84221835e079be5bcad029e79dd9",
-                "sha256:0aadfb2d3935988ec3815952e44058a3100499f5be5b28c34ac9d79f002a4a9a",
-                "sha256:119bed3832d961f3a880787bf621634ba042cb8dc850a7429f643508eeac97b9",
-                "sha256:1a85e280d4d217150ce8cb1a6dddffd14e753a4e0c3cf90baabb32cefa41b59e",
-                "sha256:3c4b8ca36877fc75339253721f69603a9c7fdb5d4d5a95a1a1b899d8b86a4de2",
-                "sha256:3e382b29f8e0ccf19a2df2b29a167591245df90c0b5a2542249873b5c1d78212",
-                "sha256:42c266ced41b65ed40a282c575705325fa7991af370036d3f134518336636f5b",
-                "sha256:53fd2eb27a8ee2892614370896956af2ff61254c275aaee4c230ae771cadd885",
-                "sha256:704098302473cb31a218f1775a873b376b30b4c18229421e9e9dc8916fd16150",
-                "sha256:7df1ead20c81371ccd6091fa3e2878559b5c4d4caadaf1a484cf88d93ca06703",
-                "sha256:866c41f28cee548475f146aa4d39a51cf3b6a84246969f3759cb3e9c742fc072",
-                "sha256:a155d80ea6cee511a3694b108c4494a39f42de11ee4e61e72bc424c490e46457",
-                "sha256:adaeee09bfde366d2c13fe6093a7df5df83c9a2ba98638c7d76b010694db760e",
-                "sha256:b6fb13123aeef4a3abbcfd7e71773ff3ff1526a7d3dc538f3929a49b42be03f0",
-                "sha256:b94e4b785e304a04ea0828759172a15add27088520dc7e49ceade7834275bedb",
-                "sha256:c0df2d30ed496a08de5daed2a9ea807d07c21ae0ab23acf541ab88c24b26ab97",
-                "sha256:c6c2602dffb74867498f86e6129fd52a2770c48b7cd3ece77ada4fa38f94eba8",
-                "sha256:ceb6e0a6e27fb364fb3853389607cf7eb3a126ad335790fa1e14ed02fba50811",
-                "sha256:d9dd839eb0dc1bbe866a288ba3c1afc33a202015d2ad83b31e875b5905a079b6",
-                "sha256:e4dab234478e3bd3ce83bac4193b2ecd9cf94e720ddd95ce69840273bf44f6de",
-                "sha256:ec4e0cd079db280b6bdabdc807047ff3e199f334050db5cbb91ba3e959a67504",
-                "sha256:ecd2c3fe726758037234c93df7e98deb257fd15c24c9180dacf1ef829da5f921",
-                "sha256:ef565033fa5a958e62796867b1df10c40263ea9ded87164d67572834e57a174d"
+                "sha256:0038b21890867793581e4cb0d810829f5fd4441aa75796b53033af3aa30430ce",
+                "sha256:1171f2e0859cfff2d366da2c7092b06130f232c636a3f7301e3feb8b41f6377d",
+                "sha256:1b06268df7eb53a8feea99cbfff77a6e2b205e70bf31743e786678ef87ee8069",
+                "sha256:1b65714dc296a7991000b6ee59a35b3f550e0073411ac9d3202f6516621ba66c",
+                "sha256:1bf752559797c897cdd2c65f7b60c2b6969ffe458417b8d947b8340cc9cec08d",
+                "sha256:300717a07ad09525401a508ef5d105e6b56646f7942eb92715a1c8d610149714",
+                "sha256:3c5b42d0815e15518b1f0990cff7a705805961613e701db60387e6fb663fe78a",
+                "sha256:4365c60266b95a3f216a3047f1d8e3f895da6c7402e9e1ddfab96393122cc58d",
+                "sha256:50c7346a46dc76a4ed88f3277d4959de8a2bd0a0fa47fa87a4cde36fe247ac05",
+                "sha256:5b56154f8c09427bae082b32275a21f500b24d93c88d69a5e82f3978018a0266",
+                "sha256:74f7eccbfd436abe9c352ad9fb65872cc0f1f0a868e9d9c44db0893440f0c697",
+                "sha256:7b3f6f557ba4afc7f2ce6d3215d5db279bcf120b3cfd0add20a5d4f4abdae5bc",
+                "sha256:8c11003aaeaf7cc2d0f1bc101c1cc9454ec4cc9cb825aef3cafff8a5fdf4c799",
+                "sha256:8ca7f8c4b1584d63c9a0f827c37ba7a47226c19a23a753d52e5b5eddb201afcd",
+                "sha256:c89702cac5b302f0c5d33b172d2b55b5df2bede3344a2fbed99ff96bddb2cf00",
+                "sha256:d8f1ff62f7a879c9fe5917b3f9eb93a79b78aad47b533911b853a757223f72e7",
+                "sha256:d9d2b84b2007cea426e327d2483238f040c49405a6bf4074f605f0156c91a47a",
+                "sha256:e839191b8da5b4e5d805f940537efcaa13ea5dd98418f06dc585d2891d228cf0",
+                "sha256:f9fe20d0872b26c4bba1c1be02c5340de1019530302cf2dcc85c7f9fc3252ae0",
+                "sha256:ff3bf387c14c805ab1388185dd22d6b210824e164d4bb324b195ff34e322d166"
             ],
             "index": "pypi",
-            "version": "==0.910"
+            "version": "==0.931"
         },
         "mypy-extensions": {
             "hashes": [
@@ -1771,11 +1811,11 @@
         },
         "platformdirs": {
             "hashes": [
-                "sha256:367a5e80b3d04d2428ffa76d33f124cf11e8fff2acdaa9b43d545f5c7d661ef2",
-                "sha256:8868bbe3c3c80d42f20156f22e7131d2fb321f5bc86a2a345375c6481a67021d"
+                "sha256:1d7385c7db91728b83efd0ca99a5afb296cab9d0ed8313a45ed8ba17967ecfca",
+                "sha256:440633ddfebcc36264232365d7840a970e75e1018d15b4327d11f91909045fda"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==2.4.0"
+            "markers": "python_version >= '3.7'",
+            "version": "==2.4.1"
         },
         "plette": {
             "extras": [
@@ -1853,10 +1893,10 @@
         },
         "pyinstaller-hooks-contrib": {
             "hashes": [
-                "sha256:169b09802a19f83593114821d6ba0416a05c7071ef0ca394f7bfb7e2c0c916c8",
-                "sha256:a52bc3834281266bbf77239cfc9521923336ca622f44f90924546ed6c6d3ad5e"
+                "sha256:e47b382c209dd2f62ac2ef26cade49148e9a4702ec91958772b0270599f8c2a9",
+                "sha256:e658281cbf90570d9bc6a06f4b8f64c28d1076c722f6fb80c02a863bcbb8e7cd"
             ],
-            "version": "==2021.3"
+            "version": "==2021.5"
         },
         "pyjwt": {
             "extras": [
@@ -1871,27 +1911,19 @@
         },
         "pynacl": {
             "hashes": [
-                "sha256:06cbb4d9b2c4bd3c8dc0d267416aaed79906e7b33f114ddbf0911969794b1cc4",
-                "sha256:11335f09060af52c97137d4ac54285bcb7df0cef29014a1a4efe64ac065434c4",
-                "sha256:2fe0fc5a2480361dcaf4e6e7cea00e078fcda07ba45f811b167e3f99e8cff574",
-                "sha256:30f9b96db44e09b3304f9ea95079b1b7316b2b4f3744fe3aaecccd95d547063d",
-                "sha256:4e10569f8cbed81cb7526ae137049759d2a8d57726d52c1a000a3ce366779634",
-                "sha256:511d269ee845037b95c9781aa702f90ccc36036f95d0f31373a6a79bd8242e25",
-                "sha256:537a7ccbea22905a0ab36ea58577b39d1fa9b1884869d173b5cf111f006f689f",
-                "sha256:54e9a2c849c742006516ad56a88f5c74bf2ce92c9f67435187c3c5953b346505",
-                "sha256:757250ddb3bff1eecd7e41e65f7f833a8405fede0194319f87899690624f2122",
-                "sha256:7757ae33dae81c300487591c68790dfb5145c7d03324000433d9a2c141f82af7",
-                "sha256:7c6092102219f59ff29788860ccb021e80fffd953920c4a8653889c029b2d420",
-                "sha256:8122ba5f2a2169ca5da936b2e5a511740ffb73979381b4229d9188f6dcb22f1f",
-                "sha256:9c4a7ea4fb81536c1b1f5cc44d54a296f96ae78c1ebd2311bd0b60be45a48d96",
-                "sha256:c914f78da4953b33d4685e3cdc7ce63401247a21425c16a39760e282075ac4a6",
-                "sha256:cd401ccbc2a249a47a3a1724c2918fcd04be1f7b54eb2a5a71ff915db0ac51c6",
-                "sha256:d452a6746f0a7e11121e64625109bc4468fc3100452817001dbe018bb8b08514",
-                "sha256:ea6841bc3a76fa4942ce00f3bda7d436fda21e2d91602b9e21b7ca9ecab8f3ff",
-                "sha256:f8851ab9041756003119368c1e6cd0b9c631f46d686b3904b18c0139f4419f80"
+                "sha256:06b8f6fa7f5de8d5d2f7573fe8c863c051225a27b61e6860fd047b1775807858",
+                "sha256:0c84947a22519e013607c9be43706dd42513f9e6ae5d39d3613ca1e142fba44d",
+                "sha256:20f42270d27e1b6a29f54032090b972d97f0a1b0948cc52392041ef7831fee93",
+                "sha256:401002a4aaa07c9414132aaed7f6836ff98f59277a234704ff66878c2ee4a0d1",
+                "sha256:52cb72a79269189d4e0dc537556f4740f7f0a9ec41c1322598799b0bdad4ef92",
+                "sha256:61f642bf2378713e2c2e1de73444a3778e5f0a38be6fee0fe532fe30060282ff",
+                "sha256:8ac7448f09ab85811607bdd21ec2464495ac8b7c66d146bf545b0f08fb9220ba",
+                "sha256:a36d4a9dda1f19ce6e03c9a784a2921a4b726b02e1c736600ca9c22029474394",
+                "sha256:a422368fc821589c228f4c49438a368831cb5bbc0eab5ebe1d7fac9dded6567b",
+                "sha256:e46dae94e34b085175f8abb3b0aaa7da40767865ac82c928eeb9e57e1ea8a543"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==1.4.0"
+            "markers": "python_version >= '3.6'",
+            "version": "==1.5.0"
         },
         "pyparsing": {
             "hashes": [
@@ -1974,23 +2006,38 @@
         },
         "regex": {
             "hashes": [
+                "sha256:0416f7399e918c4b0e074a0f66e5191077ee2ca32a0f99d4c187a62beb47aa05",
                 "sha256:05b7d6d7e64efe309972adab77fc2af8907bb93217ec60aa9fe12a0dad35874f",
                 "sha256:0617383e2fe465732af4509e61648b77cbe3aee68b6ac8c0b6fe934db90be5cc",
                 "sha256:07856afef5ffcc052e7eccf3213317fbb94e4a5cd8177a2caa69c980657b3cb4",
+                "sha256:0f594b96fe2e0821d026365f72ac7b4f0b487487fb3d4aaf10dd9d97d88a9737",
+                "sha256:139a23d1f5d30db2cc6c7fd9c6d6497872a672db22c4ae1910be22d4f4b2068a",
                 "sha256:162abfd74e88001d20cb73ceaffbfe601469923e875caf9118333b1a4aaafdc4",
                 "sha256:2207ae4f64ad3af399e2d30dde66f0b36ae5c3129b52885f1bffc2f05ec505c8",
+                "sha256:2409b5c9cef7054dde93a9803156b411b677affc84fca69e908b1cb2c540025d",
+                "sha256:2fee3ed82a011184807d2127f1733b4f6b2ff6ec7151d83ef3477f3b96a13d03",
                 "sha256:30ab804ea73972049b7a2a5c62d97687d69b5a60a67adca07eb73a0ddbc9e29f",
+                "sha256:3598893bde43091ee5ca0a6ad20f08a0435e93a69255eeb5f81b85e81e329264",
                 "sha256:3b5df18db1fccd66de15aa59c41e4f853b5df7550723d26aa6cb7f40e5d9da5a",
                 "sha256:3c5fb32cc6077abad3bbf0323067636d93307c9fa93e072771cf9a64d1c0f3ef",
                 "sha256:416c5f1a188c91e3eb41e9c8787288e707f7d2ebe66e0a6563af280d9b68478f",
+                "sha256:42b50fa6666b0d50c30a990527127334d6b96dd969011e843e726a64011485da",
                 "sha256:432bd15d40ed835a51617521d60d0125867f7b88acf653e4ed994a1f8e4995dc",
+                "sha256:473e67837f786404570eae33c3b64a4b9635ae9f00145250851a1292f484c063",
                 "sha256:4aaa4e0705ef2b73dd8e36eeb4c868f80f8393f5f4d855e94025ce7ad8525f50",
+                "sha256:50a7ddf3d131dc5633dccdb51417e2d1910d25cbcf842115a3a5893509140a3a",
+                "sha256:529801a0d58809b60b3531ee804d3e3be4b412c94b5d267daa3de7fadef00f49",
                 "sha256:537ca6a3586931b16a85ac38c08cc48f10fc870a5b25e51794c74df843e9966d",
                 "sha256:53db2c6be8a2710b359bfd3d3aa17ba38f8aa72a82309a12ae99d3c0c3dcd74d",
                 "sha256:5537f71b6d646f7f5f340562ec4c77b6e1c915f8baae822ea0b7e46c1f09b733",
+                "sha256:563d5f9354e15e048465061509403f68424fef37d5add3064038c2511c8f5e00",
+                "sha256:5d408a642a5484b9b4d11dea15a489ea0928c7e410c7525cd892f4d04f2f617b",
+                "sha256:61600a7ca4bcf78a96a68a27c2ae9389763b5b94b63943d5158f2a377e09d29a",
                 "sha256:6650f16365f1924d6014d2ea770bde8555b4a39dc9576abb95e3cd1ff0263b36",
                 "sha256:666abff54e474d28ff42756d94544cdfd42e2ee97065857413b72e8a2d6a6345",
                 "sha256:68a067c11463de2a37157930d8b153005085e42bcb7ad9ca562d77ba7d1404e0",
+                "sha256:6e1d2cc79e8dae442b3fa4a26c5794428b98f81389af90623ffcc650ce9f6732",
+                "sha256:74cbeac0451f27d4f50e6e8a8f3a52ca074b5e2da9f7b505c4201a57a8ed6286",
                 "sha256:780b48456a0f0ba4d390e8b5f7c661fdd218934388cde1a974010a965e200e12",
                 "sha256:788aef3549f1924d5c38263104dae7395bf020a42776d5ec5ea2b0d3d85d6646",
                 "sha256:7ee1227cf08b6716c85504aebc49ac827eb88fcc6e51564f010f11a406c0a667",
@@ -2000,24 +2047,34 @@
                 "sha256:9345b6f7ee578bad8e475129ed40123d265464c4cfead6c261fd60fc9de00bcf",
                 "sha256:93a5051fcf5fad72de73b96f07d30bc29665697fb8ecdfbc474f3452c78adcf4",
                 "sha256:962b9a917dd7ceacbe5cd424556914cb0d636001e393b43dc886ba31d2a1e449",
+                "sha256:96fc32c16ea6d60d3ca7f63397bff5c75c5a562f7db6dec7d412f7c4d2e78ec0",
                 "sha256:98ba568e8ae26beb726aeea2273053c717641933836568c2a0278a84987b2a1a",
                 "sha256:a3feefd5e95871872673b08636f96b61ebef62971eab044f5124fb4dea39919d",
+                "sha256:a955b747d620a50408b7fdf948e04359d6e762ff8a85f5775d907ceced715129",
                 "sha256:b43c2b8a330a490daaef5a47ab114935002b13b3f9dc5da56d5322ff218eeadb",
                 "sha256:b483c9d00a565633c87abd0aaf27eb5016de23fed952e054ecc19ce32f6a9e7e",
+                "sha256:b9ed0b1e5e0759d6b7f8e2f143894b2a7f3edd313f38cf44e1e15d360e11749b",
                 "sha256:ba05430e819e58544e840a68b03b28b6d328aff2e41579037e8bab7653b37d83",
+                "sha256:ca49e1ab99593438b204e00f3970e7a5f70d045267051dfa6b5f4304fcfa1dbf",
                 "sha256:ca5f18a75e1256ce07494e245cdb146f5a9267d3c702ebf9b65c7f8bd843431e",
+                "sha256:cd410a1cbb2d297c67d8521759ab2ee3f1d66206d2e4328502a487589a2cb21b",
+                "sha256:ce298e3d0c65bd03fa65ffcc6db0e2b578e8f626d468db64fdf8457731052942",
                 "sha256:d5ca078bb666c4a9d1287a379fe617a6dccd18c3e8a7e6c7e1eb8974330c626a",
+                "sha256:d5fd67df77bab0d3f4ea1d7afca9ef15c2ee35dfb348c7b57ffb9782a6e4db6e",
                 "sha256:da1a90c1ddb7531b1d5ff1e171b4ee61f6345119be7351104b67ff413843fe94",
                 "sha256:dba70f30fd81f8ce6d32ddeef37d91c8948e5d5a4c63242d16a2b2df8143aafc",
+                "sha256:dc07f021ee80510f3cd3af2cad5b6a3b3a10b057521d9e6aaeb621730d320c5a",
                 "sha256:dd33eb9bdcfbabab3459c9ee651d94c842bc8a05fabc95edf4ee0c15a072495e",
                 "sha256:e0538c43565ee6e703d3a7c3bdfe4037a5209250e8502c98f20fea6f5fdf2965",
                 "sha256:e1f54b9b4b6c53369f40028d2dd07a8c374583417ee6ec0ea304e710a20f80a0",
                 "sha256:e32d2a2b02ccbef10145df9135751abea1f9f076e67a4e261b05f24b94219e36",
+                "sha256:e6096b0688e6e14af6a1b10eaad86b4ff17935c49aa774eac7c95a57a4e8c296",
                 "sha256:e71255ba42567d34a13c03968736c5d39bb4a97ce98188fafb27ce981115beec",
                 "sha256:ed2e07c6a26ed4bea91b897ee2b0835c21716d9a469a96c3e878dc5f8c55bb23",
                 "sha256:eef2afb0fd1747f33f1ee3e209bce1ed582d1896b240ccc5e2697e3275f037c7",
                 "sha256:f23222527b307970e383433daec128d769ff778d9b29343fb3496472dc20dabe",
                 "sha256:f341ee2df0999bfdf7a95e448075effe0db212a59387de1a70690e4acb03d4c6",
+                "sha256:f5be7805e53dafe94d295399cfbe5227f39995a997f4fd8539bf3cbdc8f47ca8",
                 "sha256:f7f325be2804246a75a4f45c72d4ce80d2443ab815063cdf70ee8fb2ca59ee1b",
                 "sha256:f8af619e3be812a2059b212064ea7a640aff0568d972cd1b9e920837469eb3cb",
                 "sha256:fa8c626d6441e2d04b6ee703ef2d1e17608ad44c7cb75258c09dd42bacdfc64b",
@@ -2028,11 +2085,11 @@
         },
         "requests": {
             "hashes": [
-                "sha256:6c1246513ecd5ecd4528a0906f910e8f0f9c6b8ec72030dc9fd154dc1a6efd24",
-                "sha256:b8aa58f8cf793ffd8782d3d8cb19e66ef36f7aba4353eec859e74678b01b07a7"
+                "sha256:68d7c56fd5a8999887728ef304a6d12edc7be74f1cfa47714fc8b414525c9a61",
+                "sha256:f22fa1e554c9ddfd16e6e41ac79759e17be9e492b3587efa038054674760e72d"
             ],
             "index": "pypi",
-            "version": "==2.26.0"
+            "version": "==2.27.1"
         },
         "requests-mock": {
             "extras": [
@@ -2086,44 +2143,44 @@
         },
         "tomli": {
             "hashes": [
-                "sha256:c6ce0015eb38820eaf32b5db832dbc26deb3dd427bd5f6556cf0acac2c214fee",
-                "sha256:f04066f68f5554911363063a30b108d2b5a5b1a010aa8b6132af78489fe3aade"
+                "sha256:b5bde28da1fed24b9bd1d4d2b8cba62300bfb4ec9a6187a957e8ddb9434c5224",
+                "sha256:c292c34f58502a1eb2bbb9f5bbc9a5ebc37bee10ffb8c2d6bbdfa8eb13cc14e1"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==1.2.2"
+            "version": "==2.0.0"
         },
         "tomlkit": {
             "hashes": [
-                "sha256:173ad840fa5d2aac140528ca1933c29791b79a374a0861a80347f42ec9328117",
-                "sha256:d7a454f319a7e9bd2e249f239168729327e4dd2d27b17dc68be264ad1ce36754"
+                "sha256:29e84a855712dfe0e88a48f6d05c21118dbafb283bb2eed614d46f80deb8e9a1",
+                "sha256:b824e3466f1d475b2b5f1c392954c6cb7ea04d64354ff7300dc7c14257dc85db"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==0.7.2"
+            "markers": "python_version >= '3.6' and python_version < '4'",
+            "version": "==0.8.0"
         },
         "typed-ast": {
             "hashes": [
-                "sha256:14fed8820114a389a2b7e91624db5f85f3f6682fda09fe0268a59aabd28fe5f5",
-                "sha256:155b74b078be842d2eb630dd30a280025eca0a5383c7d45853c27afee65f278f",
-                "sha256:224afecb8b39739f5c9562794a7c98325cb9d972712e1a98b6989a4720219541",
-                "sha256:361b9e5d27bd8e3ccb6ea6ad6c4f3c0be322a1a0f8177db6d56264fa0ae40410",
-                "sha256:37ba2ab65a0028b1a4f2b61a8fe77f12d242731977d274a03d68ebb751271508",
-                "sha256:49af5b8f6f03ed1eb89ee06c1d7c2e7c8e743d720c3746a5857609a1abc94c94",
-                "sha256:51040bf45aacefa44fa67fb9ebcd1f2bec73182b99a532c2394eea7dabd18e24",
-                "sha256:52ca2b2b524d770bed7a393371a38e91943f9160a190141e0df911586066ecda",
-                "sha256:618912cbc7e17b4aeba86ffe071698c6e2d292acbd6d1d5ec1ee724b8c4ae450",
-                "sha256:65c81abbabda7d760df7304d843cc9dbe7ef5d485504ca59a46ae2d1731d2428",
-                "sha256:7b310a207ee9fde3f46ba327989e6cba4195bc0c8c70a158456e7b10233e6bed",
-                "sha256:7e6731044f748340ef68dcadb5172a4b1f40847a2983fe3983b2a66445fbc8e6",
-                "sha256:806e0c7346b9b4af8c62d9a29053f484599921a4448c37fbbcbbf15c25138570",
-                "sha256:a67fd5914603e2165e075f1b12f5a8356bfb9557e8bfb74511108cfbab0f51ed",
-                "sha256:e4374a76e61399a173137e7984a1d7e356038cf844f24fd8aea46c8029a2f712",
-                "sha256:e8a9b9c87801cecaad3b4c2b8876387115d1a14caa602c1618cedbb0cb2a14e6",
-                "sha256:ea517c2bb11c5e4ba7a83a91482a2837041181d57d3ed0749a6c382a2b6b7086",
-                "sha256:ec184dfb5d3d11e82841dbb973e7092b75f306b625fad7b2e665b64c5d60ab3f",
-                "sha256:ff4ad88271aa7a55f19b6a161ed44e088c393846d954729549e3cde8257747bb"
+                "sha256:24058827d8f5d633f97223f5148a7d22628099a3d2efe06654ce872f46f07cdb",
+                "sha256:256115a5bc7ea9e665c6314ed6671ee2c08ca380f9d5f130bd4d2c1f5848d695",
+                "sha256:38cf5c642fa808300bae1281460d4f9b7617cf864d4e383054a5ef336e344d32",
+                "sha256:484137cab8ecf47e137260daa20bafbba5f4e3ec7fda1c1e69ab299b75fa81c5",
+                "sha256:4f30a2bcd8e68adbb791ce1567fdb897357506f7ea6716f6bbdd3053ac4d9471",
+                "sha256:591bc04e507595887160ed7aa8d6785867fb86c5793911be79ccede61ae96f4d",
+                "sha256:5b6ab14c56bc9c7e3c30228a0a0b54b915b1579613f6e463ba6f4eb1382e7fd4",
+                "sha256:5d8314c92414ce7481eee7ad42b353943679cf6f30237b5ecbf7d835519e1212",
+                "sha256:71dcda943a471d826ea930dd449ac7e76db7be778fcd722deb63642bab32ea3f",
+                "sha256:7c42707ab981b6cf4b73490c16e9d17fcd5227039720ca14abe415d39a173a30",
+                "sha256:9caaf2b440efb39ecbc45e2fabde809cbe56272719131a6318fd9bf08b58e2cb",
+                "sha256:a2b8d7007f6280e36fa42652df47087ac7b0a7d7f09f9468f07792ba646aac2d",
+                "sha256:a6d495c1ef572519a7bac9534dbf6d94c40e5b6a608ef41136133377bba4aa08",
+                "sha256:a80d84f535642420dd17e16ae25bb46c7f4c16ee231105e7f3eb43976a89670a",
+                "sha256:b53ae5de5500529c76225d18eeb060efbcec90ad5e030713fe8dab0fb4531631",
+                "sha256:b6d17f37f6edd879141e64a5db17b67488cfeffeedad8c5cec0392305e9bc775",
+                "sha256:c9bcad65d66d594bffab8575f39420fe0ee96f66e23c4d927ebb4e24354ec1af",
+                "sha256:ca9e8300d8ba0b66d140820cf463438c8e7b4cdc6fd710c059bfcfb1531d03fb",
+                "sha256:de4ecae89c7d8b56169473e08f6bfd2df7f95015591f43126e4ea7865928677e"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==1.5.0"
+            "version": "==1.5.1"
         },
         "typing-extensions": {
             "hashes": [
@@ -2136,11 +2193,11 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:4987c65554f7a2dbf30c18fd48778ef124af6fab771a377103da0585e2336ece",
-                "sha256:c4fdf4019605b6e5423637e01bc9fe4daef873709a7973e195ceba0a62bbc844"
+                "sha256:000ca7f471a233c2251c6c7023ee85305721bfdf18621ebff4fd17a8653427ed",
+                "sha256:0e7c33d9a63e7ddfcb86780aac87befc2fbddf46c58dbb487e0855f7ceec283c"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4.0'",
-            "version": "==1.26.7"
+            "version": "==1.26.8"
         },
         "vistir": {
             "hashes": [
@@ -2152,11 +2209,11 @@
         },
         "wheel": {
             "hashes": [
-                "sha256:21014b2bd93c6d0034b6ba5d35e4eb284340e09d63c59aef6fc14b0f346146fd",
-                "sha256:e2ef7239991699e3355d54f8e968a21bb940a1dbf34a4d226741e64462516fad"
+                "sha256:4bdcd7d840138086126cd09254dc6195fb4fc6f01c050a1d7236f2630db1d22a",
+                "sha256:e9a504e793efbca1b8e0e9cb979a249cf4a0a7b5b8c9e8b65a5e39d49529c1c4"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==0.37.0"
+            "version": "==0.37.1"
         },
         "wrapt": {
             "hashes": [

--- a/modules/aws_k8s_base/aws_k8s_base.py
+++ b/modules/aws_k8s_base/aws_k8s_base.py
@@ -2,13 +2,12 @@ from typing import TYPE_CHECKING, Optional
 
 import mypy_boto3_elbv2.type_defs
 from kubernetes.client import CoreV1Api, V1ConfigMap
-from kubernetes.config import load_kube_config
 from mypy_boto3_elbv2 import ElasticLoadBalancingv2Client
 from ruamel.yaml.compat import StringIO
 
 from modules.base import AWSK8sModuleProcessor, K8sBaseModuleProcessor
 from opta.core.aws import AWS
-from opta.core.kubernetes import configure_kubectl, list_namespaces
+from opta.core.kubernetes import configure_kubectl, list_namespaces, load_opta_kube_config
 from opta.core.terraform import Terraform
 from opta.exceptions import UserErrors
 from opta.utils import yaml
@@ -84,7 +83,7 @@ class AwsK8sBaseProcessor(AWSK8sModuleProcessor, K8sBaseModuleProcessor):
             return
         Terraform.download_state(self.layer)
         configure_kubectl(self.layer)
-        load_kube_config()
+        load_opta_kube_config()
         v1 = CoreV1Api()
         aws_auth_config_map: V1ConfigMap = v1.read_namespaced_config_map(
             "aws-auth", "kube-system"

--- a/modules/aws_k8s_base/tests/test_aws_k8sbase.py
+++ b/modules/aws_k8s_base/tests/test_aws_k8sbase.py
@@ -25,7 +25,7 @@ class TestAwsK8sBaseProcessor:
 
         mocker.patch("modules.aws_k8s_base.aws_k8s_base.Terraform")
         mocker.patch("modules.aws_k8s_base.aws_k8s_base.configure_kubectl")
-        mocker.patch("modules.aws_k8s_base.aws_k8s_base.load_kube_config")
+        mocker.patch("modules.aws_k8s_base.aws_k8s_base.load_opta_kube_config")
 
         mocked_core_v1_api = mocker.Mock()
         mocker.patch(

--- a/modules/datadog/datadog.py
+++ b/modules/datadog/datadog.py
@@ -3,11 +3,10 @@ from typing import TYPE_CHECKING
 
 import click
 from kubernetes.client import ApiException, CoreV1Api, V1Namespace, V1ObjectMeta, V1Secret
-from kubernetes.config import load_kube_config
 from requests import codes, get
 
 from modules.base import ModuleProcessor
-from opta.core.kubernetes import configure_kubectl
+from opta.core.kubernetes import configure_kubectl, load_opta_kube_config
 from opta.exceptions import UserErrors
 
 if TYPE_CHECKING:

--- a/modules/datadog/datadog.py
+++ b/modules/datadog/datadog.py
@@ -25,7 +25,7 @@ class DatadogProcessor(ModuleProcessor):
 
     def process(self, module_idx: int) -> None:
         configure_kubectl(self.layer)
-        load_kube_config()
+        load_opta_kube_config()
         v1 = CoreV1Api()
         # Update the secrets
         namespaces = v1.list_namespace(field_selector=f"metadata.name={self.layer.name}")

--- a/opta/commands/events.py
+++ b/opta/commands/events.py
@@ -3,11 +3,14 @@ from typing import Optional
 
 import click
 import pytz
-from kubernetes.config import load_kube_config
 
 from opta.amplitude import amplitude_client
 from opta.core.generator import gen_all
-from opta.core.kubernetes import configure_kubectl, tail_namespace_events
+from opta.core.kubernetes import (
+    configure_kubectl,
+    load_opta_kube_config,
+    tail_namespace_events,
+)
 from opta.layer import Layer
 
 
@@ -43,5 +46,5 @@ def events(env: Optional[str], config: str, seconds: Optional[int]) -> None:
     layer.verify_cloud_credentials()
     gen_all(layer)
     configure_kubectl(layer)
-    load_kube_config()
+    load_opta_kube_config()
     tail_namespace_events(layer, start_time)

--- a/opta/commands/kubectl.py
+++ b/opta/commands/kubectl.py
@@ -3,8 +3,8 @@ from typing import Optional
 import click
 
 from opta.amplitude import amplitude_client
-from opta.core.generator import gen_all
 from opta.core.kubernetes import configure_kubectl as configure
+from opta.core.kubernetes import load_opta_config_to_default
 from opta.layer import Layer
 from opta.utils import check_opta_file_exists
 
@@ -26,6 +26,5 @@ def configure_kubectl(config: str, env: Optional[str]) -> None:
         event_properties={"org_name": layer.org_name, "layer_name": layer.name},
     )
     layer.verify_cloud_credentials()
-    gen_all(layer)
-
     configure(layer)
+    load_opta_config_to_default(layer)

--- a/opta/commands/logs.py
+++ b/opta/commands/logs.py
@@ -1,11 +1,10 @@
 from typing import Optional
 
 import click
-from kubernetes.config import load_kube_config
 
 from opta.amplitude import amplitude_client
 from opta.core.generator import gen_all
-from opta.core.kubernetes import configure_kubectl, tail_module_log
+from opta.core.kubernetes import configure_kubectl, load_opta_kube_config, tail_module_log
 from opta.exceptions import UserErrors
 from opta.layer import Layer
 from opta.utils import check_opta_file_exists
@@ -39,7 +38,7 @@ def logs(env: Optional[str], config: str, seconds: Optional[int]) -> None:
     layer.verify_cloud_credentials()
     gen_all(layer)
     configure_kubectl(layer)
-    load_kube_config()
+    load_opta_kube_config()
     if layer.cloud == "aws":
         modules = layer.get_module_by_type("k8s-service")
     elif layer.cloud == "google":

--- a/opta/commands/shell.py
+++ b/opta/commands/shell.py
@@ -2,12 +2,11 @@ from typing import Optional
 
 import click
 from kubernetes.client import CoreV1Api
-from kubernetes.config import load_kube_config
 
 from opta.amplitude import amplitude_client
 from opta.constants import SHELLS_ALLOWED
 from opta.core.generator import gen_all
-from opta.core.kubernetes import configure_kubectl
+from opta.core.kubernetes import configure_kubectl, load_opta_kube_config
 from opta.exceptions import UserErrors
 from opta.layer import Layer
 from opta.nice_subprocess import nice_run
@@ -42,7 +41,7 @@ def shell(env: Optional[str], config: str, type: str) -> None:
     layer.verify_cloud_credentials()
     gen_all(layer)
     configure_kubectl(layer)
-    load_kube_config()
+    load_opta_kube_config()
 
     # Get a random pod in the service
     v1 = CoreV1Api()

--- a/opta/core/kubernetes.py
+++ b/opta/core/kubernetes.py
@@ -1,13 +1,17 @@
 import base64
 import datetime
 import time
+from os import makedirs
+from os.path import exists, expanduser
+from shutil import which
 from subprocess import DEVNULL  # nosec
 from threading import Thread
 from typing import TYPE_CHECKING, Dict, FrozenSet, List, Optional, Set, Tuple
 
 import boto3
-from botocore.exceptions import ClientError, NoCredentialsError
+from botocore.config import Config
 from colored import attr, fg
+from google.cloud.container_v1 import ClusterManagerClient
 from kubernetes.client import (
     ApiException,
     AppsV1Api,
@@ -28,17 +32,27 @@ from kubernetes.client import (
     V1ServiceList,
 )
 from kubernetes.config import load_kube_config
+from kubernetes.config.kube_config import (
+    ENV_KUBECONFIG_PATH_SEPARATOR,
+    KUBE_CONFIG_DEFAULT_LOCATION,
+)
 from kubernetes.watch import Watch
+from mypy_boto3_eks import EKSClient
 
+from opta.constants import yaml
 from opta.core.gcp import GCP
 from opta.core.terraform import get_terraform_outputs
 from opta.exceptions import UserErrors
 from opta.nice_subprocess import nice_run
-from opta.utils import deep_merge, fmt_msg, logger
+from opta.utils import deep_merge, logger
 from opta.utils.dependencies import ensure_installed
 
 if TYPE_CHECKING:
     from opta.layer import Layer
+
+GENERATED_KUBE_CONFIG: Optional[str] = None
+HOME = expanduser("~")
+GENERATED_KUBE_CONFIG_DIR = f"{HOME}/.opta/kubeconfigs"
 
 
 def get_required_path_executables(cloud: str) -> FrozenSet[str]:
@@ -57,6 +71,7 @@ def configure_kubectl(layer: "Layer") -> None:
     # kubectl may not *technically* be required for this opta command to run, but require
     # it anyways since user must install it to access the cluster.
     ensure_installed("kubectl")
+    makedirs(GENERATED_KUBE_CONFIG_DIR, exist_ok=True)
     if layer.cloud == "aws":
         _aws_configure_kubectl(layer)
     elif layer.cloud == "google":
@@ -75,72 +90,131 @@ def _local_configure_kubectl(layer: "Layer") -> None:
     ).stdout
 
 
+def load_opta_config_to_default(layer: "Layer") -> None:
+    config_file_name = (
+        f"{GENERATED_KUBE_CONFIG_DIR}/kubeconfig-{layer.root().name}-{layer.cloud}.yaml"
+    )
+    if not exists(config_file_name):
+        logger.debug(
+            f"Can not find opta managed kube config, {config_file_name}, to load to user default"
+        )
+        return
+    opta_config = yaml.load(open(config_file_name))
+    default_kube_config_filename = expanduser(
+        KUBE_CONFIG_DEFAULT_LOCATION.split(ENV_KUBECONFIG_PATH_SEPARATOR)[0]
+    )
+    if not exists(default_kube_config_filename):
+        with open(expanduser(default_kube_config_filename), "w") as f:
+            yaml.dump(opta_config, f)
+        return
+    default_kube_config = yaml.load(open(default_kube_config_filename))
+    opta_config_user = opta_config["users"][0]
+    opta_config_context = opta_config["contexts"][0]
+    opta_config_cluster = opta_config["clusters"][0]
+
+    user_indices = [
+        i
+        for i, x in enumerate(default_kube_config["users"])
+        if x["name"] == opta_config_user["name"]
+    ]
+    if user_indices:
+        default_kube_config["users"][user_indices[0]] = opta_config_user
+    else:
+        default_kube_config["users"].append(opta_config_user)
+
+    context_indices = [
+        i
+        for i, x in enumerate(default_kube_config["contexts"])
+        if x["name"] == opta_config_context["name"]
+    ]
+    if context_indices:
+        default_kube_config["contexts"][context_indices[0]] = opta_config_context
+    else:
+        default_kube_config["contexts"].append(opta_config_context)
+
+    cluster_indices = [
+        i
+        for i, x in enumerate(default_kube_config["clusters"])
+        if x["name"] == opta_config_cluster["name"]
+    ]
+    if cluster_indices:
+        default_kube_config["clusters"][context_indices[0]] = opta_config_cluster
+    else:
+        default_kube_config["clusters"].append(opta_config_cluster)
+
+    default_kube_config["current-context"] = opta_config_context["name"]
+    with open(default_kube_config_filename, "w") as f:
+        yaml.dump(default_kube_config, f)
+
+
 def _gcp_configure_kubectl(layer: "Layer") -> None:
     ensure_installed("gcloud")
-
-    try:
-        if GCP.using_service_account():
-            service_account_key_path = GCP.get_service_account_key_path()
-            nice_run(
-                [
-                    "gcloud",
-                    "auth",
-                    "activate-service-account",
-                    "--key-file",
-                    service_account_key_path,
-                ]
-            )
-
-        out: str = nice_run(
-            ["gcloud", "config", "get-value", "project"], check=True, capture_output=True,
-        ).stdout
-    except Exception as err:
-        raise UserErrors(
-            fmt_msg(
-                f"""
-                Running the gcloud CLI failed. Please make sure you've properly
-                configured your gcloud credentials, and recently refreshed them if
-                they're expired:
-                ~{err}
-                """
-            )
-        )
-    current_project_id = out.strip()
-
-    root_layer = layer.root()
-    env_gcp_region, env_gcp_project = _gcp_get_cluster_env(root_layer)
-    if env_gcp_project != current_project_id:
-        raise UserErrors(
-            fmt_msg(
-                f"""
-                The gcloud CLI is not configured with the right credentials to
-                access the {root_layer.name or ""} cluster.
-                ~Current GCP project: {current_project_id}
-                ~Expected GCP project: {env_gcp_project}
-                """
-            )
-        )
-
-    cluster_name = get_cluster_name(root_layer)
-
-    if cluster_name is None:
-        raise Exception(
-            "The GKE cluster name could not be determined -- please make sure it has been applied in the environment."
-        )
-
-    # Update kubeconfig with the cluster details, and also switches context
-    nice_run(
-        [
-            "gcloud",
-            "container",
-            "clusters",
-            "get-credentials",
-            cluster_name,
-            f"--region={env_gcp_region}",
-        ],
-        stdout=DEVNULL,
-        check=True,
+    config_file_name = (
+        f"{GENERATED_KUBE_CONFIG_DIR}/kubeconfig-{layer.root().name}-{layer.cloud}.yaml"
     )
+    global GENERATED_KUBE_CONFIG
+    if exists(config_file_name):
+        GENERATED_KUBE_CONFIG = config_file_name
+        return
+
+    gcp = GCP(layer=layer)
+    credentials = gcp.get_credentials()[0]
+    region, project_id = _gcp_get_cluster_env(layer.root())
+    cluster_name = get_cluster_name(layer.root())
+    gke_client = ClusterManagerClient(credentials=credentials)
+    cluster_data = gke_client.get_cluster(
+        name=f"projects/{project_id}/locations/{region}/clusters/{cluster_name}"
+    )
+
+    cluster_ca_certificate = cluster_data.master_auth.cluster_ca_certificate
+    cluster_endpoint = f"https://{cluster_data.endpoint}"
+    gcloud_path = which("gcloud")
+    kube_config_resource_name = f"{project_id}_{region}_{cluster_name}"
+
+    cluster_config = {
+        "apiVersion": "v1",
+        "kind": "Config",
+        "clusters": [
+            {
+                "cluster": {
+                    "server": cluster_endpoint,
+                    "certificate-authority-data": cluster_ca_certificate,
+                },
+                "name": kube_config_resource_name,
+            }
+        ],
+        "contexts": [
+            {
+                "context": {
+                    "cluster": kube_config_resource_name,
+                    "user": kube_config_resource_name,
+                },
+                "name": kube_config_resource_name,
+            }
+        ],
+        "current-context": kube_config_resource_name,
+        "preferences": {},
+        "users": [
+            {
+                "name": kube_config_resource_name,
+                "user": {
+                    "auth-provider": {
+                        "name": "gcp",
+                        "config": {
+                            "cmd-args": "config config-helper --format=json",
+                            "cmd-path": gcloud_path,
+                            "expiry-key": "{.credential.token_expiry}",
+                            "token-key": "{.credential.access_token}",
+                        },
+                    }
+                },
+            }
+        ],
+    }
+    with open(config_file_name, "w") as f:
+        yaml.dump(cluster_config, f)
+    GENERATED_KUBE_CONFIG = config_file_name
+    return
 
 
 def _azure_configure_kubectl(layer: "Layer") -> None:
@@ -175,44 +249,18 @@ def _azure_configure_kubectl(layer: "Layer") -> None:
 
 
 def _aws_configure_kubectl(layer: "Layer") -> None:
-    ensure_installed("aws")
+    config_file_name = (
+        f"{GENERATED_KUBE_CONFIG_DIR}/kubeconfig-{layer.root().name}-{layer.cloud}.yaml"
+    )
+    global GENERATED_KUBE_CONFIG
+    if exists(config_file_name):
+        GENERATED_KUBE_CONFIG = config_file_name
+        return
 
-    # Get the current account details from the AWS CLI.
-    try:
-        aws_caller_identity = boto3.client("sts").get_caller_identity()
-    except NoCredentialsError:
-        raise UserErrors(
-            "Unable to locate credentials.\n"
-            "Visit `https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/setup-credentials.html` "
-            "for more information."
-        )
-    except ClientError as e:
-        raise UserErrors(
-            "The AWS Credentials are not configured properly.\n"
-            f" - Code: {e.response['Error']['Code']} Error Message: {e.response['Error']['Message']}"
-            "Visit `https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/setup-credentials.html` "
-            "for more information."
-        )
-
-    current_aws_account_id = aws_caller_identity["Account"]
+    region, account_id = _aws_get_cluster_env(layer.root())
 
     # Get the environment's account details from the opta config
     root_layer = layer.root()
-    env_aws_region, env_aws_account_ids = _aws_get_cluster_env(root_layer)
-
-    # Make sure the current account points to the cluster environment
-    if str(current_aws_account_id) not in env_aws_account_ids:
-        raise UserErrors(
-            fmt_msg(
-                f"""
-                The AWS CLI is not configured with the right credentials to
-                access the {root_layer.name or ""} cluster.
-                ~Current AWS Account ID: {current_aws_account_id}
-                ~Valid AWS Account IDs: {env_aws_account_ids}
-                """
-            )
-        )
-
     cluster_name = get_cluster_name(root_layer)
 
     if cluster_name is None:
@@ -220,21 +268,62 @@ def _aws_configure_kubectl(layer: "Layer") -> None:
             "The EKS cluster name could not be determined -- please make sure it has been applied in the environment."
         )
 
-    # Update kubeconfig with the cluster details, and also switches context
-    # TODO: Change AWS to BOTO3
-    nice_run(
-        [
-            "aws",
-            "eks",
-            "update-kubeconfig",
-            "--name",
-            cluster_name,
-            "--region",
-            env_aws_region,
+    client: EKSClient = boto3.client("eks", config=Config(region_name=region))
+
+    # get cluster details
+    cluster = client.describe_cluster(name=cluster_name)
+    cluster_cert = cluster["cluster"]["certificateAuthority"]["data"]
+    cluster_ep = cluster["cluster"]["endpoint"]
+    kube_config_resource_name = f"{account_id}_{region}_{cluster_name}"
+
+    cluster_config = {
+        "apiVersion": "v1",
+        "kind": "Config",
+        "clusters": [
+            {
+                "cluster": {
+                    "server": str(cluster_ep),
+                    "certificate-authority-data": str(cluster_cert),
+                },
+                "name": kube_config_resource_name,
+            }
         ],
-        stdout=DEVNULL,
-        check=True,
-    )
+        "contexts": [
+            {
+                "context": {
+                    "cluster": kube_config_resource_name,
+                    "user": kube_config_resource_name,
+                },
+                "name": kube_config_resource_name,
+            }
+        ],
+        "current-context": kube_config_resource_name,
+        "preferences": {},
+        "users": [
+            {
+                "name": kube_config_resource_name,
+                "user": {
+                    "exec": {
+                        "apiVersion": "client.authentication.k8s.io/v1alpha1",
+                        "command": "aws",
+                        "args": [
+                            "--region",
+                            region,
+                            "eks",
+                            "get-token",
+                            "--cluster-name",
+                            cluster_name,
+                        ],
+                        "env": None,
+                    }
+                },
+            }
+        ],
+    }
+    with open(config_file_name, "w") as f:
+        yaml.dump(cluster_config, f)
+    GENERATED_KUBE_CONFIG = config_file_name
+    return
 
 
 def get_cluster_name(layer: "Layer") -> Optional[str]:
@@ -245,9 +334,9 @@ def get_cluster_name(layer: "Layer") -> Optional[str]:
     return cluster_name
 
 
-def _aws_get_cluster_env(root_layer: "Layer") -> Tuple[str, List[str]]:
+def _aws_get_cluster_env(root_layer: "Layer") -> Tuple[str, str]:
     aws_provider = root_layer.providers["aws"]
-    return aws_provider["region"], [aws_provider["account_id"]]
+    return aws_provider["region"], aws_provider["account_id"]
 
 
 def _gcp_get_cluster_env(root_layer: "Layer") -> Tuple[str, str]:
@@ -255,9 +344,13 @@ def _gcp_get_cluster_env(root_layer: "Layer") -> Tuple[str, str]:
     return googl_provider["region"], googl_provider["project"]
 
 
+def load_opta_kube_config() -> None:
+    load_kube_config(config_file=GENERATED_KUBE_CONFIG or KUBE_CONFIG_DEFAULT_LOCATION)
+
+
 def current_image_digest_tag(layer: "Layer") -> dict:
     image_info = {"digest": None, "tag": None}
-    load_kube_config()
+    load_opta_kube_config()
     apps_client = AppsV1Api()
     deployment_list: V1DeploymentList = apps_client.list_namespaced_deployment(
         namespace=layer.name
@@ -276,7 +369,7 @@ def current_image_digest_tag(layer: "Layer") -> dict:
 
 
 def create_namespace_if_not_exists(layer_name: str) -> None:
-    load_kube_config()
+    load_opta_kube_config()
     v1 = CoreV1Api()
     namespaces = v1.list_namespace(field_selector=f"metadata.name={layer_name}")
     if len(namespaces.items) == 0:
@@ -290,7 +383,7 @@ def create_namespace_if_not_exists(layer_name: str) -> None:
 
 
 def create_manual_secrets_if_not_exists(layer_name: str) -> None:
-    load_kube_config()
+    load_opta_kube_config()
     v1 = CoreV1Api()
     manual_secrets: V1SecretList = v1.list_namespaced_secret(
         layer_name, field_selector="metadata.name=manual-secrets"
@@ -302,7 +395,7 @@ def create_manual_secrets_if_not_exists(layer_name: str) -> None:
 
 
 def get_manual_secrets(layer_name: str) -> dict:
-    load_kube_config()
+    load_opta_kube_config()
     v1 = CoreV1Api()
     try:
         api_response = v1.read_namespaced_secret("manual-secrets", layer_name)
@@ -320,7 +413,7 @@ def get_manual_secrets(layer_name: str) -> dict:
 
 
 def update_manual_secrets(layer_name: str, new_values: dict) -> None:
-    load_kube_config()
+    load_opta_kube_config()
     v1 = CoreV1Api()
     create_manual_secrets_if_not_exists(layer_name)
     current_secret_object: V1Secret = v1.read_namespaced_secret(
@@ -335,7 +428,7 @@ def update_manual_secrets(layer_name: str, new_values: dict) -> None:
 
 
 def get_linked_secrets(layer_name: str) -> dict:
-    load_kube_config()
+    load_opta_kube_config()
     v1 = CoreV1Api()
     try:
         api_response = v1.read_namespaced_secret("secret", layer_name)
@@ -353,7 +446,7 @@ def get_linked_secrets(layer_name: str) -> dict:
 
 
 def list_namespaces() -> None:
-    load_kube_config()
+    load_opta_kube_config()
     v1 = CoreV1Api()
     try:
         v1.list_namespace()
@@ -372,7 +465,7 @@ def list_persistent_volume_claims(
     :param str namespace: namespace to search in. If not set, search all namespaces
     :param bool opta_managed: filter to only returned objects managed by opta
     """
-    load_kube_config()
+    load_opta_kube_config()
     v1 = CoreV1Api()
 
     if namespace:
@@ -404,7 +497,7 @@ def delete_persistent_volume_claim(
     :param str name: name of the PersistentVolumeClaim (required)
     :param bool async_req: execute request asynchronously
     """
-    load_kube_config()
+    load_opta_kube_config()
     v1 = CoreV1Api()
 
     try:
@@ -456,7 +549,7 @@ def delete_persistent_volume_claims(
 
 
 def list_services(*, namespace: Optional[str] = None) -> List[V1Service]:
-    load_kube_config()
+    load_opta_kube_config()
     v1 = CoreV1Api()
 
     services: V1ServiceList
@@ -469,7 +562,7 @@ def list_services(*, namespace: Optional[str] = None) -> List[V1Service]:
 
 
 def get_config_map(namespace: str, name: str) -> V1ConfigMap:
-    load_kube_config()
+    load_opta_kube_config()
     v1 = CoreV1Api()
     try:
         cm: V1ConfigMap = v1.read_namespaced_config_map(name, namespace)
@@ -483,7 +576,7 @@ def get_config_map(namespace: str, name: str) -> V1ConfigMap:
 
 
 def update_config_map_data(namespace: str, name: str, data: Dict[str, str]) -> None:
-    load_kube_config()
+    load_opta_kube_config()
     v1 = CoreV1Api()
 
     # Pulled from https://github.com/kubernetes-client/python/issues/1549#issuecomment-921611078
@@ -513,7 +606,7 @@ def tail_module_log(
     start_color_idx: int = 1,
 ) -> None:
     current_pods_monitored: Set[str] = set()
-    load_kube_config()
+    load_opta_kube_config()
     v1 = CoreV1Api()
     watch = Watch()
     count = 0
@@ -594,7 +687,7 @@ def tail_namespace_events(
     earliest_event_start_time: Optional[datetime.datetime] = None,
     color_idx: int = 1,
 ) -> None:
-    load_kube_config()
+    load_opta_kube_config()
     v1 = CoreV1Api()
     watch = Watch()
     print(f"{fg(color_idx)}Showing events for namespace {layer.name}{attr(0)}")

--- a/tests/commands/test_kubectl.py
+++ b/tests/commands/test_kubectl.py
@@ -1,5 +1,3 @@
-from subprocess import CompletedProcess
-
 from click.testing import CliRunner
 from pytest_mock import MockFixture
 
@@ -33,43 +31,3 @@ def test_configure_kubectl(mocker: MockFixture) -> None:
     mocked_configure.assert_called_once_with(mocked_layer)
     mocked_load_opta_config_to_default.assert_called_once_with(mocked_layer)
     mocked_check_opta_file_exists.assert_called_once_with("opta.yaml")
-
-    # # Mock that the kubectl and aws comamnds exist in the env.
-    # mocked_ensure_installed = mocker.patch("opta.core.kubernetes.ensure_installed")
-    #
-    # # Mock aws commands, including fetching the current aws account id.
-    # fake_aws_account_id = 1234567890123
-    # mock_eks_client = mocker.Mock()
-    # mocker.patch("opta.core.kubernetes.boto3.client", return_value=mock_eks_client)
-    # mock_eks_client.describe_cluster.return_value = {
-    #     "cluster": {
-    #         "certificateAuthority": {"data": "ca-data"},
-    #         "endpoint": "eks-endpoint",
-    #     }
-    # }
-    # mocked_update_kubeconfig = "Updated context arn... in ../.kube/config"
-    # mocker.patch(
-    #     "opta.core.kubernetes.nice_run",
-    #     side_effect=[
-    #         CompletedProcess(
-    #             None, 0, mocked_update_kubeconfig.encode("utf-8")  # type: ignore
-    #         ),
-    #     ],
-    # )
-    #
-    # # Mock fetching the opta env aws account id.
-    # mocker.patch(
-    #     "opta.core.kubernetes._aws_get_cluster_env",
-    #     return_value=("us-east-1", [f"{fake_aws_account_id}"]),
-    # )
-    # # Mock fetching the cluster name
-    # mocker.patch(
-    #     "opta.core.kubernetes.get_terraform_outputs",
-    #     return_value={"parent.k8s_cluster_name": "main"},
-    # )
-    #
-    # runner = CliRunner()
-    # result = runner.invoke(configure_kubectl, [])
-    # mocked_layer_class.load_from_yaml.assert_called_with("opta.yaml", None)
-    # mocked_ensure_installed.assert_has_calls([mocker.call("kubectl")])
-    # assert result.exit_code == 0

--- a/tests/commands/test_kubectl.py
+++ b/tests/commands/test_kubectl.py
@@ -8,10 +8,6 @@ from opta.layer import Layer
 
 
 def test_configure_kubectl(mocker: MockFixture) -> None:
-    # Opta file check
-    mocked_os_path_exists = mocker.patch("opta.utils.os.path.exists")
-    mocked_os_path_exists.return_value = True
-
     # Mock tf file generation
     mocked_layer_class = mocker.patch("opta.commands.kubectl.Layer")
     mocked_layer = mocker.Mock(spec=Layer)
@@ -20,76 +16,60 @@ def test_configure_kubectl(mocker: MockFixture) -> None:
     mocked_layer.org_name = "dummy_org_name"
     mocked_layer_class.load_from_yaml.return_value = mocked_layer
     mocked_layer.root.return_value = mocked_layer
-    mocker.patch("opta.commands.kubectl.gen_all")
 
-    # Mock that the kubectl and aws comamnds exist in the env.
-    mocked_ensure_installed = mocker.patch("opta.core.kubernetes.ensure_installed")
-
-    # Mock aws commands, including fetching the current aws account id.
-    fake_aws_account_id = 1234567890123
-    mock_aws_client_instance = mocker.Mock()
-    mock_aws_get_caller_identity = {
-        "UserId": "mocked_user_id:jd@runx.dev",
-        "Account": "1234567890123",
-        "Arn": "mocked_arn",
-    }
-    mock_sts_client = mocker.patch(
-        "opta.core.kubernetes.boto3.client", return_value=mock_aws_client_instance
+    mocked_configure = mocker.patch("opta.commands.kubectl.configure")
+    mocked_check_opta_file_exists = mocker.patch(
+        "opta.commands.kubectl.check_opta_file_exists"
     )
-    mock_aws_client_instance.get_caller_identity.return_value = (
-        mock_aws_get_caller_identity
-    )
-    mocked_update_kubeconfig = "Updated context arn... in ../.kube/config"
-    mocker.patch(
-        "opta.core.kubernetes.nice_run",
-        side_effect=[
-            CompletedProcess(
-                None, 0, mocked_update_kubeconfig.encode("utf-8")  # type: ignore
-            ),
-        ],
-    )
-
-    # Mock fetching the opta env aws account id.
-    mocker.patch(
-        "opta.core.kubernetes._aws_get_cluster_env",
-        return_value=("us-east-1", [f"{fake_aws_account_id}"]),
-    )
-    # Mock fetching the cluster name
-    mocker.patch(
-        "opta.core.kubernetes.get_terraform_outputs",
-        return_value={"parent.k8s_cluster_name": "main"},
+    mocked_load_opta_config_to_default = mocker.patch(
+        "opta.commands.kubectl.load_opta_config_to_default"
     )
 
     runner = CliRunner()
     result = runner.invoke(configure_kubectl, [])
-    mocked_layer_class.load_from_yaml.assert_called_with("opta.yaml", None)
-    mock_sts_client.assert_called()
-    mocked_ensure_installed.assert_has_calls([mocker.call("kubectl"), mocker.call("aws")])
     assert result.exit_code == 0
+    mocked_layer_class.load_from_yaml.assert_called_with(mocker.ANY, None)
+    mocked_layer.verify_cloud_credentials.assert_called_once_with()
+    mocked_configure.assert_called_once_with(mocked_layer)
+    mocked_load_opta_config_to_default.assert_called_once_with(mocked_layer)
+    mocked_check_opta_file_exists.assert_called_once_with("opta.yaml")
 
-    # If the current aws account id does not match the specified opta env's, then
-    # raise an exception.
-    mock_aws_client_instance = mocker.Mock()
-    mock_aws_get_caller_identity = {
-        "UserId": "mocked_user_id:jd@runx.dev",
-        "Account": "999999999999",
-        "Arn": "mocked_arn",
-    }
-    mock_sts_client = mocker.patch(
-        "opta.core.kubernetes.boto3.client", return_value=mock_aws_client_instance
-    )
-    mock_aws_client_instance.get_caller_identity.return_value = (
-        mock_aws_get_caller_identity
-    )
-    mocker.patch(
-        "opta.core.kubernetes.nice_run",
-        side_effect=[
-            CompletedProcess(
-                None, 0, mocked_update_kubeconfig.encode("utf-8")  # type: ignore
-            ),
-        ],
-    )
-    result = runner.invoke(configure_kubectl, [])
-    mock_sts_client.assert_called()
-    assert result.exit_code == 1
-    assert "is not configured with the right credentials" in str(result.exception)
+    # # Mock that the kubectl and aws comamnds exist in the env.
+    # mocked_ensure_installed = mocker.patch("opta.core.kubernetes.ensure_installed")
+    #
+    # # Mock aws commands, including fetching the current aws account id.
+    # fake_aws_account_id = 1234567890123
+    # mock_eks_client = mocker.Mock()
+    # mocker.patch("opta.core.kubernetes.boto3.client", return_value=mock_eks_client)
+    # mock_eks_client.describe_cluster.return_value = {
+    #     "cluster": {
+    #         "certificateAuthority": {"data": "ca-data"},
+    #         "endpoint": "eks-endpoint",
+    #     }
+    # }
+    # mocked_update_kubeconfig = "Updated context arn... in ../.kube/config"
+    # mocker.patch(
+    #     "opta.core.kubernetes.nice_run",
+    #     side_effect=[
+    #         CompletedProcess(
+    #             None, 0, mocked_update_kubeconfig.encode("utf-8")  # type: ignore
+    #         ),
+    #     ],
+    # )
+    #
+    # # Mock fetching the opta env aws account id.
+    # mocker.patch(
+    #     "opta.core.kubernetes._aws_get_cluster_env",
+    #     return_value=("us-east-1", [f"{fake_aws_account_id}"]),
+    # )
+    # # Mock fetching the cluster name
+    # mocker.patch(
+    #     "opta.core.kubernetes.get_terraform_outputs",
+    #     return_value={"parent.k8s_cluster_name": "main"},
+    # )
+    #
+    # runner = CliRunner()
+    # result = runner.invoke(configure_kubectl, [])
+    # mocked_layer_class.load_from_yaml.assert_called_with("opta.yaml", None)
+    # mocked_ensure_installed.assert_has_calls([mocker.call("kubectl")])
+    # assert result.exit_code == 0

--- a/tests/commands/test_logs.py
+++ b/tests/commands/test_logs.py
@@ -19,7 +19,7 @@ def test_logs(mocker: MockFixture) -> None:
     mocked_layer_class.load_from_yaml.return_value = mocked_layer
     layer_gen_all = mocker.patch("opta.commands.logs.gen_all")
     configure_kubectl = mocker.patch("opta.commands.logs.configure_kubectl")
-    load_kube_config = mocker.patch("opta.commands.logs.load_kube_config")
+    load_kube_config = mocker.patch("opta.commands.logs.load_opta_kube_config")
 
     mocked_module = mocker.Mock(spec=Module)
     mocked_module.type = "k8s-service"

--- a/tests/commands/test_shell.py
+++ b/tests/commands/test_shell.py
@@ -17,7 +17,7 @@ def test_shell(mocker: MockFixture) -> None:
     mocked_layer_class.load_from_yaml.return_value = mocked_layer
     layer_gen_all = mocker.patch("opta.commands.shell.gen_all")
     configure_kubectl = mocker.patch("opta.commands.shell.configure_kubectl")
-    load_kube_config = mocker.patch("opta.commands.shell.load_kube_config")
+    load_kube_config = mocker.patch("opta.commands.shell.load_opta_kube_config")
 
     mocked_core_v1_api_class = mocker.patch("opta.commands.shell.CoreV1Api")
     mocked_core_v1_api = mocker.Mock(spec=CoreV1Api)
@@ -68,7 +68,7 @@ def test_shell_with_sh(mocker: MockFixture) -> None:
     mocked_layer_class.load_from_yaml.return_value = mocked_layer
     layer_gen_all = mocker.patch("opta.commands.shell.gen_all")
     configure_kubectl = mocker.patch("opta.commands.shell.configure_kubectl")
-    load_kube_config = mocker.patch("opta.commands.shell.load_kube_config")
+    load_kube_config = mocker.patch("opta.commands.shell.load_opta_kube_config")
 
     mocked_core_v1_api_class = mocker.patch("opta.commands.shell.CoreV1Api")
     mocked_core_v1_api = mocker.Mock(spec=CoreV1Api)


### PR DESCRIPTION
# Description
OK, so here is the situation:
Everytime we need to setup the kubectl config to use the cluster created in the current environment (and we do this in many places just to be sure it's done well) it used to take an insane amount of time (~2 seconds) because of API requests. However, we realized that this doesn't need to be the case as the data fetched in these requests for aws and gcp is practically idempotent. We're doing expensive requests to get the data which we already have, and furthermore tainting the user's kubeconfig without their knowledge by doing so.

So this is the solution:
We keep kubeconfig cache files for each environment encountered in the hidden ~/.opta directory. We tell all our functions to use the current such file for the kubernetes config to be used in the HTTP requests, and if the user wants thay can add it to the user-managed default ~/.kube/config files via the configure kubectl command


# Safety checklist
* [x] This change is backwards compatible and safe to apply by existing users
* [x] This change will NOT lead to data loss
* [x] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
manually run for aws, gcp and azure dummy environments
