### PR TITLE
Refactoring kubeconfig setup and adding kubeconfig purge

### DIFF
--- a/modules/aws_eks/aws_eks.py
+++ b/modules/aws_eks/aws_eks.py
@@ -9,6 +9,7 @@ from mypy_boto3_ec2.type_defs import NetworkInterfaceTypeDef
 from mypy_boto3_logs import CloudWatchLogsClient
 
 from modules.base import ModuleProcessor
+from opta.core.kubernetes import purge_opta_kube_config
 from opta.exceptions import UserErrors
 from opta.utils import logger
 
@@ -31,6 +32,7 @@ class AwsEksProcessor(ModuleProcessor):
         self.cleanup_cloudwatch_log_group(region)
         self.cleanup_dangling_enis(region)
         self.cleanup_security_groups(region)
+        purge_opta_kube_config(layer=self.layer)
 
     def cleanup_security_groups(self, region: str) -> None:
         logger.debug("Seeking dangling security groups EKS forgot to destroy.")

--- a/modules/aws_k8s_base/aws_k8s_base.py
+++ b/modules/aws_k8s_base/aws_k8s_base.py
@@ -7,7 +7,7 @@ from ruamel.yaml.compat import StringIO
 
 from modules.base import AWSK8sModuleProcessor, K8sBaseModuleProcessor
 from opta.core.aws import AWS
-from opta.core.kubernetes import configure_kubectl, list_namespaces, load_opta_kube_config
+from opta.core.kubernetes import list_namespaces, load_opta_kube_config, set_kube_config
 from opta.exceptions import UserErrors
 from opta.utils import yaml
 
@@ -41,7 +41,7 @@ class AwsK8sBaseProcessor(AWSK8sModuleProcessor, K8sBaseModuleProcessor):
                 "certificate_chain"
             ] = f"${{{{module.{byo_cert_module.name}.certificate_chain}}}}"
 
-        configure_kubectl(self.layer)
+        set_kube_config(self.layer)
         self._process_nginx_extra_ports(self.module.data)
 
         aws_dns_module = None
@@ -66,7 +66,7 @@ class AwsK8sBaseProcessor(AWSK8sModuleProcessor, K8sBaseModuleProcessor):
         super(AwsK8sBaseProcessor, self).process(module_idx)
 
     def pre_hook(self, module_idx: int) -> None:
-        configure_kubectl(self.layer)
+        set_kube_config(self.layer)
         list_namespaces()
         super(AwsK8sBaseProcessor, self).pre_hook(module_idx)
 
@@ -78,7 +78,7 @@ class AwsK8sBaseProcessor(AWSK8sModuleProcessor, K8sBaseModuleProcessor):
     def add_admin_roles(self) -> None:
         if self.module.data.get("admin_arns") is None:
             return
-        configure_kubectl(self.layer)
+        set_kube_config(self.layer)
         load_opta_kube_config()
         v1 = CoreV1Api()
         aws_auth_config_map: V1ConfigMap = v1.read_namespaced_config_map(

--- a/modules/aws_k8s_base/tests/test_aws_k8sbase.py
+++ b/modules/aws_k8s_base/tests/test_aws_k8sbase.py
@@ -23,7 +23,7 @@ class TestAwsK8sBaseProcessor:
             "arn:aws:iam::445935066876:user/silly-user",
         ]
 
-        mocker.patch("modules.aws_k8s_base.aws_k8s_base.configure_kubectl")
+        mocker.patch("modules.aws_k8s_base.aws_k8s_base.set_kube_config")
         mocker.patch("modules.aws_k8s_base.aws_k8s_base.load_opta_kube_config")
 
         mocked_core_v1_api = mocker.Mock()

--- a/modules/datadog/datadog.py
+++ b/modules/datadog/datadog.py
@@ -6,7 +6,7 @@ from kubernetes.client import ApiException, CoreV1Api, V1Namespace, V1ObjectMeta
 from requests import codes, get
 
 from modules.base import ModuleProcessor
