### PR TITLE
Feature/local fixes

### DIFF
--- a/opta/commands/apply.py
+++ b/opta/commands/apply.py
@@ -29,6 +29,7 @@ from opta.exceptions import MissingState, UserErrors
 from opta.layer import Layer, StructuredConfig
 from opta.pre_check import pre_check
 from opta.utils import check_opta_file_exists, fmt_msg, logger
+from opta.utils.clickoptions import local_option
 
 
 @click.command()
@@ -63,13 +64,6 @@ from opta.utils import check_opta_file_exists, fmt_msg, logger
     hidden=True,
 )
 @click.option(
-    "--local",
-    is_flag=True,
-    default=False,
-    help="""Run the service locally on a local Kubernetes cluster for development and testing,  irrespective of the environment specified inside the opta service yaml file""",
-    hidden=False,
-)
-@click.option(
     "--auto-approve",
     is_flag=True,
     default=False,
@@ -81,6 +75,7 @@ from opta.utils import check_opta_file_exists, fmt_msg, logger
     default=False,
     help="Show full terraform plan in detail, not the opta provided summary",
 )
+@local_option
 def apply(
     config: str,
     env: Optional[str],
@@ -403,7 +398,7 @@ def _verify_parent_layer(layer: Layer, auto_approve: bool = False) -> None:
 
 
 def _local_setup(
-    config: str, image_tag: Optional[str], refresh_local_env: bool = False
+    config: str, image_tag: Optional[str] = "", refresh_local_env: bool = False
 ) -> str:
     adjusted_config, localopta_envfile = _handle_local_flag(config, False)
     if adjusted_config != config:  # Only do this for service opta files

--- a/opta/commands/apply.py
+++ b/opta/commands/apply.py
@@ -403,7 +403,7 @@ def _verify_parent_layer(layer: Layer, auto_approve: bool = False) -> None:
 
 
 def _local_setup(
-    config: str, image_tag: str = None, refresh_local_env: bool = False
+    config: str, image_tag: Optional[str], refresh_local_env: bool = False
 ) -> str:
     adjusted_config, localopta_envfile = _handle_local_flag(config, False)
     if adjusted_config != config:  # Only do this for service opta files

--- a/opta/commands/apply.py
+++ b/opta/commands/apply.py
@@ -81,8 +81,6 @@ from opta.utils import check_opta_file_exists, fmt_msg, logger
     default=False,
     help="Show full terraform plan in detail, not the opta provided summary",
 )
