### PR TITLE
Upgrade datadog to latest version

### DIFF
--- a/modules/datadog/datadog.json
+++ b/modules/datadog/datadog.json
@@ -17,6 +17,11 @@
       "description": "Additional configuration for datadog. [Available options](https://github.com/DataDog/helm-charts/blob/master/charts/datadog/README.md#values)",
       "default": {}
     },
+    "chart_version": {
+      "type": "string",
+      "description": "Datadog Helm chart version. [Available versions](https://github.com/DataDog/helm-charts/releases)",
+      "default": "2.30.2"
+    },
     "type": {
       "description": "The name of this module",
       "enum": [

--- a/modules/datadog/datadog.yaml
+++ b/modules/datadog/datadog.yaml
@@ -28,6 +28,11 @@ inputs:
     validator: any(required=False)
     description: Additional configuration for datadog. [Available options](https://github.com/DataDog/helm-charts/blob/master/charts/datadog/README.md#values)
     default: { }
+  - name: chart_version
+    user_facing: true
+    validator: str(required=False)
+    description: Datadog Helm chart version. [Available versions](https://github.com/DataDog/helm-charts/releases)
+    default: "2.30.2"
 outputs: { }
 output_providers: { }
 output_data: { }

--- a/modules/datadog/tf_module/main.tf
+++ b/modules/datadog/tf_module/main.tf
@@ -17,7 +17,7 @@ resource "helm_release" "datadog" {
   repository = "https://helm.datadoghq.com"
   chart      = "datadog"
   name       = "${var.layer_name}-${var.module_name}"
-  version    = "2.10.3"
+  version    = var.chart_version
   values = [
     yamlencode({
       datadog : {
@@ -51,9 +51,6 @@ resource "helm_release" "datadog" {
         useHostNetwork : true
         enabled : true
         token : random_password.cluster_agent_token.result
-        metricsProvider : {
-          enabled : true
-        }
         admissionController : {
           enabled : true
           mutateUnlabelled : true

--- a/modules/datadog/tf_module/variables.tf
+++ b/modules/datadog/tf_module/variables.tf
@@ -27,3 +27,8 @@ variable "timeout" {
   type    = number
   default = 600
 }
+
+variable "chart_version" {
+  description = "Chart version"
+  type        = string
+}


### PR DESCRIPTION
# Description
Upgrade datadog to latest version - which has removed all log4j dependencies.
There seems to be an issue when using the latest version and having the [datadog custom metrics](https://docs.datadoghq.com/agent/cluster_agent/external_metrics/?tab=helm) server enabled. I will follow up with datadog and verify on it.
As a result, datadog custom metrics is now disabled by default.

But if a user wants to enable it, they can still set their own helm chart values.
Ex:
```yaml
#opta.yaml
modules:
  - type: base
  - type: k8s-cluster
  - type: k8s-base
  - type: datadog
    values:
      clusterAgent:
        metricsProvider:
          enabled: true

```
A new field `chart_version` was also added if a user wants to use a different version.


# Safety checklist
* [X] This change is backwards compatible and safe to apply by existing users
* [X] This change will NOT lead to data loss
* [X] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
Tested the fix on a new EKS cluster using a simple container using dd-agent on. ([details](https://github.com/RemyDeWolf/hello-app-datadog))

APM trace worked:
<img width="1123" alt="test-datadog-apm" src="https://user-images.githubusercontent.com/9467584/152263835-2467a171-6574-45fa-b1a7-202d40e1e8b1.png">



