### PR TITLE
User configurable deletion_protection for documentdb

### DIFF
--- a/examples/ci-tests/create-and-destroy-aws/service-docdb.yml
+++ b/examples/ci-tests/create-and-destroy-aws/service-docdb.yml
@@ -1,6 +1,6 @@
 environments:
   - name: awsenv-ci
-    path: "/home/ubuntu/yaml/aws.yml"
+    path: "environment.yml"
     variables: {}
 name: ci-docdb
 modules:
@@ -27,4 +27,3 @@ modules:
       - docdb
   - name: docdb
     type: aws-documentdb
-    deletion_protection: true

--- a/examples/ci-tests/create-and-destroy-aws/service-docdb.yml
+++ b/examples/ci-tests/create-and-destroy-aws/service-docdb.yml
@@ -1,6 +1,6 @@
 environments:
   - name: awsenv-ci
-    path: "environment.yml"
+    path: "/home/ubuntu/yaml/aws.yml"
     variables: {}
 name: ci-docdb
 modules:
@@ -27,3 +27,4 @@ modules:
       - docdb
   - name: docdb
     type: aws-documentdb
+    deletion_protection: true

--- a/modules/aws_documentdb/aws-documentdb.json
+++ b/modules/aws_documentdb/aws-documentdb.json
@@ -19,6 +19,11 @@
       "minimum": 1,
       "default": 1
     },
+    "deletion_protection": {
+      "type": "boolean",
+      "description": "A value that indicates whether the DB cluster has deletion protection enabled. The database can't be deleted when deletion protection is enabled. By default, deletion protection is disabled.",
+      "default": false
+    },
     "type": {
       "description": "The name of this module",
       "enum": [

--- a/modules/aws_documentdb/aws-documentdb.yaml
+++ b/modules/aws_documentdb/aws-documentdb.yaml
@@ -29,6 +29,11 @@ inputs:
     validator: int(required=False)
     description: This is to specify the count of instances for Document DB Cluster. Note -> These would be Multi-AZ.
     default: 1
+  - name: deletion_protection
+    user_facing: true
+    validator: bool(required=False)
+    description: A value that indicates whether the DB cluster has deletion protection enabled. The database can't be deleted when deletion protection is enabled. By default, deletion protection is disabled.
+    default: false
 outputs:
   - name: db_host
     export: true

--- a/modules/aws_documentdb/tf_module/main.tf
+++ b/modules/aws_documentdb/tf_module/main.tf
@@ -41,6 +41,7 @@ resource "aws_docdb_cluster" "cluster" {
   backup_retention_period = 5
   apply_immediately       = true
   skip_final_snapshot     = true
+  deletion_protection     = var.deletion_protection
   lifecycle {
     ignore_changes = [cluster_identifier]
   }

--- a/modules/aws_documentdb/tf_module/variables.tf
+++ b/modules/aws_documentdb/tf_module/variables.tf
@@ -28,3 +28,8 @@ variable "instance_count" {
   default     = 1
   description = "Number of Instances for aws_docdb_cluster_instance"
 }
+variable "deletion_protection" {
+  type        = bool
+  default     = false
+  description = "A value that indicates whether the DB cluster has deletion protection enabled. The database can't be deleted when deletion protection is enabled."
+}


### PR DESCRIPTION
# Description
Add User configurable deletion protection parameter for DocumentDB

# Safety checklist
* [x] This change is backwards compatible and safe to apply by existing users
* [x] This change will NOT lead to data loss
* [x] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
Tested manually.
<img width="1792" alt="Screenshot 2022-01-25 at 2 22 15 AM" src="https://user-images.githubusercontent.com/20905988/150864485-490e5006-d435-4a48-9653-24d564261c5f.png">
<img width="1792" alt="Screenshot 2022-01-25 at 2 22 32 AM" src="https://user-images.githubusercontent.com/20905988/150864506-05e391fa-1cdc-4a34-804a-ccac0d775ade.png">
<img width="1792" alt="Screenshot 2022-01-25 at 2 24 30 AM" src="https://user-images.githubusercontent.com/20905988/150864511-3ae3ef1d-2cb7-483a-abd4-5e20b0a5a895.png">
<img width="1792" alt="Screenshot 2022-01-25 at 2 24 45 AM" src="https://user-images.githubusercontent.com/20905988/150864517-252cdbeb-e029-4463-ba30-d3248d62853c.png">

