### PR TITLE
Remove aws_s3_bucket_public_access_block from Buckets

### DIFF
--- a/config/config.rego
+++ b/config/config.rego
@@ -40,6 +40,11 @@ waivers[waiver] {
     "rule_id": "FG_R00068",
     "resource_id": "aws_cloudwatch_log_group.logs"
   }
+} {
+  waiver := {
+    "rule_id": "FG_R00229",
+    "resource_id": "aws_s3_bucket.log_bucket"
+  }
 }
 
 rules[rule] {

--- a/modules/aws_base/tf_module/log_bucket.tf
+++ b/modules/aws_base/tf_module/log_bucket.tf
@@ -42,15 +42,7 @@ resource "aws_s3_bucket" "log_bucket" {
   }
 }
 
-resource "aws_s3_bucket_public_access_block" "block" {
-  bucket = aws_s3_bucket.log_bucket.id
-
-  block_public_acls       = true
-  block_public_policy     = true
-  ignore_public_acls      = true
-  restrict_public_buckets = true
-}
-
+# Visit (https://run-x.atlassian.net/browse/RUNX-1125) for further reference
 
 data "aws_iam_policy_document" "log_bucket_policy" {
   statement {
@@ -129,7 +121,5 @@ data "aws_iam_policy_document" "log_bucket_policy" {
 resource "aws_s3_bucket_policy" "log_bucket_policy" {
   bucket = aws_s3_bucket.log_bucket.id
   policy = data.aws_iam_policy_document.log_bucket_policy.json
-  depends_on = [
-    aws_s3_bucket_public_access_block.block
-  ]
+# Visit (https://run-x.atlassian.net/browse/RUNX-1125) for further reference
 }

--- a/modules/aws_base/tf_module/log_bucket.tf
+++ b/modules/aws_base/tf_module/log_bucket.tf
@@ -121,5 +121,5 @@ data "aws_iam_policy_document" "log_bucket_policy" {
 resource "aws_s3_bucket_policy" "log_bucket_policy" {
   bucket = aws_s3_bucket.log_bucket.id
   policy = data.aws_iam_policy_document.log_bucket_policy.json
-# Visit (https://run-x.atlassian.net/browse/RUNX-1125) for further reference
+  # Visit (https://run-x.atlassian.net/browse/RUNX-1125) for further reference
 }

--- a/modules/config.rego
+++ b/modules/config.rego
@@ -40,6 +40,11 @@ waivers[waiver] {
     "rule_id": "FG_R00068",
     "resource_id": "aws_cloudwatch_log_group.logs"
   }
+} {
+  waiver := {
+    "rule_id": "FG_R00229",
+    "resource_id": "aws_s3_bucket.log_bucket"
+  }
 }
 
 rules[rule] {

--- a/opta/core/terraform.py
+++ b/opta/core/terraform.py
@@ -754,15 +754,7 @@ class Terraform:
                     ]
                 },
             )
-            s3.put_public_access_block(
-                Bucket=bucket_name,
-                PublicAccessBlockConfiguration={
-                    "BlockPublicAcls": True,
-                    "IgnorePublicAcls": True,
-                    "BlockPublicPolicy": True,
-                    "RestrictPublicBuckets": True,
-                },
-            )
+            # Visit (https://run-x.atlassian.net/browse/RUNX-1125) for further reference
             s3.put_bucket_versioning(
                 Bucket=bucket_name, VersioningConfiguration={"Status": "Enabled"},
             )

--- a/tests/core/test_terraform.py
+++ b/tests/core/test_terraform.py
@@ -336,15 +336,7 @@ class TestTerraform:
                 ]
             },
         )
-        mocked_s3_client.put_public_access_block.assert_called_once_with(
-            Bucket="opta-tf-state-test-dev1",
-            PublicAccessBlockConfiguration={
-                "BlockPublicAcls": True,
-                "IgnorePublicAcls": True,
-                "BlockPublicPolicy": True,
-                "RestrictPublicBuckets": True,
-            },
-        )
+        # Visit (https://run-x.atlassian.net/browse/RUNX-1125) for further reference
         mocked_boto3.client.assert_has_calls(
             [
                 mocker.call("s3", config=mocker.ANY),


### PR DESCRIPTION
# Description
This change allows users to add public access to objects and buckets.

# Safety checklist
* [ ] This change is backwards compatible and safe to apply by existing users
* [ ] This change will NOT lead to data loss
* [ ] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?