-from opta.core.kubernetes import configure_kubectl, load_opta_kube_config
+from opta.core.kubernetes import load_opta_kube_config, set_kube_config
 from opta.exceptions import UserErrors
 
 if TYPE_CHECKING:
@@ -23,7 +23,7 @@ class DatadogProcessor(ModuleProcessor):
         super(DatadogProcessor, self).__init__(module, layer)
 
     def process(self, module_idx: int) -> None:
-        configure_kubectl(self.layer)
+        set_kube_config(self.layer)
         load_opta_kube_config()
         v1 = CoreV1Api()
         # Update the secrets

--- a/modules/gcp_gke/gcp_gke.py
+++ b/modules/gcp_gke/gcp_gke.py
@@ -2,6 +2,7 @@ from typing import TYPE_CHECKING
 
 from modules.base import ModuleProcessor
 from opta.core.gcp import GCP
+from opta.core.kubernetes import purge_opta_kube_config
 from opta.exceptions import UserErrors
 
 if TYPE_CHECKING:
@@ -12,6 +13,9 @@ if TYPE_CHECKING:
 class GcpGkeProcessor(ModuleProcessor):
     def __init__(self, module: "Module", layer: "Layer"):
         super(GcpGkeProcessor, self).__init__(module, layer)
+
+    def post_delete(self, module_idx: int) -> None:
+        purge_opta_kube_config(layer=self.layer)
 
     def process(self, module_idx: int) -> None:
         gcp_base_module = None

--- a/modules/k8s_manifest/k8s_manifest.py
+++ b/modules/k8s_manifest/k8s_manifest.py
@@ -8,7 +8,7 @@ if TYPE_CHECKING:
 
 import yaml
 
-from opta.core.kubernetes import get_config_file_name
+from opta.core.kubernetes import get_kube_config_file_name
 
 
 class K8smanifestProcessor(ModuleProcessor):
@@ -27,7 +27,7 @@ class K8smanifestProcessor(ModuleProcessor):
         if layer.cloud == "local":
             return "~/.kube/config", "kind-opta-local-cluster"
         else:
-            config_file_name = get_config_file_name(layer)
+            config_file_name = get_kube_config_file_name(layer)
         with open(config_file_name, "r") as stream:
             context = (yaml.safe_load(stream))["current-context"]
         return config_file_name, context

--- a/opta/commands/events.py
+++ b/opta/commands/events.py
@@ -7,8 +7,8 @@ import pytz
 from opta.amplitude import amplitude_client
 from opta.core.generator import gen_all
 from opta.core.kubernetes import (
-    configure_kubectl,
     load_opta_kube_config,
+    set_kube_config,
     tail_namespace_events,
 )
 from opta.layer import Layer
@@ -45,6 +45,6 @@ def events(env: Optional[str], config: str, seconds: Optional[int]) -> None:
         )
     layer.verify_cloud_credentials()
     gen_all(layer)
-    configure_kubectl(layer)
+    set_kube_config(layer)
     load_opta_kube_config()
     tail_namespace_events(layer, start_time)

--- a/opta/commands/force_unlock.py
+++ b/opta/commands/force_unlock.py
@@ -5,7 +5,7 @@ import click
 from opta.amplitude import amplitude_client
 from opta.core.generator import gen_all
 from opta.core.helm import Helm
-from opta.core.kubernetes import configure_kubectl
+from opta.core.kubernetes import set_kube_config
 from opta.core.terraform import Terraform
 from opta.layer import Layer
 from opta.utils import check_opta_file_exists
@@ -51,7 +51,7 @@ def force_unlock(config: str, env: Optional[str]) -> None:
 
     if Terraform.download_state(layer):
         if layer.parent is not None or "k8scluster" in modules:
