### PR TITLE
increase sleep time before destroy 2 -> 5 sec

### DIFF
--- a/opta/commands/destroy.py
+++ b/opta/commands/destroy.py
@@ -90,7 +90,7 @@ def destroy(
 
     tf_flags: List[str] = []
     if auto_approve:
-        sleep_time = 2
+        sleep_time = 5
         logger.info(
             f"{attr('bold')}Opta will now destroy the {attr('underlined')}{layer.name}{attr(0)}"
             f"{attr('bold')} layer.{attr(0)}\n"


### PR DESCRIPTION
# Description
2 sec doesn't seem enough time to read the message and act on it.
@nsarupr ok with that?

# Safety checklist
* [X] This change is backwards compatible and safe to apply by existing users
* [X] This change will NOT lead to data loss
* [X] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
ran locally
