### PR TITLE
opta secrets are automatically loaded as env variables in deployments

### DIFF
--- a/modules/aws_k8s_service/aws-k8s-service.json
+++ b/modules/aws_k8s_service/aws-k8s-service.json
@@ -57,7 +57,7 @@
     },
     "secrets": {
       "type": "array",
-      "description": "A list of secrets to add as environment variables for your container. All secrets must be set following the [secrets instructions](/tutorials/secrets).",
+      "description": "Deprecated, see [secrets instructions](/tutorials/secrets).",
       "items": {
         "type": "string"
       },

--- a/modules/aws_k8s_service/aws-k8s-service.yaml
+++ b/modules/aws_k8s_service/aws-k8s-service.yaml
@@ -34,10 +34,6 @@ inputs:
     user_facing: false
     description: "Secrets from links"
     default: []
-  - name: manual_secrets
-    user_facing: false
-    description: "Manually set secrets"
-    default: []
   - name: iam_policy
     user_facing: false
     description: "The IAM policy created for this service"
@@ -90,7 +86,7 @@ inputs:
   - name: secrets
     user_facing: true
     validator: list(str(), required=False)
-    description: A list of secrets to add as environment variables for your container. All secrets must be set following the [secrets instructions](/tutorials/secrets).
+    description: Deprecated, see [secrets instructions](/tutorials/secrets).
     default: []
   - name: env_vars
     user_facing: true

--- a/modules/aws_k8s_service/aws_k8s_service.py
+++ b/modules/aws_k8s_service/aws_k8s_service.py
@@ -34,7 +34,6 @@ class AwsK8sServiceProcessor(
 
     def process(self, module_idx: int) -> None:
         # Update the secrets
-        self.module.data["manual_secrets"] = self.module.data.get("secrets", [])
         self.module.data["link_secrets"] = self.module.data.get("link_secrets", [])
 
         current_envars: Union[List, Dict[str, str]] = self.module.data.get("env_vars", [])

--- a/modules/aws_k8s_service/tests/test_k8s_service.py
+++ b/modules/aws_k8s_service/tests/test_k8s_service.py
@@ -47,9 +47,8 @@ class TestK8sServiceProcessor:
             {"name": "DOCDBHOST2", "value": "${{module.docdb2.db_host}}"},
             {"name": "DOCDBPASSWORD2", "value": "${{module.docdb2.db_password}}"},
         ]
-        assert app_module.data["manual_secrets"] == [
-            "BALONEY",
-        ]
+        # this field has been deprecated, no longer populated
+        assert "manual_secrets" not in app_module.data.keys()
         assert app_module.data["iam_policy"] == {
             "Version": "2012-10-17",
             "Statement": [

--- a/modules/aws_k8s_service/tf_module/main.tf
+++ b/modules/aws_k8s_service/tf_module/main.tf
@@ -41,7 +41,6 @@ resource "helm_release" "k8s-service" {
       healthcheck_path : var.healthcheck_path,
       envVars : var.env_vars,
       linkSecrets : var.link_secrets,
-      manualSecrets : var.manual_secrets,
       uriComponents : local.uri_components,
       layerName : var.layer_name,
       moduleName : var.module_name,

--- a/modules/aws_k8s_service/tf_module/variables.tf
+++ b/modules/aws_k8s_service/tf_module/variables.tf
@@ -159,11 +159,6 @@ variable "link_secrets" {
   default = []
 }
 
-variable "manual_secrets" {
-  type    = list(string)
-  default = []
-}
-
 variable "iam_policy" {
 }
 

--- a/modules/azure_k8s_service/azure-k8s-service.json
+++ b/modules/azure_k8s_service/azure-k8s-service.json
@@ -38,7 +38,7 @@
     },
     "secrets": {
       "type": "array",
-      "description": "Optional. A list of secrets to add as environment variables for your container. All secrets must be set following the [secrets instructions](/tutorials/secrets).",
+      "description": "Deprecated, see [secrets instructions](/tutorials/secrets).",
       "items": {
         "type": "string"
       },

--- a/modules/azure_k8s_service/azure-k8s-service.yaml
+++ b/modules/azure_k8s_service/azure-k8s-service.yaml
@@ -30,10 +30,6 @@ inputs: # (what users see)
     user_facing: false
     description: "Secrets from links"
     default: []
-  - name: manual_secrets
-    user_facing: false
-    description: "Manually set secrets"
-    default: []
   - name: image
     user_facing: true
     validator: str(required=True)
@@ -76,7 +72,7 @@ inputs: # (what users see)
   - name: secrets
     user_facing: true
     validator: list(str(), required=False)
-    description: Optional. A list of secrets to add as environment variables for your container. All secrets must be set following the [secrets instructions](/tutorials/secrets).
+    description: Deprecated, see [secrets instructions](/tutorials/secrets).
     default: []
   - name: env_vars
     user_facing: true

--- a/modules/azure_k8s_service/azure_k8s_service.py
+++ b/modules/azure_k8s_service/azure_k8s_service.py
@@ -15,8 +15,8 @@ class AzureK8sServiceProcessor(K8sServiceModuleProcessor):
             raise Exception(
                 f"The module {module.name} was expected to be of type k8s service"
             )
-        self.read_buckets: list[str] = []
-        self.write_buckets: list[str] = []
+        self.read_buckets: List[str] = []
+        self.write_buckets: List[str] = []
         super(AzureK8sServiceProcessor, self).__init__(module, layer)
 
     def pre_hook(self, module_idx: int) -> None:
@@ -25,7 +25,6 @@ class AzureK8sServiceProcessor(K8sServiceModuleProcessor):
 
     def process(self, module_idx: int) -> None:
         # Update the secrets
-        self.module.data["manual_secrets"] = self.module.data.get("secrets", [])
         self.module.data["link_secrets"] = self.module.data.get("link_secrets", [])
 
         current_envars: Union[List, Dict[str, str]] = self.module.data.get("env_vars", [])

--- a/modules/azure_k8s_service/tests/test_azure_k8s_service.py
+++ b/modules/azure_k8s_service/tests/test_azure_k8s_service.py
@@ -40,9 +40,6 @@ class TestAzureK8sServiceProcessor:
             {"name": "CACHEHOST2", "value": "${{module.redis2.cache_host}}"},
             {"name": "CACHEAUTH2", "value": "${{module.redis2.cache_auth_token}}"},
         ]
-        assert app_module.data["manual_secrets"] == [
-            "BALONEY",
-        ]
 
     def test_prehook(self, mocker: MockFixture):
         layer = Layer.load_from_yaml(

--- a/modules/azure_k8s_service/tf_module/main.tf
+++ b/modules/azure_k8s_service/tf_module/main.tf
@@ -41,7 +41,6 @@ resource "helm_release" "k8s-service" {
       healthcheck_path : var.healthcheck_path,
       envVars : var.env_vars,
       linkSecrets : var.link_secrets,
-      manualSecrets : var.manual_secrets,
       uriComponents : local.uri_components,
       layerName : var.layer_name,
       moduleName : var.module_name,

--- a/modules/azure_k8s_service/tf_module/variables.tf
+++ b/modules/azure_k8s_service/tf_module/variables.tf
@@ -160,11 +160,6 @@ variable "link_secrets" {
   default = []
 }
 
-variable "manual_secrets" {
-  type    = list(string)
-  default = []
-}
-
 variable "acr_registry_name" {
   type = string
 }

--- a/modules/gcp_k8s_service/gcp-k8s-service.json
+++ b/modules/gcp_k8s_service/gcp-k8s-service.json
@@ -42,7 +42,7 @@
     },
     "secrets": {
       "type": "array",
-      "description": "Optional. A list of secrets to add as environment variables for your container. All secrets must be set following the [secrets instructions](/tutorials/secrets).",
+      "description": "Deprecated, see [secrets instructions](/tutorials/secrets).",
       "items": {
         "type": "string"
       },

--- a/modules/gcp_k8s_service/gcp-k8s-service.yaml
+++ b/modules/gcp_k8s_service/gcp-k8s-service.yaml
@@ -26,10 +26,6 @@ inputs:
     user_facing: false
     description: "Secrets from links"
     default: []
-  - name: manual_secrets
-    user_facing: false
-    description: "Manually set secrets"
-    default: []
   - name: read_buckets
     user_facing: false
     description: Buckets to grant read permissions for
@@ -80,7 +76,7 @@ inputs:
   - name: secrets
     user_facing: true
     validator: list(str(), required=False)
-    description: Optional. A list of secrets to add as environment variables for your container. All secrets must be set following the [secrets instructions](/tutorials/secrets).
+    description: Deprecated, see [secrets instructions](/tutorials/secrets).
     default: []
   - name: env_vars
     user_facing: true

--- a/modules/gcp_k8s_service/gcp_k8s_service.py
+++ b/modules/gcp_k8s_service/gcp_k8s_service.py
@@ -16,8 +16,8 @@ class GcpK8sServiceProcessor(GcpK8sModuleProcessor, K8sServiceModuleProcessor):
             raise Exception(
                 f"The module {module.name} was expected to be of type k8s service"
             )
-        self.read_buckets: list[str] = []
-        self.write_buckets: list[str] = []
+        self.read_buckets: List[str] = []
+        self.write_buckets: List[str] = []
         super(GcpK8sServiceProcessor, self).__init__(module, layer)
 
     def pre_hook(self, module_idx: int) -> None:
@@ -26,7 +26,6 @@ class GcpK8sServiceProcessor(GcpK8sModuleProcessor, K8sServiceModuleProcessor):
 
     def process(self, module_idx: int) -> None:
         # Update the secrets
-        self.module.data["manual_secrets"] = self.module.data.get("secrets", [])
         self.module.data["link_secrets"] = self.module.data.get("link_secrets", [])
 
         current_envars: Union[List, Dict[str, str]] = self.module.data.get("env_vars", [])

--- a/modules/gcp_k8s_service/tests/test_gcp_k8s_service.py
+++ b/modules/gcp_k8s_service/tests/test_gcp_k8s_service.py
@@ -41,9 +41,6 @@ class TestGCPK8sServiceProcessor:
             {"name": "CACHEHOST2", "value": "${{module.redis2.cache_host}}"},
             {"name": "CACHEAUTH2", "value": "${{module.redis2.cache_auth_token}}"},
         ]
-        assert app_module.data["manual_secrets"] == [
-            "BALONEY",
-        ]
         assert app_module.data["read_buckets"] == ["${{module.bucket1.bucket_name}}"]
         assert app_module.data["write_buckets"] == [
             "${{module.bucket2.bucket_name}}",

--- a/modules/gcp_k8s_service/tf_module/main.tf
+++ b/modules/gcp_k8s_service/tf_module/main.tf
@@ -40,7 +40,6 @@ resource "helm_release" "k8s-service" {
       initialReadinessDelay : var.initial_readiness_delay
       envVars : var.env_vars,
       linkSecrets : var.link_secrets,
-      manualSecrets : var.manual_secrets,
       uriComponents : local.uri_components,
       layerName : var.layer_name,
       moduleName : var.module_name,

--- a/modules/gcp_k8s_service/tf_module/variables.tf
+++ b/modules/gcp_k8s_service/tf_module/variables.tf
@@ -158,11 +158,6 @@ variable "link_secrets" {
   default = []
 }
 
-variable "manual_secrets" {
-  type    = list(string)
-  default = []
-}
-
 variable "read_buckets" {
   type    = list(string)
   default = []

--- a/modules/local_k8s_service/local-k8s-service.json
+++ b/modules/local_k8s_service/local-k8s-service.json
@@ -44,7 +44,7 @@
     },
     "secrets": {
       "type": "array",
-      "description": "A list of secrets to add as environment variables for your container. All secrets must be set following the [secrets instructions](/miscellaneous/secrets).",
+      "description": "Deprecated, see [secrets instructions](/tutorials/secrets).",
       "items": {
         "type": "string"
       },

--- a/modules/local_k8s_service/local-k8s-service.yaml
+++ b/modules/local_k8s_service/local-k8s-service.yaml
@@ -30,10 +30,6 @@ inputs:
     validator: list(any(str(), map()), required=False)
     description: A list of extra IAM role policies not captured by Opta which you wish to give to your service.
     default: []
-  - name: manual_secrets
-    user_facing: false
-    description: "Manually set secrets"
-    default: [ ]
   - name: image
     user_facing: true
     validator: str(required=True)
@@ -76,7 +72,7 @@ inputs:
   - name: secrets
     user_facing: true
     validator: list(str(), required=False)
-    description: A list of secrets to add as environment variables for your container. All secrets must be set following the [secrets instructions](/miscellaneous/secrets).
+    description: Deprecated, see [secrets instructions](/tutorials/secrets).
     default: []
   - name: env_vars
     user_facing: true

--- a/modules/local_k8s_service/local_k8s_service.py
+++ b/modules/local_k8s_service/local_k8s_service.py
@@ -25,7 +25,6 @@ class LocalK8sServiceProcessor(LocalK8sModuleProcessor, K8sServiceModuleProcesso
 
     def process(self, module_idx: int) -> None:
         # Update the secrets
-        self.module.data["manual_secrets"] = self.module.data.get("secrets", [])
         self.module.data["link_secrets"] = self.module.data.get("link_secrets", [])
 
         if isinstance(self.module.data.get("public_uri"), str):

--- a/modules/local_k8s_service/tests/test_local_k8s_service.py
+++ b/modules/local_k8s_service/tests/test_local_k8s_service.py
@@ -49,6 +49,3 @@ class TestLocalK8sServiceProcessor:
                 "value": "${{module.mongodbatlas.mongodb_atlas_connection_string}}",
             },
         ]
-        assert app_module.data["manual_secrets"] == [
-            "BALONEY",
-        ]

--- a/modules/local_k8s_service/tf_module/deployment.yaml
+++ b/modules/local_k8s_service/tf_module/deployment.yaml
@@ -68,14 +68,10 @@ spec:
                   key: {{ $val.name | quote }}
                   optional: true
             {{ end }}
-            {{ range $val := .Values.manualSecrets }}
-            - name: {{ $val | quote }}
-              valueFrom:
-                secretKeyRef:
-                  name: manual-secrets
-                  key: {{ $val | quote }}
-                  optional: true
-            {{ end }}
+          envFrom:
+          - secretRef:
+              name: manual-secrets
+              optional: true
           {{/* No probes for grpc at the moment */}}
           {{ if not (hasKey .Values.port "grpc") }}
           {{ if .Values.livenessProbePath }} 

--- a/modules/local_k8s_service/tf_module/main.tf
+++ b/modules/local_k8s_service/tf_module/main.tf
@@ -42,7 +42,6 @@ resource "helm_release" "k8s-service" {
       healthcheck_path : var.healthcheck_path,
       envVars : var.env_vars,
       linkSecrets : var.link_secrets,
-      manualSecrets : var.manual_secrets,
       uriComponents : local.uri_components,
       layerName : var.layer_name,
       moduleName : var.module_name,

--- a/modules/local_k8s_service/tf_module/values.yaml
+++ b/modules/local_k8s_service/tf_module/values.yaml
@@ -7,7 +7,6 @@ moduleName: ""
 environmentName: ""
 envVars: []
 linkSecrets: []
-manualSecrets: []
 port: {}
 serviceAccount:
   # The name of the service account to use.

--- a/modules/local_k8s_service/tf_module/variables.tf
+++ b/modules/local_k8s_service/tf_module/variables.tf
@@ -152,11 +152,6 @@ variable "link_secrets" {
   default = []
 }
 
-variable "manual_secrets" {
-  type    = list(string)
-  default = []
-}
-
 variable "local_registry_name" {
   type    = string
   default = "localhost:5000"

--- a/modules/opta-k8s-service-helm/templates/deployment.yaml
+++ b/modules/opta-k8s-service-helm/templates/deployment.yaml
@@ -65,14 +65,10 @@ spec:
                   key: {{ $val.name | quote }}
                   optional: true
             {{ end }}
-            {{ range $val := .Values.manualSecrets }}
-            - name: {{ $val | quote }}
-              valueFrom:
-                secretKeyRef:
-                  name: manual-secrets
-                  key: {{ $val | quote }}
-                  optional: true
-            {{ end }}
+          envFrom:
+          - secretRef:
+              name: manual-secrets
+              optional: true
           {{- if .Values.livenessProbePath }}
           livenessProbe:
             initialDelaySeconds: {{ .Values.initialLivenessDelay }}

--- a/modules/opta-k8s-service-helm/templates/statefulset.yaml
+++ b/modules/opta-k8s-service-helm/templates/statefulset.yaml
@@ -81,14 +81,10 @@ spec:
                   key: {{ $val.name | quote }}
                   optional: true
             {{ end }}
-            {{ range $val := .Values.manualSecrets }}
-            - name: {{ $val | quote }}
-              valueFrom:
-                secretKeyRef:
-                  name: manual-secrets
-                  key: {{ $val | quote }}
-                  optional: true
-            {{ end }}
+          envFrom:
+          - secretRef:
+              name: manual-secrets
+              optional: true
           {{- if .Values.livenessProbePath }}
           livenessProbe:
             initialDelaySeconds: {{ .Values.initialLivenessDelay }}

--- a/modules/opta-k8s-service-helm/values.yaml
+++ b/modules/opta-k8s-service-helm/values.yaml
@@ -10,7 +10,6 @@ stickySession: false
 stickySessionMaxAge: 86400
 envVars: []
 linkSecrets: []
-manualSecrets: []
 ports: []
 probePort: null
 httpPort: null

--- a/modules/tests/test_linkerhelper.py
+++ b/modules/tests/test_linkerhelper.py
@@ -20,9 +20,7 @@ class TestLinkerHelper:
         atlas_module = layer.get_module("mongodbatlas", idx)
 
         atlas_module.data["link_secrets"] = []
-        atlas_module.data["manual_secrets"] = []
         app_module.data["link_secrets"] = []
-        app_module.data["manual_secrets"] = []
         link_permissions = []
         for link_data in app_module.data.get("links", []):
             if type(link_data) is str:

--- a/opta/core/secrets.py
+++ b/opta/core/secrets.py
@@ -12,17 +12,9 @@ LINKED_SECRET_NAME = "secret"  # nosec
 
 def get_secrets(layer_name: str) -> dict:
     """:return: manual and linked secrets"""
-    return deep_merge(get_manual_secrets(layer_name), get_linked_secrets(layer_name))
-
-
-def get_manual_secrets(layer_name: str) -> dict:
-    """:return: manual secrets, saved in the secret called 'manual-secrets'"""
-    return get_namespaced_secrets(layer_name, MANUAL_SECRET_NAME)
-
-
-def get_linked_secrets(layer_name: str) -> dict:
-    """:return: manual secrets, saved in the secret called 'secret'"""
-    return get_namespaced_secrets(layer_name, LINKED_SECRET_NAME)
+    manual_secrets = get_namespaced_secrets(layer_name, MANUAL_SECRET_NAME)
+    linked_secrets = get_namespaced_secrets(layer_name, LINKED_SECRET_NAME)
+    return deep_merge(manual_secrets, linked_secrets)
 
 
 def update_manual_secrets(layer_name: str, new_values: dict) -> None:

--- a/tests/commands/test_secret.py
+++ b/tests/commands/test_secret.py
@@ -104,7 +104,9 @@ class TestSecretManager:
         mocked_update_manual_secrets = mocker.patch(
             "opta.commands.secret.update_manual_secrets"
         )
-
+        mocked_restart_deployments = mocker.patch(
+            "opta.commands.secret.restart_deployments"
+        )
         mocker.patch("opta.commands.secret.set_kube_config")
 
         mocked_amplitude_client = mocker.patch(
@@ -133,6 +135,7 @@ class TestSecretManager:
         mocked_amplitude_client.send_event.assert_called_once_with(
             amplitude_client.UPDATE_SECRET_EVENT
         )
+        mocked_restart_deployments.assert_called_once_with("dummy_layer")
 
         # test updating a secret that is not listed in the config file - should work
         result = runner.invoke(update, ["unlistedsecret", "newvalue"])
@@ -155,6 +158,9 @@ class TestSecretManager:
         mocked_amplitude_event = mocker.patch(
             "opta.commands.secret.amplitude_client.send_event"
         )
+        mocked_restart_deployments = mocker.patch(
+            "opta.commands.secret.restart_deployments"
+        )
 
         runner = CliRunner()
         result = runner.invoke(
@@ -173,3 +179,12 @@ class TestSecretManager:
         mocked_amplitude_event.assert_called_once_with(
             amplitude_client.UPDATE_BULK_SECRET_EVENT
         )
+        mocked_restart_deployments.assert_called_once_with("dummy_layer")
+
+        # test deployment is not restarted with flag --no-restart
+        mocked_restart_deployments.reset_mock()
+        result = runner.invoke(
+            bulk_update,
+            [env_file, "--env", "dummyenv", "--config", "--no-restart", "dummyconfig"],
+        )
+        mocked_restart_deployments.assert_not_called()


### PR DESCRIPTION
# Description
With this change the user doesn't need to update the `secrets` field in the `k8s-service` module.

Here is how it works:
1. The user runs `opta secret bulk-update` or `opta secret update`
2. This command will update the secret called `manual-secrets` and restart the deployment
3. The deployment is configured to load `manual-secrets` as environments variables. The restarted pod will pick up the updated values. 
  ```yaml
  envFrom:
  - secretRef:
      name: manual-secrets
      optional: true
  ```

Implementation notes:
- Since we use the default strategy, Rolling Update Deployment, there will be no downtime.
- Added a flag `--no-restart` if the restart is not desirable.
- The restart is done by adding a timestamp annotation to the deployment, similar to what kubectl does. 
- The field `secret` was marked as deprecated - not deleted, for backward compatibility.
- The filed `manual_secrets` was deleted - this was not user facing.

Changes to documentation https://github.com/run-x/opta-docs/pull/126

# Safety checklist
* [X] This change is backwards compatible and safe to apply by existing users
   - The field `secrets` is deprecated, but if they still use it they will be no change. As long as the secrets exist, they will be populated at runtime.
* [X] This change will NOT lead to data loss
* [X] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
1. Before the change: set a local service with existing secrets defined in the opta yaml
2. After the change, opta apply check old secrets where mounted as env var
3. Ran opta secret update with new values, check old and new secrets were mounted  as env var

