### PR TITLE
Downgrade helm-chart version for admission controller to work in EKS

### DIFF
--- a/modules/datadog/tf_module/main.tf
+++ b/modules/datadog/tf_module/main.tf
@@ -17,7 +17,7 @@ resource "helm_release" "datadog" {
   repository = "https://helm.datadoghq.com"
   chart      = "datadog"
   name       = "${var.layer_name}-${var.module_name}"
-  version    = "2.28.13"
+  version    = "2.10.3"
   values = [
     yamlencode({
       datadog : {


### PR DESCRIPTION
# Description
The Version 2.28.13 does not support admission controller on EKS. So we choose a version 2.10.3 from March 2021 that seems to work. Could it be a version between the two where things break? Definitely; since there are dozens of releases we'll go with 2.10.3 for now and determine where the issue lies before upgrading.

# Safety checklist
* [ X] This change is backwards compatible and safe to apply by existing users
* [ X] This change will NOT lead to data loss
* [ X] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
Manual testing
