### PR TITLE
Fixing some annoying Azure things

### DIFF
--- a/modules/azure_aks/azure-aks.json
+++ b/modules/azure_aks/azure-aks.json
@@ -121,7 +121,6 @@
     }
   },
   "required": [
-    "admin_group_object_ids",
     "type"
   ],
   "opta_metadata": {

--- a/modules/azure_aks/azure-aks.yaml
+++ b/modules/azure_aks/azure-aks.yaml
@@ -41,7 +41,7 @@ inputs:
     default: "1.19.11"
   - name: admin_group_object_ids
     user_facing: true
-    validator: list(str(), require=False)
+    validator: list(str(), required=False)
     description: ids of the Active Directory [groups](https://docs.microsoft.com/en-us/azure/active-directory/fundamentals/active-directory-groups-create-azure-portal) to make admins in the K8s cluster.
     default: []
   - name: service_cidr

--- a/tests/core/test_azure.py
+++ b/tests/core/test_azure.py
@@ -1,3 +1,4 @@
+from typing import Generator
 from unittest.mock import Mock
 
 from azure.identity import DefaultAzureCredential
@@ -50,15 +51,19 @@ def azure_layer() -> Mock:
     return layer
 
 
+@fixture(autouse=True)
+def reset_azure_creds() -> Generator:
+    Azure.credentials = None
+    yield
+
+
 class TestAzure:
     def test_get_credentials(self, mocker: MockFixture) -> None:
         mocked_default_creds = mocker.patch("opta.core.azure.DefaultAzureCredential")
         Azure.get_credentials()
-        Azure.credentials = None
         mocked_default_creds.assert_called_once_with()
 
     def test_get_remote_config(self, mocker: MockFixture, azure_layer: Mock) -> None:
-        Azure.credentials = None
         mocked_creds = mocker.Mock()
         mocked_default_creds = mocker.patch(
             "opta.core.azure.DefaultAzureCredential", return_value=mocked_creds

--- a/tests/core/test_azure.py
+++ b/tests/core/test_azure.py
@@ -54,9 +54,11 @@ class TestAzure:
     def test_get_credentials(self, mocker: MockFixture) -> None:
         mocked_default_creds = mocker.patch("opta.core.azure.DefaultAzureCredential")
         Azure.get_credentials()
+        Azure.credentials = None
         mocked_default_creds.assert_called_once_with()
 
     def test_get_remote_config(self, mocker: MockFixture, azure_layer: Mock) -> None:
+        Azure.credentials = None
         mocked_creds = mocker.Mock()
         mocked_default_creds = mocker.patch(
             "opta.core.azure.DefaultAzureCredential", return_value=mocked_creds
@@ -94,6 +96,7 @@ class TestAzure:
         )
 
     def test_upload_opta_config(self, mocker: MockFixture, azure_layer: Mock) -> None:
+        Azure.credentials = None
         mocked_creds = mocker.Mock()
         mocked_default_creds = mocker.patch(
             "opta.core.azure.DefaultAzureCredential", return_value=mocked_creds
@@ -120,6 +123,7 @@ class TestAzure:
         )
 
     def test_delete_opta_config(self, mocker: MockFixture, azure_layer: Mock) -> None:
+        Azure.credentials = None
         mocked_creds = mocker.Mock()
         mocked_default_creds = mocker.patch(
             "opta.core.azure.DefaultAzureCredential", return_value=mocked_creds
@@ -145,6 +149,7 @@ class TestAzure:
         )
 
     def test_delete_remote_state(self, mocker: MockFixture, azure_layer: Mock) -> None:
+        Azure.credentials = None
         mocked_creds = mocker.Mock()
         mocked_default_creds = mocker.patch(
             "opta.core.azure.DefaultAzureCredential", return_value=mocked_creds


### PR DESCRIPTION
# Description
1. AKS admin group object ids are no longer required
2. Get rid of annoying messages about credential verification
3. Cache credentials for significant speedup


# Safety checklist
* [x] This change is backwards compatible and safe to apply by existing users
* [x] This change will NOT lead to data loss
* [x] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
Manually tested
