### PR TITLE
Removed unsupported clouds from Atlas Mongodb

### DIFF
--- a/config/registry/schemas/opta-config-files/azure-service.json
+++ b/config/registry/schemas/opta-config-files/azure-service.json
@@ -26,9 +26,6 @@
           },
           {
             "$ref": "https://app.runx.dev/modules/helm-chart"
-          },
-          {
-            "$ref": "https://app.runx.dev/modules/mongodb-atlas"
           }
         ]
       }

--- a/config/registry/schemas/opta-config-files/gcp-service.json
+++ b/config/registry/schemas/opta-config-files/gcp-service.json
@@ -35,9 +35,6 @@
           },
           {
             "$ref": "https://app.runx.dev/modules/helm-chart"
-          },
-          {
-            "$ref": "https://app.runx.dev/modules/mongodb-atlas"
           }
         ]
       }

--- a/modules/mongodb_atlas/mongodb-atlas.json
+++ b/modules/mongodb_atlas/mongodb-atlas.json
@@ -31,9 +31,7 @@
     },
     "cloud_provider": {
       "enum": [
-        "AWS",
-        "AZURE",
-        "GCP"
+        "AWS"
       ],
       "default": "AWS"
     },
@@ -65,9 +63,7 @@
   "opta_metadata": {
     "module_type": "service",
     "clouds": [
-      "aws",
-      "azure",
-      "gcp"
+      "aws"
     ],
     "name": "mongodb-atlas",
     "display_name": "mongodb-atlas",

--- a/modules/mongodb_atlas/mongodb-atlas.yaml
+++ b/modules/mongodb_atlas/mongodb-atlas.yaml
@@ -65,7 +65,5 @@ outputs:
 output_providers: { }
 output_data: { }
 clouds:
-  - azure
   - aws
-  - gcp
   - local


### PR DESCRIPTION
# Description

We had included GCP and azure in the registry values for mongodb-atlas; but in reality they are not supported in the code.

# Safety checklist
* [  X] This change is backwards compatible and safe to apply by existing users
* [ X] This change will NOT lead to data loss
* [ X] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
Mnaually tested AWS + Mongo
