### PR TITLE
More speedup fixes

### DIFF
--- a/modules/aws_k8s_base/aws_k8s_base.py
+++ b/modules/aws_k8s_base/aws_k8s_base.py
@@ -42,7 +42,6 @@ class AwsK8sBaseProcessor(AWSK8sModuleProcessor, K8sBaseModuleProcessor):
                 "certificate_chain"
             ] = f"${{{{module.{byo_cert_module.name}.certificate_chain}}}}"
 
-        Terraform.download_state(self.layer)
         configure_kubectl(self.layer)
         self._process_nginx_extra_ports(self.module.data)
 

--- a/opta/core/plan_displayer.py
+++ b/opta/core/plan_displayer.py
@@ -112,13 +112,16 @@ class PlanDisplayer:
 
     @staticmethod
     def display(detailed_plan: bool = False) -> None:
-        regular_plan = Terraform.show(TF_PLAN_PATH, capture_output=True)
-        CURRENT_CRASH_REPORTER.tf_plan_text = ansi_scrub(regular_plan or "")
         if detailed_plan:
+            regular_plan = Terraform.show(TF_PLAN_PATH, capture_output=True)
+            CURRENT_CRASH_REPORTER.tf_plan_text = ansi_scrub(regular_plan or "")
             print(regular_plan)
             return
         plan_dict = json.loads(
             Terraform.show(*["-no-color", "-json", TF_PLAN_PATH], capture_output=True)  # type: ignore
+        )
+        CURRENT_CRASH_REPORTER.tf_plan_text = (
+            CURRENT_CRASH_REPORTER.tf_plan_text or ansi_scrub(plan_dict)
         )
         plan_risk = LOW_RISK
         module_changes: dict = {}

--- a/tests/core/test_plan_displayer.py
+++ b/tests/core/test_plan_displayer.py
@@ -17,4 +17,4 @@ class TestPlanDisplayer:
             plan_dict = yaml.load(f)
         mocked_terraform = mocker.patch("opta.core.plan_displayer.Terraform")
         mocked_terraform.show.side_effect = ["bare show", json.dumps(plan_dict)]
-        PlanDisplayer.display()
+        PlanDisplayer.display(detailed_plan=True)


### PR DESCRIPTION
# Description
Looks like a freebie as it's ok if we have the json plan for the crash reporter if a person did not specify the detailed plan, and I don't think that the download state is needed repeatedly anymore

# Safety checklist
* [x] This change is backwards compatible and safe to apply by existing users
* [x] This change will NOT lead to data loss
* [x] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
Seems to be working fine
