### PR TITLE
Removed extra line that was causing the old api version to be used

### DIFF
--- a/modules/aws_k8s_base/tf_module/opta-base/templates/nginx_health_check.yaml
+++ b/modules/aws_k8s_base/tf_module/opta-base/templates/nginx_health_check.yaml
@@ -14,12 +14,12 @@ spec:
   selector:
     opta-ingress-healthcheck : "yes"
 ---
+
 {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
 apiVersion: networking.k8s.io/v1
 {{- else if $.Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress" }}
 apiVersion: networking.k8s.io/v1beta1
 {{ end }}  
-apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name:  opta-ingress-healthcheck


### PR DESCRIPTION
# Description
Fix the extra lines.

# Safety checklist
* [X ] This change is backwards compatible and safe to apply by existing users
* [X ] This change will NOT lead to data loss
* [ X] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
Will test on CircleCI
