### PR TITLE
fix test_destroy_env_with_children when AWS session has expired

### DIFF
--- a/tests/commands/test_destroy.py
+++ b/tests/commands/test_destroy.py
@@ -35,6 +35,7 @@ def test_destroy_env_with_children(mocker: MockFixture) -> None:
     )
 
     mocked_gen_all = mocker.patch("opta.commands.destroy.gen_all")
+    mocker.patch("opta.commands.destroy.Layer.verify_cloud_credentials")
 
     runner = CliRunner()
     result = runner.invoke(destroy, ["--config", FAKE_ENV_CONFIG])


### PR DESCRIPTION
# Description

This test would fail if the local AWS session has expired.
```
botocore.exceptions.UnauthorizedSSOTokenError: The SSO session associated with this profile has expired or is otherwise invalid. To refresh this SSO session run aws sso login with the corresponding profile.
============================================================================================== short test summary info ==============================================================================================
FAILED tests/commands/test_destroy.py::test_destroy_env_with_children - AssertionError: assert False
```

Mocking the verify credential call would make the test pass when it happens.

# Safety checklist
* [X] This change is backwards compatible and safe to apply by existing users
* [X] This change will NOT lead to data loss
* [X] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
Ran the unit test locally with expired AWS session.
