### PR TITLE
Updating the azure and gcp nginx spec to have the client ip fix

### DIFF
--- a/modules/azure_k8s_base/tf_module/ingress_nginx.tf
+++ b/modules/azure_k8s_base/tf_module/ingress_nginx.tf
@@ -64,6 +64,7 @@ resource "helm_release" "ingress-nginx" {
         extraArgs : var.private_key == "" ? {} : { default-ssl-certificate : "ingress-nginx/secret-tls" }
         config : local.config
         podAnnotations : {
+          "config.linkerd.io/skip-inbound-ports" : "80,443" // NOTE: should be removed when this is fixed: https://github.com/linkerd/linkerd2/issues/4219
           "linkerd.io/inject" : "enabled"
         }
         resources : {

--- a/modules/gcp_k8s_base/tf_module/ingress_nginx.tf
+++ b/modules/gcp_k8s_base/tf_module/ingress_nginx.tf
@@ -16,6 +16,7 @@ resource "helm_release" "ingress-nginx" {
         extraArgs : var.private_key == "" ? {} : { default-ssl-certificate : "ingress-nginx/secret-tls" }
         config : local.config
         podAnnotations : {
+          "config.linkerd.io/skip-inbound-ports" : "80,443" // NOTE: should be removed when this is fixed: https://github.com/linkerd/linkerd2/issues/4219
           "linkerd.io/inject" : "enabled"
           "cluster-autoscaler.kubernetes.io/safe-to-evict" : "true"
         }


### PR DESCRIPTION
# Description
In our haste, we did not update GCP and Azure, just AWS (https://github.com/run-x/opta/pull/614). Let's fix that.

NOTE: this will lead to downtime for GCP and Azure users. It will not lead to downtime for AWS because that was already done in the pr doing this for AWS

# Safety checklist
* [X] This change is backwards compatible and safe to apply by existing users
* [X] This change will NOT lead to data loss
* [ ] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
manually