-            configure_kubectl(layer)
+            set_kube_config(layer)
             pending_upgrade_release_list = Helm.get_helm_list(status="pending-upgrade")
             click.confirm(
                 "Do you also wish to Rollback the Helm releases in Pending-Upgrade State?"

--- a/opta/commands/kubectl.py
+++ b/opta/commands/kubectl.py
@@ -16,14 +16,7 @@ from opta.utils import check_opta_file_exists
 @click.option(
     "-e", "--env", default=None, help="The env to use when loading the config file"
 )
-@click.option(
-    "-f",
-    "--force",
-    is_flag=True,
-    default=False,
-    help="Purge the existing cached kube config",
-)
-def configure_kubectl(config: str, env: Optional[str], force: bool) -> None:
+def configure_kubectl(config: str, env: Optional[str]) -> None:
     """
     Configure kubectl so you can connect to the cluster
 
@@ -40,7 +33,6 @@ def configure_kubectl(config: str, env: Optional[str], force: bool) -> None:
         event_properties={"org_name": layer.org_name, "layer_name": layer.name},
     )
     layer.verify_cloud_credentials()
-    if force:
-        purge_opta_kube_config(layer)
+    purge_opta_kube_config(layer)
     configure(layer)
     load_opta_kube_config_to_default(layer)

--- a/opta/commands/kubectl.py
+++ b/opta/commands/kubectl.py
@@ -3,8 +3,8 @@ from typing import Optional
 import click
 
 from opta.amplitude import amplitude_client
-from opta.core.kubernetes import configure_kubectl as configure
-from opta.core.kubernetes import load_opta_config_to_default
+from opta.core.kubernetes import load_opta_kube_config_to_default, purge_opta_kube_config
+from opta.core.kubernetes import set_kube_config as configure
 from opta.layer import Layer
 from opta.utils import check_opta_file_exists
 
@@ -16,7 +16,14 @@ from opta.utils import check_opta_file_exists
 @click.option(
     "-e", "--env", default=None, help="The env to use when loading the config file"
 )
-def configure_kubectl(config: str, env: Optional[str]) -> None:
+@click.option(
+    "-f",
+    "--force",
+    is_flag=True,
+    default=False,
+    help="Purge the existing cached kube config",
+)
+def configure_kubectl(config: str, env: Optional[str], force: bool) -> None:
     """
     Configure kubectl so you can connect to the cluster
 
@@ -33,5 +40,7 @@ def configure_kubectl(config: str, env: Optional[str]) -> None:
         event_properties={"org_name": layer.org_name, "layer_name": layer.name},
     )
     layer.verify_cloud_credentials()
+    if force:
+        purge_opta_kube_config(layer)
     configure(layer)
-    load_opta_config_to_default(layer)
+    load_opta_kube_config_to_default(layer)

--- a/opta/commands/logs.py
+++ b/opta/commands/logs.py
@@ -4,7 +4,7 @@ import click
 
 from opta.amplitude import amplitude_client
 from opta.core.generator import gen_all
-from opta.core.kubernetes import configure_kubectl, load_opta_kube_config, tail_module_log
+from opta.core.kubernetes import load_opta_kube_config, set_kube_config, tail_module_log
 from opta.exceptions import UserErrors
 from opta.layer import Layer
 from opta.utils import check_opta_file_exists
@@ -44,7 +44,7 @@ def logs(env: Optional[str], config: str, seconds: Optional[int]) -> None:
     )
     layer.verify_cloud_credentials()
     gen_all(layer)
-    configure_kubectl(layer)
+    set_kube_config(layer)
     load_opta_kube_config()
     if layer.cloud == "aws":
         modules = layer.get_module_by_type("k8s-service")

--- a/opta/commands/secret.py
+++ b/opta/commands/secret.py
@@ -5,7 +5,7 @@ from click_didyoumean import DYMGroup
 
 from opta.amplitude import amplitude_client
 from opta.core.generator import gen_all