-
-
 def apply(
     config: str,
     env: Optional[str],
@@ -133,7 +131,6 @@ def _apply(
     _clean_tf_folder()
     if local and not test:
         config = _local_setup(config, image_tag, refresh_local_env=True)
-
 
     layer = Layer.load_from_yaml(config, env)
     layer.verify_cloud_credentials()
@@ -403,15 +400,18 @@ def _verify_parent_layer(layer: Layer, auto_approve: bool = False) -> None:
             auto_approve=False,
         )
         cleanup_files()
-        
-def _local_setup(config: str, image_tag: str=None, refresh_local_env: bool=False) -> str:
+
+
+def _local_setup(
+    config: str, image_tag: str = None, refresh_local_env: bool = False
+) -> str:
     adjusted_config, localopta_envfile = _handle_local_flag(config, False)
     if adjusted_config != config:  # Only do this for service opta files
         config = adjusted_config  # Config for service
         if refresh_local_env:
             _apply(
                 config=localopta_envfile,
-                image_tag = image_tag,
+                image_tag=image_tag,
                 auto_approve=True,
                 local=False,
                 env="",
@@ -421,4 +421,3 @@ def _local_setup(config: str, image_tag: str=None, refresh_local_env: bool=False
             )
             _clean_tf_folder()
     return config
-    

--- a/opta/commands/apply.py
+++ b/opta/commands/apply.py
@@ -132,7 +132,7 @@ def _apply(
     pre_check()
     _clean_tf_folder()
     if local and not test:
-        config = _local_setup(config, image_tag)
+        config = _local_setup(config, image_tag, refresh_local_env=True)
 
 
     layer = Layer.load_from_yaml(config, env)
@@ -404,20 +404,21 @@ def _verify_parent_layer(layer: Layer, auto_approve: bool = False) -> None:
         )
         cleanup_files()
         
-def _local_setup(config: str, image_tag: str=None) -> str:
+def _local_setup(config: str, image_tag: str=None, refresh_local_env: bool=False) -> str:
     adjusted_config, localopta_envfile = _handle_local_flag(config, False)
     if adjusted_config != config:  # Only do this for service opta files
         config = adjusted_config  # Config for service
-        _apply(
-            config=localopta_envfile,
-            image_tag = image_tag,
-            auto_approve=True,
-            local=False,
-            env="",
-            refresh=True,
-            test=False,
-            detailed_plan=True,
-        )
-        _clean_tf_folder()
+        if refresh_local_env:
+            _apply(
+                config=localopta_envfile,
+                image_tag = image_tag,
+                auto_approve=True,
+                local=False,
+                env="",
+                refresh=True,
+                test=False,
+                detailed_plan=True,
+            )
+            _clean_tf_folder()
     return config
     

--- a/opta/commands/deploy.py
+++ b/opta/commands/deploy.py
@@ -1,12 +1,9 @@
-import os
-from pathlib import Path
 from typing import Optional
 
 import click
-
+from opta.commands.apply import _local_setup
 from opta.amplitude import amplitude_client
 from opta.commands.apply import _apply
-from opta.commands.local_flag import _clean_tf_folder, _handle_local_flag
 from opta.commands.push import _push, is_service_config
 from opta.core.terraform import Terraform
 from opta.error_constants import USER_ERROR_TF_LOCK
@@ -95,23 +92,7 @@ def deploy(
         )
 
     if local:
-        adjusted_config = _handle_local_flag(config, False)
-        if adjusted_config != config:  # Only do this for service opta files
-            config = adjusted_config
-            localopta_envfile = os.path.join(
-                Path.home(), ".opta", "local", "localopta.yaml"
-            )
-            _apply(
-                config=localopta_envfile,
-                auto_approve=True,
-                local=False,
-                env="",
-                refresh=True,
-                image_tag="",
-                test=False,
-                detailed_plan=True,
-            )
-            _clean_tf_folder()
+        config = _local_setup(config)
 
     layer = Layer.load_from_yaml(config, env)
     amplitude_client.send_event(

--- a/opta/commands/deploy.py
+++ b/opta/commands/deploy.py
@@ -79,7 +79,7 @@ def deploy(
 
     config = check_opta_file_exists(config)
     if local:
-        config = _local_setup(config, image_tag = tag, refresh_local_env=True)
+        config = _local_setup(config, image_tag=tag, refresh_local_env=True)
     if not is_service_config(config):
         raise UserErrors(
             fmt_msg(

--- a/opta/commands/deploy.py
+++ b/opta/commands/deploy.py
@@ -1,9 +1,9 @@
 from typing import Optional
 
 import click
-from opta.commands.apply import _local_setup
+
 from opta.amplitude import amplitude_client
-from opta.commands.apply import _apply
+from opta.commands.apply import _apply, _local_setup
 from opta.commands.push import _push, is_service_config
 from opta.core.terraform import Terraform
 from opta.error_constants import USER_ERROR_TF_LOCK
@@ -78,6 +78,8 @@ def deploy(
     pre_check()
 
     config = check_opta_file_exists(config)
+    if local:
+        config = _local_setup(config, refresh_local_env=True)
     if not is_service_config(config):
         raise UserErrors(
             fmt_msg(
@@ -90,9 +92,6 @@ def deploy(
             """
             )
         )
-
-    if local:
-        config = _local_setup(config, refresh_local_env=True)
 
     layer = Layer.load_from_yaml(config, env)
     amplitude_client.send_event(

--- a/opta/commands/deploy.py
+++ b/opta/commands/deploy.py
@@ -79,7 +79,7 @@ def deploy(
 
     config = check_opta_file_exists(config)
     if local:
-        config = _local_setup(config, refresh_local_env=True)
+        config = _local_setup(config, image_tag = tag, refresh_local_env=True)
     if not is_service_config(config):
         raise UserErrors(
             fmt_msg(

--- a/opta/commands/deploy.py
+++ b/opta/commands/deploy.py
@@ -92,7 +92,7 @@ def deploy(
         )
 
     if local:
-        config = _local_setup(config)
+        config = _local_setup(config, refresh_local_env=True)
 
     layer = Layer.load_from_yaml(config, env)
     amplitude_client.send_event(

--- a/opta/commands/deploy.py
+++ b/opta/commands/deploy.py
@@ -11,6 +11,7 @@ from opta.exceptions import MissingState, UserErrors
 from opta.layer import Layer
 from opta.pre_check import pre_check
 from opta.utils import check_opta_file_exists, fmt_msg, logger
+from opta.utils.clickoptions import local_option
 
 
 @click.command()
@@ -39,13 +40,7 @@ from opta.utils import check_opta_file_exists, fmt_msg, logger
     default=False,
     help="Show full terraform plan in detail, not the opta provided summary",
 )
-@click.option(
-    "--local",
-    is_flag=True,
-    default=False,
-    help="""Run the service locally on a local Kubernetes cluster for development and testing,  irrespective of the environment specified inside the opta service yaml file""",
-    hidden=False,
-)
+@local_option
 def deploy(
     image: str,
     config: str,

--- a/opta/commands/destroy.py
+++ b/opta/commands/destroy.py
@@ -10,6 +10,7 @@ from botocore.config import Config
 from colored import attr
 from google.cloud import storage  # type: ignore
 from google.cloud.exceptions import NotFound
+
 from opta.amplitude import amplitude_client
 from opta.commands.local_flag import _clean_tf_folder, _handle_local_flag
 from opta.constants import TF_PLAN_PATH

--- a/opta/commands/destroy.py
+++ b/opta/commands/destroy.py
@@ -10,7 +10,6 @@ from botocore.config import Config
 from colored import attr
 from google.cloud import storage  # type: ignore
 from google.cloud.exceptions import NotFound
-
 from opta.amplitude import amplitude_client
 from opta.commands.local_flag import _clean_tf_folder, _handle_local_flag
 from opta.constants import TF_PLAN_PATH
@@ -72,7 +71,7 @@ def destroy(
 
     config = check_opta_file_exists(config)
     if local:
-        config = _handle_local_flag(config, False)
+        config, _ = _handle_local_flag(config, False)
         _clean_tf_folder()
     layer = Layer.load_from_yaml(config, env)
     event_properties: Dict = layer.get_event_properties()

--- a/opta/commands/destroy.py
+++ b/opta/commands/destroy.py
@@ -24,6 +24,7 @@ from opta.exceptions import UserErrors
 from opta.layer import Layer
 from opta.pre_check import pre_check
 from opta.utils import check_opta_file_exists, logger
+from opta.utils.clickoptions import local_option
 
 
 @click.command()
@@ -43,13 +44,7 @@ from opta.utils import check_opta_file_exists, logger
     default=False,
     help="Show full terraform plan in detail, not the opta provided summary",
 )
-@click.option(
-    "--local",
-    is_flag=True,
-    default=False,
-    help="""Use the local Kubernetes cluster for development and testing, irrespective of the environment specified inside the opta service yaml file""",
-    hidden=False,
-)
+@local_option
 def destroy(
     config: str,
     env: Optional[str],

--- a/opta/commands/events.py
+++ b/opta/commands/events.py
@@ -1,6 +1,6 @@
 import datetime
 from typing import Optional
-
+from opta.commands.apply import _local_setup
 import click
 import pytz
 
@@ -13,7 +13,13 @@ from opta.core.kubernetes import (
 )
 from opta.layer import Layer
 
-
+@click.option(
+    "--local",
+    is_flag=True,
+    default=False,
+    help="""Use the local Kubernetes cluster for development and testing, irrespective of the environment specified inside the opta service yaml file""",
+    hidden=False,
+)
 @click.command(hidden=True)
 @click.option(
     "-e", "--env", default=None, help="The env to use when loading the config file"
@@ -29,9 +35,10 @@ from opta.layer import Layer
     show_default=False,
     type=int,
 )
-def events(env: Optional[str], config: str, seconds: Optional[int]) -> None:
+def events(env: Optional[str], config: str, seconds: Optional[int],local: Optional[bool]) -> None:
     """Get stream of logs from your service"""
-
+    if local:
+        config = _local_setup(config)
     # Configure kubectl
     layer = Layer.load_from_yaml(config, env)
     amplitude_client.send_event(

--- a/opta/commands/events.py
+++ b/opta/commands/events.py
@@ -13,15 +13,9 @@ from opta.core.kubernetes import (
     tail_namespace_events,
 )
 from opta.layer import Layer
+from opta.utils.clickoptions import local_option
 
 
-@click.option(
-    "--local",
-    is_flag=True,
-    default=False,
-    help="""Use the local Kubernetes cluster for development and testing, irrespective of the environment specified inside the opta service yaml file""",
-    hidden=False,
-)
 @click.command(hidden=True)
 @click.option(
     "-e", "--env", default=None, help="The env to use when loading the config file"
@@ -37,6 +31,7 @@ from opta.layer import Layer
     show_default=False,
     type=int,
 )
+@local_option
 def events(
     env: Optional[str], config: str, seconds: Optional[int], local: Optional[bool]
 ) -> None:

--- a/opta/commands/events.py
+++ b/opta/commands/events.py
@@ -1,10 +1,11 @@
 import datetime
 from typing import Optional
-from opta.commands.apply import _local_setup
+
 import click
 import pytz
 
 from opta.amplitude import amplitude_client
+from opta.commands.apply import _local_setup
 from opta.core.generator import gen_all
 from opta.core.kubernetes import (
     load_opta_kube_config,
@@ -12,6 +13,7 @@ from opta.core.kubernetes import (
     tail_namespace_events,
 )
 from opta.layer import Layer
+
 
 @click.option(
     "--local",
@@ -35,7 +37,9 @@ from opta.layer import Layer
     show_default=False,
     type=int,
 )
-def events(env: Optional[str], config: str, seconds: Optional[int],local: Optional[bool]) -> None:
+def events(
+    env: Optional[str], config: str, seconds: Optional[int], local: Optional[bool]
+) -> None:
     """Get stream of logs from your service"""
     if local:
         config = _local_setup(config)

--- a/opta/commands/force_unlock.py
+++ b/opta/commands/force_unlock.py
@@ -3,13 +3,14 @@ from typing import List, Optional
 import click
 
 from opta.amplitude import amplitude_client
+from opta.commands.apply import _local_setup
 from opta.core.generator import gen_all
 from opta.core.helm import Helm
 from opta.core.kubernetes import set_kube_config
 from opta.core.terraform import Terraform
 from opta.layer import Layer
 from opta.utils import check_opta_file_exists
-from opta.commands.apply import _local_setup
+
 
 @click.command()
 @click.option("-c", "--config", default="opta.yaml", help="Opta config file.")

--- a/opta/commands/force_unlock.py
+++ b/opta/commands/force_unlock.py
@@ -10,6 +10,7 @@ from opta.core.kubernetes import set_kube_config
 from opta.core.terraform import Terraform
 from opta.layer import Layer
 from opta.utils import check_opta_file_exists
+from opta.utils.clickoptions import local_option
 
 
 @click.command()
@@ -17,13 +18,7 @@ from opta.utils import check_opta_file_exists
 @click.option(
     "-e", "--env", default=None, help="The env to use when loading the config file."
 )
-@click.option(
-    "--local",
-    is_flag=True,
-    default=False,
-    help="""Use the local Kubernetes cluster for development and testing, irrespective of the environment specified inside the opta service yaml file""",
-    hidden=False,
-)
+@local_option
 def force_unlock(config: str, env: Optional[str], local: Optional[bool]) -> None:
     """Release a stuck lock on the current workspace
 

--- a/opta/commands/inspect_cmd.py
+++ b/opta/commands/inspect_cmd.py
@@ -11,6 +11,7 @@ from opta.layer import Layer
 from opta.pre_check import pre_check
 from opta.resource import Resource
 from opta.utils import check_opta_file_exists, column_print, deep_merge, json
+from opta.utils.clickoptions import local_option
 
 
 @click.command(hidden=True)
@@ -20,13 +21,7 @@ from opta.utils import check_opta_file_exists, column_print, deep_merge, json
 @click.option(
     "-e", "--env", default=None, help="The env to use when loading the config file"
 )
-@click.option(
-    "--local",
-    is_flag=True,
-    default=False,
-    help="""Use the local Kubernetes cluster for development and testing, irrespective of the environment specified inside the opta service yaml file""",
-    hidden=False,
-)
+@local_option
 def inspect(config: str, env: Optional[str], local: Optional[bool]) -> None:
     """Displays important resources and AWS/Datadog links to them"""
 

--- a/opta/commands/inspect_cmd.py
+++ b/opta/commands/inspect_cmd.py
@@ -3,6 +3,7 @@ from typing import Any, List, Optional
 import click
 
 from opta.amplitude import amplitude_client
+from opta.commands.apply import _local_setup
 from opta.constants import TF_FILE_PATH
 from opta.core.generator import gen_all
 from opta.core.terraform import fetch_terraform_state_resources
@@ -10,7 +11,7 @@ from opta.layer import Layer
 from opta.pre_check import pre_check
 from opta.resource import Resource
 from opta.utils import check_opta_file_exists, column_print, deep_merge, json
-from opta.commands.apply import _local_setup
+
 
 @click.command(hidden=True)
 @click.option(

--- a/opta/commands/inspect_cmd.py
+++ b/opta/commands/inspect_cmd.py
@@ -10,7 +10,7 @@ from opta.layer import Layer
 from opta.pre_check import pre_check
 from opta.resource import Resource
 from opta.utils import check_opta_file_exists, column_print, deep_merge, json
-
+from opta.commands.apply import _local_setup
 
 @click.command(hidden=True)
 @click.option(
@@ -19,12 +19,21 @@ from opta.utils import check_opta_file_exists, column_print, deep_merge, json
 @click.option(
     "-e", "--env", default=None, help="The env to use when loading the config file"
 )
-def inspect(config: str, env: Optional[str]) -> None:
+@click.option(
+    "--local",
+    is_flag=True,
+    default=False,
+    help="""Use the local Kubernetes cluster for development and testing, irrespective of the environment specified inside the opta service yaml file""",
+    hidden=False,
+)
+def inspect(config: str, env: Optional[str], local: Optional[bool]) -> None:
     """Displays important resources and AWS/Datadog links to them"""
 
     pre_check()
 
     config = check_opta_file_exists(config)
+    if local:
+        config = _local_setup(config)
     layer = Layer.load_from_yaml(config, env)
     amplitude_client.send_event(
         amplitude_client.INSPECT_EVENT,

--- a/opta/commands/kubectl.py
+++ b/opta/commands/kubectl.py
@@ -5,10 +5,11 @@ import click
 from opta.amplitude import amplitude_client
 from opta.core.kubernetes import load_opta_kube_config_to_default, purge_opta_kube_config
 from opta.core.kubernetes import set_kube_config as configure
+from opta.commands.apply import _local_setup
 from opta.layer import Layer
 from opta.utils import check_opta_file_exists
 
-from opta.commands.apply import _local_setup
+
 @click.command()
 @click.option(
     "-c", "--config", default="opta.yaml", help="Opta config file", show_default=True

--- a/opta/commands/kubectl.py
+++ b/opta/commands/kubectl.py
@@ -3,9 +3,9 @@ from typing import Optional
 import click
 
 from opta.amplitude import amplitude_client
+from opta.commands.apply import _local_setup
 from opta.core.kubernetes import load_opta_kube_config_to_default, purge_opta_kube_config
 from opta.core.kubernetes import set_kube_config as configure
-from opta.commands.apply import _local_setup
 from opta.layer import Layer
 from opta.utils import check_opta_file_exists
 

--- a/opta/commands/kubectl.py
+++ b/opta/commands/kubectl.py
@@ -8,6 +8,7 @@ from opta.core.kubernetes import load_opta_kube_config_to_default, purge_opta_ku
 from opta.core.kubernetes import set_kube_config as configure
 from opta.layer import Layer
 from opta.utils import check_opta_file_exists
+from opta.utils.clickoptions import local_option
 
 
 @click.command()
@@ -17,13 +18,7 @@ from opta.utils import check_opta_file_exists
 @click.option(
     "-e", "--env", default=None, help="The env to use when loading the config file"
 )
-@click.option(
-    "--local",
-    is_flag=True,
-    default=False,
-    help="""Use the local Kubernetes cluster for development and testing, irrespective of the environment specified inside the opta service yaml file""",
-    hidden=False,
-)
+@local_option
 def configure_kubectl(config: str, env: Optional[str], local: Optional[bool]) -> None:
     """
     Configure kubectl so you can connect to the cluster

--- a/opta/commands/kubectl.py
+++ b/opta/commands/kubectl.py
@@ -8,7 +8,7 @@ from opta.core.kubernetes import set_kube_config as configure
 from opta.layer import Layer
 from opta.utils import check_opta_file_exists
 
-
+from opta.commands.apply import _local_setup
 @click.command()
 @click.option(
     "-c", "--config", default="opta.yaml", help="Opta config file", show_default=True
@@ -16,7 +16,14 @@ from opta.utils import check_opta_file_exists
 @click.option(
     "-e", "--env", default=None, help="The env to use when loading the config file"
 )
-def configure_kubectl(config: str, env: Optional[str]) -> None:
+@click.option(
+    "--local",
+    is_flag=True,
+    default=False,
+    help="""Use the local Kubernetes cluster for development and testing, irrespective of the environment specified inside the opta service yaml file""",
+    hidden=False,
+)
+def configure_kubectl(config: str, env: Optional[str], local: Optional[bool]) -> None:
     """
     Configure kubectl so you can connect to the cluster
 
@@ -27,6 +34,8 @@ def configure_kubectl(config: str, env: Optional[str]) -> None:
     """
 
     config = check_opta_file_exists(config)
+    if local:
+        config = _local_setup(config)
     layer = Layer.load_from_yaml(config, env)
     amplitude_client.send_event(
         amplitude_client.CONFIGURE_KUBECTL_EVENT,

--- a/opta/commands/local_flag.py
+++ b/opta/commands/local_flag.py
@@ -1,25 +1,25 @@
 import os
 from pathlib import Path
 from shutil import rmtree
+from typing import Tuple
 
 from ruamel import yaml
-from typing import Tuple
-from opta.utils import logger
 
-def _handle_local_flag(config: str, test: bool = False) -> Tuple[str,str]:
-    if test:
-        return config
+
+def _handle_local_flag(config: str, test: bool = False) -> Tuple[str, str]:
+
     with open(config, "r") as fr:
         y = yaml.round_trip_load(fr, preserve_quotes=True)
         if "org_name" in y:
             org_name = y["org_name"]
         else:
             org_name = "localorg"
-
-    if "opta-local-" in config:
-        return config
-    
     env_yaml_path = os.path.join(Path.home(), ".opta", "local", org_name)
+    if test:
+        return config, env_yaml_path + "/localopta.yaml"
+    if "opta-local-" in config:
+        return config, env_yaml_path + "/localopta.yaml"
+
     if not os.path.exists(env_yaml_path):
         os.makedirs(os.path.abspath(env_yaml_path))
     with open(env_yaml_path + "/localopta.yaml", "w") as fw:

--- a/opta/commands/local_flag.py
+++ b/opta/commands/local_flag.py
@@ -3,10 +3,10 @@ from pathlib import Path
 from shutil import rmtree
 
 from ruamel import yaml
-
+from typing import Tuple
 from opta.utils import logger
 
-def _handle_local_flag(config: str, test: bool = False) -> str:
+def _handle_local_flag(config: str, test: bool = False) -> Tuple[str,str]:
     if test:
         return config
     with open(config, "r") as fr:

--- a/opta/commands/local_flag.py
+++ b/opta/commands/local_flag.py
@@ -6,39 +6,39 @@ from ruamel import yaml
 
 from opta.utils import logger
 
-
 def _handle_local_flag(config: str, test: bool = False) -> str:
     if test:
         return config
+    with open(config, "r") as fr:
+        y = yaml.round_trip_load(fr, preserve_quotes=True)
+        if "org_name" in y:
+            org_name = y["org_name"] or "local"
+
     if "opta-local-" in config:
         return config
     logger.info("Checking local Opta Kubernetes environment, will install if needed.")
 
-    dir_path = os.path.join(Path.home(), ".opta", "local")
-    if not os.path.exists(dir_path):
-        os.makedirs(dir_path)
-    with open(os.path.join(dir_path, "localopta.yaml"), "w") as fw:
+    env_yaml_path = os.path.join(Path.home(), ".opta", "local", org_name)
+    if not os.path.exists(env_yaml_path):
+        os.makedirs(os.path.abspath(env_yaml_path))
+    with open(env_yaml_path + "/localopta.yaml", "w") as fw:
         yaml.safe_dump(
             {
                 "name": "localopta",
-                "org_name": "local",
+                "org_name": org_name,
                 "providers": {"local": {}},
                 "modules": [{"type": "local-base"}],
             },
             fw,
         )
-
-    with open(config, "r") as fr:
-        y = yaml.round_trip_load(fr, preserve_quotes=True)
-    if "environments" not in y:  # This is an environment opta file, so do nothing
-        return config
-    y["environments"] = [{"name": "localopta", "path": dir_path + "/localopta.yaml"}]
+    y["environments"] = [{"name": "localopta", "path": env_yaml_path + "/localopta.yaml"}]
+    y.pop("org_name", None)
     p = Path(config)
-    config = os.path.join(p.parent, "opta-local-" + p.name)
+    config = os.path.join(env_yaml_path, "opta-local-" + p.name)
     with open(config, "w") as fw:
         yaml.round_trip_dump(y, fw, explicit_start=True)
 
-    return config
+    return config, env_yaml_path + "/localopta.yaml"
 
 
 def _clean_tf_folder() -> None:

--- a/opta/commands/local_flag.py
+++ b/opta/commands/local_flag.py
@@ -12,7 +12,9 @@ def _handle_local_flag(config: str, test: bool = False) -> Tuple[str,str]:
     with open(config, "r") as fr:
         y = yaml.round_trip_load(fr, preserve_quotes=True)
         if "org_name" in y:
-            org_name = y["org_name"] or "local"
+            org_name = y["org_name"]
+        else:
+            org_name = "localorg"
 
     if "opta-local-" in config:
         return config

--- a/opta/commands/local_flag.py
+++ b/opta/commands/local_flag.py
@@ -18,8 +18,7 @@ def _handle_local_flag(config: str, test: bool = False) -> Tuple[str,str]:
 
     if "opta-local-" in config:
         return config
-    logger.info("Checking local Opta Kubernetes environment, will install if needed.")
-
+    
     env_yaml_path = os.path.join(Path.home(), ".opta", "local", org_name)
     if not os.path.exists(env_yaml_path):
         os.makedirs(os.path.abspath(env_yaml_path))

--- a/opta/commands/logs.py
+++ b/opta/commands/logs.py
@@ -1,8 +1,9 @@
 from typing import Optional
-from opta.commands.apply import _local_setup
+
 import click
 
 from opta.amplitude import amplitude_client
+from opta.commands.apply import _local_setup
 from opta.core.generator import gen_all
 from opta.core.kubernetes import load_opta_kube_config, set_kube_config, tail_module_log
 from opta.exceptions import UserErrors
@@ -32,7 +33,9 @@ from opta.utils import check_opta_file_exists
     show_default=False,
     type=int,
 )
-def logs(env: Optional[str], config: str, seconds: Optional[int], local: Optional[bool]) -> None:
+def logs(
+    env: Optional[str], config: str, seconds: Optional[int], local: Optional[bool]
+) -> None:
     """
     Get stream of logs for a service
 

--- a/opta/commands/logs.py
+++ b/opta/commands/logs.py
@@ -9,6 +9,7 @@ from opta.core.kubernetes import load_opta_kube_config, set_kube_config, tail_mo
 from opta.exceptions import UserErrors
 from opta.layer import Layer
 from opta.utils import check_opta_file_exists
+from opta.utils.clickoptions import local_option
 
 
 @click.command()
@@ -19,13 +20,6 @@ from opta.utils import check_opta_file_exists
     "-c", "--config", default="opta.yaml", help="Opta config file", show_default=True
 )
 @click.option(
-    "--local",
-    is_flag=True,
-    default=False,
-    help="""Use the local Kubernetes cluster for development and testing, irrespective of the environment specified inside the opta service yaml file""",
-    hidden=False,
-)
-@click.option(
     "-s",
     "--seconds",
     default=None,
@@ -33,6 +27,7 @@ from opta.utils import check_opta_file_exists
     show_default=False,
     type=int,
 )
+@local_option
 def logs(
     env: Optional[str], config: str, seconds: Optional[int], local: Optional[bool]
 ) -> None:

--- a/opta/commands/output.py
+++ b/opta/commands/output.py
@@ -8,6 +8,7 @@ from opta.core.generator import gen_all
 from opta.core.terraform import get_terraform_outputs
 from opta.layer import Layer
 from opta.utils import check_opta_file_exists, json
+from opta.utils.clickoptions import local_option
 
 
 @click.command(hidden=True)
@@ -15,19 +16,13 @@ from opta.utils import check_opta_file_exists, json
 @click.option(
     "-e", "--env", default=None, help="The env to use when loading the config file"
 )
-@click.option(
-    "--local",
-    is_flag=True,
-    default=False,
-    help="""Use the local Kubernetes cluster for development and testing, irrespective of the environment specified inside the opta service yaml file""",
-    hidden=False,
-)
+@local_option
 def output(config: str, env: Optional[str], local: Optional[bool]) -> None:
     """Print TF outputs"""
 
     config = check_opta_file_exists(config)
     if local:
-        config = _local_setup(config)
+        config = _local_setup(config, None)
     layer = Layer.load_from_yaml(config, env)
     amplitude_client.send_event(
         amplitude_client.VIEW_OUTPUT_EVENT,

--- a/opta/commands/output.py
+++ b/opta/commands/output.py
@@ -3,11 +3,12 @@ from typing import Optional
 import click
 
 from opta.amplitude import amplitude_client
+from opta.commands.apply import _local_setup
 from opta.core.generator import gen_all
 from opta.core.terraform import get_terraform_outputs
 from opta.layer import Layer
 from opta.utils import check_opta_file_exists, json
-from opta.commands.apply import _local_setup
+
 
 @click.command(hidden=True)
 @click.option("-c", "--config", default="opta.yaml", help="Opta config file")

--- a/opta/commands/output.py
+++ b/opta/commands/output.py
@@ -7,17 +7,26 @@ from opta.core.generator import gen_all
 from opta.core.terraform import get_terraform_outputs
 from opta.layer import Layer
 from opta.utils import check_opta_file_exists, json
-
+from opta.commands.apply import _local_setup
 
 @click.command(hidden=True)
 @click.option("-c", "--config", default="opta.yaml", help="Opta config file")
 @click.option(
     "-e", "--env", default=None, help="The env to use when loading the config file"
 )
-def output(config: str, env: Optional[str],) -> None:
+@click.option(
+    "--local",
+    is_flag=True,
+    default=False,
+    help="""Use the local Kubernetes cluster for development and testing, irrespective of the environment specified inside the opta service yaml file""",
+    hidden=False,
+)
+def output(config: str, env: Optional[str], local: Optional[bool]) -> None:
     """Print TF outputs"""
 
     config = check_opta_file_exists(config)
+    if local:
+        config = _local_setup(config)
     layer = Layer.load_from_yaml(config, env)
     amplitude_client.send_event(
         amplitude_client.VIEW_OUTPUT_EVENT,

--- a/opta/commands/secret.py
+++ b/opta/commands/secret.py
@@ -19,6 +19,7 @@ from opta.core.secrets import (
 from opta.exceptions import UserErrors
 from opta.layer import Layer
 from opta.utils import check_opta_file_exists
+from opta.utils.clickoptions import local_option
 
 env_option = click.option(
     "-e", "--env", default=None, help="The env to use when loading the config file"
@@ -36,14 +37,6 @@ restart_option = click.option(
     If this flag is set, the deployment(s) will need to be restarted to have the latest secret values
     """,
     show_default=True,
-)
-
-local_option = click.option(
-    "--local",
-    is_flag=True,
-    default=False,
-    help="""Use the local Kubernetes cluster for development and testing, irrespective of the environment specified inside the opta service yaml file""",
-    hidden=False,
 )
 
 

--- a/opta/commands/secret.py
+++ b/opta/commands/secret.py
@@ -4,6 +4,7 @@ import click
 from click_didyoumean import DYMGroup
 from opta.commands.apply import _local_setup
 from opta.amplitude import amplitude_client
+from opta.commands.apply import _local_setup
 from opta.core.generator import gen_all
 from opta.core.kubernetes import (
     create_namespace_if_not_exists,

--- a/opta/commands/secret.py
+++ b/opta/commands/secret.py
@@ -2,7 +2,7 @@ from typing import Optional
 
 import click
 from click_didyoumean import DYMGroup
-from opta.commands.apply import _local_setup
+
 from opta.amplitude import amplitude_client
 from opta.commands.apply import _local_setup
 from opta.core.generator import gen_all
@@ -46,9 +46,9 @@ local_option = click.option(
     hidden=False,
 )
 
+
 def __restart_deployments(no_restart: bool, layer_name: str) -> None:
     restart_deployments(layer_name) if not no_restart else None
-
 
 
 @click.group(cls=DYMGroup)
@@ -148,7 +148,12 @@ def list_command(env: Optional[str], config: str, local: Optional[bool]) -> None
 @restart_option
 @local_option
 def update(
-    secret: str, value: str, env: Optional[str], config: str, no_restart: bool,  local: Optional[bool]
+    secret: str,
+    value: str,
+    env: Optional[str],
+    config: str,
+    no_restart: bool,
+    local: Optional[bool],
 ) -> None:
     """Update a given secret of a k8s service with a new value
 
@@ -179,7 +184,13 @@ def update(
 @config_option
 @restart_option
 @local_option
-def bulk_update(env_file: str, env: Optional[str], config: str, no_restart: bool,  local: Optional[bool]) -> None:
+def bulk_update(
+    env_file: str,
+    env: Optional[str],
+    config: str,
+    no_restart: bool,
+    local: Optional[bool],
+) -> None:
     """Bulk update a list of secrets for a k8s service using a dotenv file as in input.
 
     Each line of the file should be in VAR=VAL format.

--- a/opta/commands/shell.py
+++ b/opta/commands/shell.py
@@ -11,6 +11,7 @@ from opta.exceptions import UserErrors
 from opta.layer import Layer
 from opta.nice_subprocess import nice_run
 from opta.utils import check_opta_file_exists
+from opta.commands.apply import _local_setup
 
 
 @click.command()
@@ -28,7 +29,14 @@ from opta.utils import check_opta_file_exists
     show_default=True,
     type=click.Choice(SHELLS_ALLOWED),
 )
-def shell(env: Optional[str], config: str, type: str) -> None:
+@click.option(
+    "--local",
+    is_flag=True,
+    default=False,
+    help="""Use the local Kubernetes cluster for development and testing, irrespective of the environment specified inside the opta service yaml file""",
+    hidden=False,
+)
+def shell(env: Optional[str], config: str, type: str, local: Optional[bool]) -> None:
     """
     Get a shell into one of the pods in a service
 
@@ -39,6 +47,8 @@ def shell(env: Optional[str], config: str, type: str) -> None:
     """
 
     config = check_opta_file_exists(config)
+    if local:
+        config = _local_setup(config)
     # Configure kubectl
     layer = Layer.load_from_yaml(config, env)
     amplitude_client.send_event(

--- a/opta/commands/shell.py
+++ b/opta/commands/shell.py
@@ -12,6 +12,7 @@ from opta.exceptions import UserErrors
 from opta.layer import Layer
 from opta.nice_subprocess import nice_run
 from opta.utils import check_opta_file_exists
+from opta.utils.clickoptions import local_option
 
 
 @click.command()
@@ -29,13 +30,7 @@ from opta.utils import check_opta_file_exists
     show_default=True,
     type=click.Choice(SHELLS_ALLOWED),
 )
-@click.option(
-    "--local",
-    is_flag=True,
-    default=False,
-    help="""Use the local Kubernetes cluster for development and testing, irrespective of the environment specified inside the opta service yaml file""",
-    hidden=False,
-)
+@local_option
 def shell(env: Optional[str], config: str, type: str, local: Optional[bool]) -> None:
     """
     Get a shell into one of the pods in a service

--- a/opta/commands/shell.py
+++ b/opta/commands/shell.py
@@ -4,6 +4,7 @@ import click
 from kubernetes.client import CoreV1Api
 
 from opta.amplitude import amplitude_client
+from opta.commands.apply import _local_setup
 from opta.constants import SHELLS_ALLOWED
 from opta.core.generator import gen_all
 from opta.core.kubernetes import load_opta_kube_config, set_kube_config
@@ -11,7 +12,6 @@ from opta.exceptions import UserErrors
 from opta.layer import Layer
 from opta.nice_subprocess import nice_run
 from opta.utils import check_opta_file_exists
-from opta.commands.apply import _local_setup
 
 
 @click.command()

--- a/opta/layer.py
+++ b/opta/layer.py
@@ -141,7 +141,10 @@ class Layer:
         elif "local" in total_base_providers:
             self.cloud = "local"
         else:
-            raise UserErrors("No cloud provider (AWS, GCP, or Azure) found")
+            raise UserErrors(
+                """No cloud provider (AWS, GCP, or Azure) found, \n
+                    or did you miss providing the --local flag for local deployment?"""
+            )
         self.variables = variables or {}
         self.modules: List[Module] = []
         for module_data in modules_data:

--- a/opta/utils/clickoptions.py
+++ b/opta/utils/clickoptions.py
@@ -1,0 +1,9 @@
+import click
+
+local_option = click.option(
+    "--local",
+    is_flag=True,
+    default=False,
+    help="""Use the local Kubernetes cluster for development and testing, irrespective of the environment specified inside the opta service yaml file""",
+    hidden=False,
+)

--- a/tests/commands/test_local_flag.py
+++ b/tests/commands/test_local_flag.py
@@ -1,5 +1,6 @@
 import os
 import unittest
+from pathlib import Path
 
 import yaml
 
@@ -9,11 +10,14 @@ from opta.commands.local_flag import _handle_local_flag
 class Local_Flag_Tests(unittest.TestCase):
     def setUp(self) -> None:
         self.serviceconfig = "/tmp/test_local_flag.yaml"
+        self.derivedconfig = os.path.join(
+            Path.home(), ".opta", "local", "whatever", "opta-local-test_local_flag.yaml"
+        )
         with open(self.serviceconfig, "w") as fw:
             yaml.dump(
                 {
                     "name": "helloworld",
-                    "environments": [{"name": "somethingelse"}],
+                    "org_name": "whatever",
                     "modules": [
                         {
                             "name": "firstapp",
@@ -35,13 +39,13 @@ class Local_Flag_Tests(unittest.TestCase):
     def tearDown(self) -> None:
         if os.path.isfile(self.serviceconfig):
             os.remove(self.serviceconfig)
-        if os.path.isfile("/tmp/opta-local-test_local_flag.yaml"):
-            os.remove("/tmp/opta-local-test_local_flag.yaml")
+        if os.path.isfile(self.derivedconfig):
+            os.remove(self.derivedconfig)
         return super().tearDown()
 
     def test_handle_local_flag(self) -> None:
         _handle_local_flag(self.serviceconfig)
-        with open("/tmp/opta-local-test_local_flag.yaml", "r") as fr:
+        with open(self.derivedconfig, "r") as fr:
             y = yaml.safe_load(fr)
             assert "environments" in y
             assert y["environments"][0]["name"] == "localopta"


### PR DESCRIPTION
# Description

Several updates to opta local

1. Added support for opta's other commands in local environment:
events, shell, logs, force_unlock, secrets, configure_kubectl, output

2. Added the ability to optionally add "org_name" within (local) service file; so now, there is absolutely no need for environment opta yaml file; this means we can streamline the local documentation without confusion.
Example:
```
name: helloworld
org_name: hifi
modules:
  - name: firstapp
    type: k8s-service
    port:
      http: 80
    image: docker.io/kennethreitz/httpbin:latest
    healthcheck_path: "/get"
    links:
      - sessionstore
      - database
    public_uri: "/"
  - name: sessionstore
    type: redis    
  - name: database
    type: postgres
```
3. Moved the automatically generated local files from the PWD to ~/.opta/local/<org_name>/; so no pollution of user's directory.
4. Several other code and speed improvements 

# Safety checklist
* [X ] This change is backwards compatible and safe to apply by existing users
* [X ] This change will NOT lead to data loss
* [X ] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
Manual tests
