### PR TITLE
Fixing sticky sessions

### DIFF
--- a/config/opta-k8s-service-helm/templates/ingress.yaml
+++ b/config/opta-k8s-service-helm/templates/ingress.yaml
@@ -28,7 +28,6 @@ metadata:
     {{- end }}
     cert-manager.io/cluster-issuer: opta-selfsigned
     kubernetes.io/ingress.class: "nginx"
-    nginx.ingress.kubernetes.io/service-upstream: "true"
     {{/* For websockets */}}
     {{ if eq (default "http" $.Values.httpPort.protocol) "websocket" }}
     nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"


### PR DESCRIPTION
# Description
https://linkerd.slack.com/archives/C89RTCWJF/p1643126236682619

Yestedar, we noticed that the origin IP was being lost due to a change a while back We figured out that it was a bug from linkerd and that the fix was to add the "config.linkerd.io/skip-inbound-ports" : "80,443" annotation to our nginx pods. Along the way, due to the explicit instructions on the linkerd documentation, I decided to add the nginx.ingress.kubernetes.io/service-upstream: "true" annotation. This was all done in this pr.

The problem is that now sticky sessions will not work and that extra annotation is needed for a linkerd feature which we did not need.

# Safety checklist
* [x] This change is backwards compatible and safe to apply by existing users
* [x] This change will NOT lead to data loss
* [x] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
YOUR_ANSWER
