### PR TITLE
Updating default EKS version to 1.21

### DIFF
--- a/modules/aws_eks/aws-eks.json
+++ b/modules/aws_eks/aws-eks.json
@@ -31,7 +31,7 @@
     "k8s_version": {
       "type": "string",
       "description": "The Kubernetes version for the cluster. Must be [supported by EKS](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html)",
-      "default": "1.18"
+      "default": "1.21"
     },
     "control_plane_security_groups": {
       "type": "array",

--- a/modules/aws_eks/aws-eks.yaml
+++ b/modules/aws_eks/aws-eks.yaml
@@ -55,7 +55,7 @@ inputs:
     user_facing: true
     validator: str(required=False)
     description: The Kubernetes version for the cluster. Must be [supported by EKS](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html)
-    default: "1.18"
+    default: "1.21"
   - name: control_plane_security_groups
     user_facing: true
     validator: list(str(), required=False)


### PR DESCRIPTION
# Description
Because our defaults are sticky, this will not force any of our customers to go from 1.18 to 1.21, but rather any new kubernetes clusters will come up with this version. In our talk we did not identify any issues with 1.21, and furthermore we've been running it fine on our GCP daily tests, so this should be totally safe.


# Safety checklist
* [x] This change is backwards compatible and safe to apply by existing users
* [x] This change will NOT lead to data loss
* [x] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?

