### PR TITLE
secrets no longer need to be set prior running opta apply

### DIFF
--- a/modules/aws_k8s_service/aws-k8s-service.json
+++ b/modules/aws_k8s_service/aws-k8s-service.json
@@ -57,7 +57,7 @@
     },
     "secrets": {
       "type": "array",
-      "description": "A list of secrets to add as environment variables for your container. All secrets must be set following the [secrets instructions](/tutorials/secrets) prior to deploying the app.",
+      "description": "A list of secrets to add as environment variables for your container. All secrets must be set following the [secrets instructions](/tutorials/secrets).",
       "items": {
         "type": "string"
       },

--- a/modules/aws_k8s_service/aws-k8s-service.yaml
+++ b/modules/aws_k8s_service/aws-k8s-service.yaml
@@ -90,7 +90,7 @@ inputs:
   - name: secrets
     user_facing: true
     validator: list(str(), required=False)
-    description: A list of secrets to add as environment variables for your container. All secrets must be set following the [secrets instructions](/tutorials/secrets) prior to deploying the app.
+    description: A list of secrets to add as environment variables for your container. All secrets must be set following the [secrets instructions](/tutorials/secrets).
     default: []
   - name: env_vars
     user_facing: true

--- a/modules/azure_k8s_service/azure-k8s-service.json
+++ b/modules/azure_k8s_service/azure-k8s-service.json
@@ -38,7 +38,7 @@
     },
     "secrets": {
       "type": "array",
-      "description": "Optional. A list of secrets to add as environment variables for your container. All secrets must be set following the [secrets instructions](/tutorials/secrets) prior to deploying the app.",
+      "description": "Optional. A list of secrets to add as environment variables for your container. All secrets must be set following the [secrets instructions](/tutorials/secrets).",
       "items": {
         "type": "string"
       },

--- a/modules/azure_k8s_service/azure-k8s-service.yaml
+++ b/modules/azure_k8s_service/azure-k8s-service.yaml
@@ -76,7 +76,7 @@ inputs: # (what users see)
   - name: secrets
     user_facing: true
     validator: list(str(), required=False)
-    description: Optional. A list of secrets to add as environment variables for your container. All secrets must be set following the [secrets instructions](/tutorials/secrets) prior to deploying the app.
+    description: Optional. A list of secrets to add as environment variables for your container. All secrets must be set following the [secrets instructions](/tutorials/secrets).
     default: []
   - name: env_vars
     user_facing: true

--- a/modules/gcp_k8s_service/gcp-k8s-service.json
+++ b/modules/gcp_k8s_service/gcp-k8s-service.json
@@ -42,7 +42,7 @@
     },
     "secrets": {
       "type": "array",
-      "description": "Optional. A list of secrets to add as environment variables for your container. All secrets must be set following the [secrets instructions](/tutorials/secrets) prior to deploying the app.",
+      "description": "Optional. A list of secrets to add as environment variables for your container. All secrets must be set following the [secrets instructions](/tutorials/secrets).",
       "items": {
         "type": "string"
       },

--- a/modules/gcp_k8s_service/gcp-k8s-service.yaml
+++ b/modules/gcp_k8s_service/gcp-k8s-service.yaml
@@ -80,7 +80,7 @@ inputs:
   - name: secrets
     user_facing: true
     validator: list(str(), required=False)
-    description: Optional. A list of secrets to add as environment variables for your container. All secrets must be set following the [secrets instructions](/tutorials/secrets) prior to deploying the app.
+    description: Optional. A list of secrets to add as environment variables for your container. All secrets must be set following the [secrets instructions](/tutorials/secrets).
     default: []
   - name: env_vars
     user_facing: true

--- a/modules/local_k8s_service/local-k8s-service.json
+++ b/modules/local_k8s_service/local-k8s-service.json
@@ -44,7 +44,7 @@
     },
     "secrets": {
       "type": "array",
-      "description": "A list of secrets to add as environment variables for your container. All secrets must be set following the [secrets instructions](/miscellaneous/secrets) prior to deploying the app.",
+      "description": "A list of secrets to add as environment variables for your container. All secrets must be set following the [secrets instructions](/miscellaneous/secrets).",
       "items": {
         "type": "string"
       },

--- a/modules/local_k8s_service/local-k8s-service.yaml
+++ b/modules/local_k8s_service/local-k8s-service.yaml
@@ -76,7 +76,7 @@ inputs:
   - name: secrets
     user_facing: true
     validator: list(str(), required=False)
-    description: A list of secrets to add as environment variables for your container. All secrets must be set following the [secrets instructions](/miscellaneous/secrets) prior to deploying the app.
+    description: A list of secrets to add as environment variables for your container. All secrets must be set following the [secrets instructions](/miscellaneous/secrets).
     default: []
   - name: env_vars
     user_facing: true


### PR DESCRIPTION
# Description
Update the documentation as secrets no longer need to be set _prior to deploying the app_ since #587

# Safety checklist
* [X] This change is backwards compatible and safe to apply by existing users
* [X] This change will NOT lead to data loss
* [X] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
n/a