-from opta.core.kubernetes import configure_kubectl, create_namespace_if_not_exists
+from opta.core.kubernetes import create_namespace_if_not_exists, set_kube_config
 from opta.core.secrets import (
     bulk_update_manual_secrets,
     get_secrets,
@@ -60,7 +60,7 @@ def view(secret: str, env: Optional[str], config: str) -> None:
     layer.verify_cloud_credentials()
     gen_all(layer)
 
-    configure_kubectl(layer)
+    set_kube_config(layer)
     create_namespace_if_not_exists(layer.name)
     secrets = get_secrets(layer.name)
     if secret not in secrets:
@@ -98,7 +98,7 @@ def list_command(env: Optional[str], config: str) -> None:
     amplitude_client.send_event(amplitude_client.LIST_SECRETS_EVENT)
     gen_all(layer)
 
-    configure_kubectl(layer)
+    set_kube_config(layer)
     create_namespace_if_not_exists(layer.name)
     secrets = get_secrets(layer.name)
     for key, value in secrets.items():
@@ -126,7 +126,7 @@ def update(secret: str, value: str, env: Optional[str], config: str) -> None:
     layer = Layer.load_from_yaml(config, env)
     gen_all(layer)
 
-    configure_kubectl(layer)
+    set_kube_config(layer)
     create_namespace_if_not_exists(layer.name)
     amplitude_client.send_event(amplitude_client.UPDATE_SECRET_EVENT)
     update_manual_secrets(layer.name, {secret: str(value)})
@@ -156,7 +156,7 @@ def bulk_update(env_file: str, env: Optional[str], config: str) -> None:
     layer = Layer.load_from_yaml(config, env)
     gen_all(layer)
 
-    configure_kubectl(layer)
+    set_kube_config(layer)
     create_namespace_if_not_exists(layer.name)
     amplitude_client.send_event(amplitude_client.UPDATE_BULK_SECRET_EVENT)
 

--- a/opta/commands/shell.py
+++ b/opta/commands/shell.py
@@ -6,7 +6,7 @@ from kubernetes.client import CoreV1Api
 from opta.amplitude import amplitude_client
 from opta.constants import SHELLS_ALLOWED
 from opta.core.generator import gen_all
-from opta.core.kubernetes import configure_kubectl, load_opta_kube_config
+from opta.core.kubernetes import load_opta_kube_config, set_kube_config
 from opta.exceptions import UserErrors
 from opta.layer import Layer
 from opta.nice_subprocess import nice_run
@@ -47,7 +47,7 @@ def shell(env: Optional[str], config: str, type: str) -> None:
     )
     layer.verify_cloud_credentials()
     gen_all(layer)
-    configure_kubectl(layer)
+    set_kube_config(layer)
     load_opta_kube_config()
 
     # Get a random pod in the service

--- a/opta/core/generator.py
+++ b/opta/core/generator.py
@@ -6,9 +6,9 @@ from colored import attr
 from opta import gen_tf
 from opta.constants import TF_FILE_PATH
 from opta.core.kubernetes import (
-    configure_kubectl,
     current_image_digest_tag,
     get_cluster_name,
+    set_kube_config,
 )
 from opta.utils import deep_merge, logger
 
@@ -47,7 +47,7 @@ def gen(
             and len(service_modules) > 0
             and (get_cluster_name(layer.root()) is not None)
         ):
-            configure_kubectl(layer)
+            set_kube_config(layer)
 
             for service_module in service_modules:
                 current_image_info = current_image_digest_tag(layer)

--- a/tests/commands/test_force_unlock.py
+++ b/tests/commands/test_force_unlock.py
@@ -46,7 +46,7 @@ def test_force_unlock_env(mocker: MockFixture) -> None:
         return_value=(True, "mock_lock_id"),
     )
     mocker.patch("opta.commands.force_unlock.Terraform.force_unlock")
