### PR TITLE
Fix the old ingress naming convention

### DIFF
--- a/modules/opta-k8s-service-helm/templates/ingress.yaml
+++ b/modules/opta-k8s-service-helm/templates/ingress.yaml
@@ -11,7 +11,10 @@
 {{ $domain_pathPrefix = print $val.domain "-" $val.pathPrefixName }}
 {{ $domain_pathPrefix_sha256 = trunc 8 (sha256sum $domain_pathPrefix) }}
 {{ $ingress_name_new_convention = print $ingress_base_name "-" $domain_pathPrefix_sha256 }}
+
+{{ if $.Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress" }}
 {{ $old_ingress_convention = (lookup "networking.k8s.io/v1beta1" "Ingress" $namespace_name $ingress_name_old_convention) }}
+{{ end }}  
 
 {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
 apiVersion: networking.k8s.io/v1


### PR DESCRIPTION
# Description
Fix issue that the old naming convention check assumes old ingress API.

# Safety checklist
* [X ] This change is backwards compatible and safe to apply by existing users
* [X ] This change will NOT lead to data loss
* [X ] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
Running Circle CI on 1.22 GKE fails the PG service check if this change doesnt work as planned. Running that test now here: https://app.circleci.com/pipelines/github/run-x/opta/1071/workflows/5ce68e63-1674-4361-b274-307f3cbc431a
