### PR TITLE
Use stable k8s ingress version if detected

### DIFF
--- a/modules/aws_k8s_base/tf_module/opta-base/Chart.yaml
+++ b/modules/aws_k8s_base/tf_module/opta-base/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.2
+version: 0.2.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/modules/aws_k8s_base/tf_module/opta-base/templates/_helpers.tpl
+++ b/modules/aws_k8s_base/tf_module/opta-base/templates/_helpers.tpl
@@ -59,3 +59,32 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- .Values.moduleName }}
 {{- end }}
 
+{{- define "ingress.apiVersion" -}}
+  {{- if and (.Capabilities.APIVersions.Has "networking.k8s.io/v1") (semverCompare ">= 1.19.x" (include "prometheus.kubeVersion" .)) -}}
+      {{- print "networking.k8s.io/v1" -}}
+  {{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" -}}
+    {{- print "networking.k8s.io/v1beta1" -}}
+  {{- else -}}
+    {{- print "extensions/v1beta1" -}}
+  {{- end -}}
+{{- end -}}
+
+
+{{/*
+Return if ingress is stable.
+*/}}
+{{- define "ingress.isStable" -}}
+  {{- eq (include "ingress.apiVersion" .) "networking.k8s.io/v1" -}}
+{{- end -}}
+{{/*
+Return if ingress supports ingressClassName.
+*/}}
+{{- define "ingress.supportsIngressClassName" -}}
+  {{- or (eq (include "ingress.isStable" .) "true") (and (eq (include "ingress.apiVersion" .) "networking.k8s.io/v1beta1") (semverCompare ">= 1.18.x" (include "prometheus.kubeVersion" .))) -}}
+{{- end -}}
+{{/*
+Return if ingress supports pathType.
+*/}}
+{{- define "ingress.supportsPathType" -}}
+  {{- or (eq (include "ingress.isStable" .) "true") (and (eq (include "ingress.apiVersion" .) "networking.k8s.io/v1beta1") (semverCompare ">= 1.18.x" (include "prometheus.kubeVersion" .))) -}}
+{{- end -}}

--- a/modules/aws_k8s_base/tf_module/opta-base/templates/_helpers.tpl
+++ b/modules/aws_k8s_base/tf_module/opta-base/templates/_helpers.tpl
@@ -1,4 +1,11 @@
 {{/*
+Get KubeVersion removing pre-release information.
+*/}}
+{{- define "opta.kubeVersion" -}}
+  {{- default .Capabilities.KubeVersion.Version (regexFind "v[0-9]+\\.[0-9]+\\.[0-9]+" .Capabilities.KubeVersion.Version) -}}
+{{- end -}}
+
+{{/*
 Expand the name of the chart.
 */}}
 {{- define "opta-base.name" -}}
@@ -60,7 +67,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{- define "ingress.apiVersion" -}}
-  {{- if and (.Capabilities.APIVersions.Has "networking.k8s.io/v1") (semverCompare ">= 1.19.x" (include "prometheus.kubeVersion" .)) -}}
+  {{- if and (.Capabilities.APIVersions.Has "networking.k8s.io/v1") (semverCompare ">= 1.19.x" (include "opta.kubeVersion" .)) -}}
       {{- print "networking.k8s.io/v1" -}}
   {{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" -}}
     {{- print "networking.k8s.io/v1beta1" -}}
@@ -80,11 +87,11 @@ Return if ingress is stable.
 Return if ingress supports ingressClassName.
 */}}
 {{- define "ingress.supportsIngressClassName" -}}
-  {{- or (eq (include "ingress.isStable" .) "true") (and (eq (include "ingress.apiVersion" .) "networking.k8s.io/v1beta1") (semverCompare ">= 1.18.x" (include "prometheus.kubeVersion" .))) -}}
+  {{- or (eq (include "ingress.isStable" .) "true") (and (eq (include "ingress.apiVersion" .) "networking.k8s.io/v1beta1") (semverCompare ">= 1.18.x" (include "opta.kubeVersion" .))) -}}
 {{- end -}}
 {{/*
 Return if ingress supports pathType.
 */}}
 {{- define "ingress.supportsPathType" -}}
-  {{- or (eq (include "ingress.isStable" .) "true") (and (eq (include "ingress.apiVersion" .) "networking.k8s.io/v1beta1") (semverCompare ">= 1.18.x" (include "prometheus.kubeVersion" .))) -}}
+  {{- or (eq (include "ingress.isStable" .) "true") (and (eq (include "ingress.apiVersion" .) "networking.k8s.io/v1beta1") (semverCompare ">= 1.18.x" (include "opta.kubeVersion" .))) -}}
 {{- end -}}

--- a/modules/aws_k8s_base/tf_module/opta-base/templates/nginx_health_check.yaml
+++ b/modules/aws_k8s_base/tf_module/opta-base/templates/nginx_health_check.yaml
@@ -1,3 +1,6 @@
+{{- $ingressApiIsStable := eq (include "ingress.isStable" .) "true" -}}
+{{- $ingressSupportsIngressClassName := eq (include "ingress.supportsIngressClassName" .) "true" -}}
+{{- $ingressSupportsPathType := eq (include "ingress.supportsPathType" .) "true" -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -22,12 +25,27 @@ metadata:
   labels:
     opta-generated: "true"
   annotations:
+    {{- if not $ingressSupportsIngressClassName }}
     kubernetes.io/ingress.class: "nginx"
+    {{- end }}
 spec:
+  {{- if $ingressSupportsIngressClassName }}
+  ingressClassName: "nginx"
+  {{- end }}
   rules:
     - http:
         paths:
           - path: "/healthz"
+            {{- if $ingressSupportsPathType }}
+            pathType: "prefix"
+            {{- end }}
             backend:
+              {{- if $ingressApiIsStable }}
+              service:
+                name: opta-ingress-healthcheck
+                port:
+                  number: 80
+              {{- else }}
               serviceName: opta-ingress-healthcheck
               servicePort: 80
+              {{- end }}

--- a/modules/opta-k8s-service-helm/templates/_helpers.tpl
+++ b/modules/opta-k8s-service-helm/templates/_helpers.tpl
@@ -74,3 +74,32 @@ opta.dev/environment-name: {{ .Values.environmentName }}
 {{- .Values.moduleName }}
 {{- end }}
 
+{{- define "ingress.apiVersion" -}}
+  {{- if and (.Capabilities.APIVersions.Has "networking.k8s.io/v1") (semverCompare ">= 1.19.x" (include "prometheus.kubeVersion" .)) -}}
+      {{- print "networking.k8s.io/v1" -}}
+  {{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" -}}
+    {{- print "networking.k8s.io/v1beta1" -}}
+  {{- else -}}
+    {{- print "extensions/v1beta1" -}}
+  {{- end -}}
+{{- end -}}
+
+
+{{/*
+Return if ingress is stable.
+*/}}
+{{- define "ingress.isStable" -}}
+  {{- eq (include "ingress.apiVersion" .) "networking.k8s.io/v1" -}}
+{{- end -}}
+{{/*
+Return if ingress supports ingressClassName.
+*/}}
+{{- define "ingress.supportsIngressClassName" -}}
+  {{- or (eq (include "ingress.isStable" .) "true") (and (eq (include "ingress.apiVersion" .) "networking.k8s.io/v1beta1") (semverCompare ">= 1.18.x" (include "prometheus.kubeVersion" .))) -}}
+{{- end -}}
+{{/*
+Return if ingress supports pathType.
+*/}}
+{{- define "ingress.supportsPathType" -}}
+  {{- or (eq (include "ingress.isStable" .) "true") (and (eq (include "ingress.apiVersion" .) "networking.k8s.io/v1beta1") (semverCompare ">= 1.18.x" (include "prometheus.kubeVersion" .))) -}}
+{{- end -}}

--- a/modules/opta-k8s-service-helm/templates/_helpers.tpl
+++ b/modules/opta-k8s-service-helm/templates/_helpers.tpl
@@ -1,4 +1,11 @@
 {{/*
+Get KubeVersion removing pre-release information.
+*/}}
+{{- define "opta.kubeVersion" -}}
+  {{- default .Capabilities.KubeVersion.Version (regexFind "v[0-9]+\\.[0-9]+\\.[0-9]+" .Capabilities.KubeVersion.Version) -}}
+{{- end -}}
+
+{{/*
 Expand the name of the chart.
 */}}
 {{- define "k8s-service.name" -}}
@@ -75,7 +82,7 @@ opta.dev/environment-name: {{ .Values.environmentName }}
 {{- end }}
 
 {{- define "ingress.apiVersion" -}}
-  {{- if and (.Capabilities.APIVersions.Has "networking.k8s.io/v1") (semverCompare ">= 1.19.x" (include "prometheus.kubeVersion" .)) -}}
+  {{- if and (.Capabilities.APIVersions.Has "networking.k8s.io/v1") (semverCompare ">= 1.19.x" (include "opta.kubeVersion" .)) -}}
       {{- print "networking.k8s.io/v1" -}}
   {{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" -}}
     {{- print "networking.k8s.io/v1beta1" -}}
@@ -95,11 +102,11 @@ Return if ingress is stable.
 Return if ingress supports ingressClassName.
 */}}
 {{- define "ingress.supportsIngressClassName" -}}
-  {{- or (eq (include "ingress.isStable" .) "true") (and (eq (include "ingress.apiVersion" .) "networking.k8s.io/v1beta1") (semverCompare ">= 1.18.x" (include "prometheus.kubeVersion" .))) -}}
+  {{- or (eq (include "ingress.isStable" .) "true") (and (eq (include "ingress.apiVersion" .) "networking.k8s.io/v1beta1") (semverCompare ">= 1.18.x" (include "opta.kubeVersion" .))) -}}
 {{- end -}}
 {{/*
 Return if ingress supports pathType.
 */}}
 {{- define "ingress.supportsPathType" -}}
-  {{- or (eq (include "ingress.isStable" .) "true") (and (eq (include "ingress.apiVersion" .) "networking.k8s.io/v1beta1") (semverCompare ">= 1.18.x" (include "prometheus.kubeVersion" .))) -}}
+  {{- or (eq (include "ingress.isStable" .) "true") (and (eq (include "ingress.apiVersion" .) "networking.k8s.io/v1beta1") (semverCompare ">= 1.18.x" (include "opta.kubeVersion" .))) -}}
 {{- end -}}

--- a/modules/opta-k8s-service-helm/templates/ingress.yaml
+++ b/modules/opta-k8s-service-helm/templates/ingress.yaml
@@ -12,6 +12,9 @@
 {{ $domain_pathPrefix_sha256 = trunc 8 (sha256sum $domain_pathPrefix) }}
 {{ $ingress_name_new_convention = print $ingress_base_name "-" $domain_pathPrefix_sha256 }}
 {{ $old_ingress_convention = (lookup "networking.k8s.io/v1beta1" "Ingress" $namespace_name $ingress_name_old_convention) }}
+{{- $ingressApiIsStable := eq (include "ingress.isStable" .) "true" -}}
+{{- $ingressSupportsIngressClassName := eq (include "ingress.supportsIngressClassName" .) "true" -}}
+{{- $ingressSupportsPathType := eq (include "ingress.supportsPathType" .) "true" -}}
 
 apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
@@ -45,7 +48,9 @@ metadata:
     nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
     {{- end }}
     cert-manager.io/cluster-issuer: opta-selfsigned
+    {{- if not $ingressSupportsIngressClassName }}
     kubernetes.io/ingress.class: "nginx"
+    {{- end }}
     nginx.ingress.kubernetes.io/configuration-snippet: |
       proxy_set_header l5d-dst-override $service_name.$namespace.svc.cluster.local:$service_port;
       grpc_set_header l5d-dst-override $service_name.$namespace.svc.cluster.local:$service_port;
@@ -58,6 +63,9 @@ metadata:
     {{ $k | quote }}: {{ $v | quote }}
     {{- end }}
 spec:
+  {{- if $ingressSupportsIngressClassName }}
+  ingressClassName: "nginx"
+  {{- end }}
   rules:
     - {{ if not (eq $val.domain "all" ) }}
       host: {{ $val.domain }}
@@ -65,9 +73,19 @@ spec:
       http:
         paths:
           - path: {{ $val.pathPrefix }}{{ if not (eq $val.pathPrefix "/") }}(/|$)(.*){{ end }}
+            {{- if $ingressSupportsPathType }}
+            pathType: "prefix"
+            {{- end }}
             backend:
+              {{- if $ingressApiIsStable }}
+              service:
+                name: {{ include "k8s-service.serviceName" $ }}
+                port:
+                  name: {{ $.Values.httpPort.name | quote }}
+              {{- else }}
               serviceName: {{ include "k8s-service.serviceName" $ }}
               servicePort: {{ $.Values.httpPort.name | quote }}
+              {{- end }}
 ---
 {{- end }}
 {{- end }}


### PR DESCRIPTION
# Description
As our users start switching to the newer versions of kubernetes, we can intelligently determine if we can use the new stable version of the k8s ingress resource (and if we can we should).

@bigbitbus this is for AWS, we still need your pr for gcp

# Safety checklist
* [ ] This change is backwards compatible and safe to apply by existing users
* [ ] This change will NOT lead to data loss
* [ ] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
testing it right now manually