-    mocker.patch("opta.commands.force_unlock.configure_kubectl")
+    mocker.patch("opta.commands.force_unlock.set_kube_config")
     mocked_helm_list = mocker.patch(
         "opta.commands.force_unlock.Helm.get_helm_list",
         return_value=[
@@ -122,7 +122,7 @@ def test_force_unlock_env_no_cluster(mocker: MockFixture) -> None:
         return_value=(True, "mock_lock_id"),
     )
     mocker.patch("opta.commands.force_unlock.Terraform.force_unlock")
-    mocker.patch("opta.commands.force_unlock.configure_kubectl")
+    mocker.patch("opta.commands.force_unlock.set_kube_config")
     mocked_helm_list = mocker.patch(
         "opta.commands.force_unlock.Helm.get_helm_list",
         return_value=[
@@ -185,7 +185,7 @@ def test_force_unlock_env_no_rollback(mocker: MockFixture) -> None:
         return_value=(True, "mock_lock_id"),
     )
     mocker.patch("opta.commands.force_unlock.Terraform.force_unlock")
-    mocker.patch("opta.commands.force_unlock.configure_kubectl")
+    mocker.patch("opta.commands.force_unlock.set_kube_config")
     mocked_helm_list = mocker.patch(
         "opta.commands.force_unlock.Helm.get_helm_list", return_value=[],
     )

--- a/tests/commands/test_kubectl.py
+++ b/tests/commands/test_kubectl.py
@@ -5,7 +5,7 @@ from opta.commands.kubectl import configure_kubectl
 from opta.layer import Layer
 
 
-def test_configure_kubectl(mocker: MockFixture) -> None:
+def test_set_kube_config(mocker: MockFixture) -> None:
     # Mock tf file generation
     mocked_layer_class = mocker.patch("opta.commands.kubectl.Layer")
     mocked_layer = mocker.Mock(spec=Layer)
@@ -19,8 +19,8 @@ def test_configure_kubectl(mocker: MockFixture) -> None:
     mocked_check_opta_file_exists = mocker.patch(
         "opta.commands.kubectl.check_opta_file_exists"
     )
-    mocked_load_opta_config_to_default = mocker.patch(
-        "opta.commands.kubectl.load_opta_config_to_default"
+    mocked_load_opta_kube_config_to_default = mocker.patch(
+        "opta.commands.kubectl.load_opta_kube_config_to_default"
     )
 
     runner = CliRunner()
@@ -29,5 +29,5 @@ def test_configure_kubectl(mocker: MockFixture) -> None:
     mocked_layer_class.load_from_yaml.assert_called_with(mocker.ANY, None)
     mocked_layer.verify_cloud_credentials.assert_called_once_with()
     mocked_configure.assert_called_once_with(mocked_layer)
-    mocked_load_opta_config_to_default.assert_called_once_with(mocked_layer)
+    mocked_load_opta_kube_config_to_default.assert_called_once_with(mocked_layer)
     mocked_check_opta_file_exists.assert_called_once_with("opta.yaml")

--- a/tests/commands/test_kubectl.py
+++ b/tests/commands/test_kubectl.py
@@ -19,6 +19,9 @@ def test_set_kube_config(mocker: MockFixture) -> None:
     mocked_check_opta_file_exists = mocker.patch(
         "opta.commands.kubectl.check_opta_file_exists"
     )
+    mocked_purge_opta_kube_config = mocker.patch(
+        "opta.commands.kubectl.purge_opta_kube_config"
+    )
     mocked_load_opta_kube_config_to_default = mocker.patch(
         "opta.commands.kubectl.load_opta_kube_config_to_default"
     )
@@ -29,5 +32,6 @@ def test_set_kube_config(mocker: MockFixture) -> None:
     mocked_layer_class.load_from_yaml.assert_called_with(mocker.ANY, None)
     mocked_layer.verify_cloud_credentials.assert_called_once_with()
     mocked_configure.assert_called_once_with(mocked_layer)
+    mocked_purge_opta_kube_config.assert_called_once_with(mocked_layer)
     mocked_load_opta_kube_config_to_default.assert_called_once_with(mocked_layer)
     mocked_check_opta_file_exists.assert_called_once_with("opta.yaml")

--- a/tests/commands/test_logs.py
+++ b/tests/commands/test_logs.py
@@ -18,7 +18,7 @@ def test_logs(mocker: MockFixture) -> None:
     mocked_layer.cloud = "aws"
     mocked_layer_class.load_from_yaml.return_value = mocked_layer
     layer_gen_all = mocker.patch("opta.commands.logs.gen_all")
-    configure_kubectl = mocker.patch("opta.commands.logs.configure_kubectl")
+    set_kube_config = mocker.patch("opta.commands.logs.set_kube_config")
     load_kube_config = mocker.patch("opta.commands.logs.load_opta_kube_config")
 
     mocked_module = mocker.Mock(spec=Module)
@@ -33,7 +33,7 @@ def test_logs(mocker: MockFixture) -> None:
 
     assert result.exit_code == 0
     layer_gen_all.assert_called_once_with(mocked_layer)
-    configure_kubectl.assert_called_once_with(mocked_layer)
+    set_kube_config.assert_called_once_with(mocked_layer)
     load_kube_config.assert_called_once()
 
     mocked_tail_module_log.assert_called_once_with(mocked_layer, "module_name", None)

--- a/tests/commands/test_secret.py
+++ b/tests/commands/test_secret.py
@@ -29,7 +29,7 @@ class TestSecretManager:
         )
 
         mocker.patch("opta.commands.secret.gen_all")
-        mocker.patch("opta.commands.secret.configure_kubectl")
+        mocker.patch("opta.commands.secret.set_kube_config")
 
         mocked_create_namespace_if_not_exists = mocker.patch(
             "opta.commands.secret.create_namespace_if_not_exists"
@@ -62,7 +62,7 @@ class TestSecretManager:
         )
         mocked_print = mocker.patch("builtins.print")
         mocker.patch("opta.commands.secret.gen_all")
-        mocker.patch("opta.commands.secret.configure_kubectl")
+        mocker.patch("opta.commands.secret.set_kube_config")
 
         mocked_create_namespace_if_not_exists = mocker.patch(
             "opta.commands.secret.create_namespace_if_not_exists"
@@ -105,7 +105,7 @@ class TestSecretManager:
             "opta.commands.secret.update_manual_secrets"
         )
 
-        mocker.patch("opta.commands.secret.configure_kubectl")
+        mocker.patch("opta.commands.secret.set_kube_config")
 
         mocked_amplitude_client = mocker.patch(
             "opta.commands.secret.amplitude_client", spec=AmplitudeClient
@@ -147,7 +147,7 @@ class TestSecretManager:
         )
         mocker.patch("opta.utils.os.path.exists")
         mocker.patch("opta.commands.secret.gen_all")
-        mocker.patch("opta.commands.secret.configure_kubectl")
+        mocker.patch("opta.commands.secret.set_kube_config")
         mocked_create_namespace_if_not_exists = mocker.patch(
             "opta.commands.secret.create_namespace_if_not_exists"
         )

--- a/tests/commands/test_shell.py
+++ b/tests/commands/test_shell.py
@@ -16,7 +16,7 @@ def test_shell(mocker: MockFixture) -> None:
     mocked_layer.org_name = "dummy_org_name"
     mocked_layer_class.load_from_yaml.return_value = mocked_layer
     layer_gen_all = mocker.patch("opta.commands.shell.gen_all")
-    configure_kubectl = mocker.patch("opta.commands.shell.configure_kubectl")
+    set_kube_config = mocker.patch("opta.commands.shell.set_kube_config")
     load_kube_config = mocker.patch("opta.commands.shell.load_opta_kube_config")
 
     mocked_core_v1_api_class = mocker.patch("opta.commands.shell.CoreV1Api")
@@ -36,7 +36,7 @@ def test_shell(mocker: MockFixture) -> None:
 
     assert result.exit_code == 0
     layer_gen_all.assert_called_once_with(mocked_layer)
-    configure_kubectl.assert_called_once_with(mocked_layer)
+    set_kube_config.assert_called_once_with(mocked_layer)
     load_kube_config.assert_called_once()
     mocked_core_v1_api.list_namespaced_pod.assert_called_once_with("layer_name")
 
@@ -67,7 +67,7 @@ def test_shell_with_sh(mocker: MockFixture) -> None:
     mocked_layer.org_name = "dummy_org_name"
     mocked_layer_class.load_from_yaml.return_value = mocked_layer
     layer_gen_all = mocker.patch("opta.commands.shell.gen_all")
-    configure_kubectl = mocker.patch("opta.commands.shell.configure_kubectl")
+    set_kube_config = mocker.patch("opta.commands.shell.set_kube_config")
     load_kube_config = mocker.patch("opta.commands.shell.load_opta_kube_config")
 
     mocked_core_v1_api_class = mocker.patch("opta.commands.shell.CoreV1Api")
@@ -87,7 +87,7 @@ def test_shell_with_sh(mocker: MockFixture) -> None:
 
     assert result.exit_code == 0
     layer_gen_all.assert_called_once_with(mocked_layer)
-    configure_kubectl.assert_called_once_with(mocked_layer)
+    set_kube_config.assert_called_once_with(mocked_layer)
     load_kube_config.assert_called_once()
     mocked_core_v1_api.list_namespaced_pod.assert_called_once_with("layer_name")
 

--- a/tests/core/test_kubernetes.py
+++ b/tests/core/test_kubernetes.py
@@ -16,10 +16,10 @@ from pytest_mock import MockFixture
 
 from opta.core.kubernetes import (
     GENERATED_KUBE_CONFIG_DIR,
-    configure_kubectl,
     delete_persistent_volume_claims,
     get_required_path_executables,
     list_persistent_volume_claims,
+    set_kube_config,
     tail_module_log,
     tail_namespace_events,
     tail_pod_log,
@@ -28,7 +28,7 @@ from opta.layer import Layer
 
 
 class TestKubernetes:
-    def test_azure_configure_kubectl(self, mocker: MockFixture) -> None:
+    def test_azure_set_kube_config(self, mocker: MockFixture) -> None:
         mocked_ensure_installed = mocker.patch("opta.core.kubernetes.ensure_installed")
         layer = mocker.Mock(spec=Layer)
         layer.parent = None
@@ -60,7 +60,7 @@ class TestKubernetes:
         )
         mocked_nice_run = mocker.patch("opta.core.kubernetes.nice_run",)
 
-        configure_kubectl(layer)
+        set_kube_config(layer)
 
         mocked_terraform_output.assert_called_once_with(layer)
         mocked_ensure_installed.assert_has_calls(
@@ -86,7 +86,7 @@ class TestKubernetes:
             ]
         )
 
-    def test_aws_configure_kubectl(self, mocker: MockFixture) -> None:
+    def test_aws_set_kube_config(self, mocker: MockFixture) -> None:
         mocked_ensure_installed = mocker.patch("opta.core.kubernetes.ensure_installed")
         mocked_exist = mocker.patch("opta.core.kubernetes.exists")
         mocked_exist.return_value = False
@@ -112,7 +112,7 @@ class TestKubernetes:
         mocked_file = mocker.patch(
             "opta.core.kubernetes.open", mocker.mock_open(read_data="")
         )
-        configure_kubectl(layer)
+        set_kube_config(layer)
         config_file_name = f"{GENERATED_KUBE_CONFIG_DIR}/kubeconfig-{layer.root().name}-{layer.cloud}.yaml"
         mocked_file.assert_called_once_with(config_file_name, "w")
         mocked_file().write.assert_called_once_with(


### PR DESCRIPTION
# Description
This change does 2 things:
1. The old configure kubectl method was poorly named, especially since now it did not actually change kubectl behavior. It has been renamed to set_kube_config and given a docstring explaining its purpose as creatign a separate kubeconfig file just for the current layer, which then may or may not be loaded to the default kubeconfig used by kubectl
2. Added a purge kube config function which cleans up the artificially created kubeconfig, usually as part of a full refresh. This can be done manually via the new --force flag of `opta configure-kubectl` and done automatically when a k8s cluster is deleted.


# Safety checklist
* [x] This change is backwards compatible and safe to apply by existing users
* [x] This change will NOT lead to data loss
* [x] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
n/a
