### PR TITLE
Change default from null to AUTO for image

### DIFF
--- a/modules/aws_k8s_service/aws-k8s-service.json
+++ b/modules/aws_k8s_service/aws-k8s-service.json
@@ -27,7 +27,8 @@
     },
     "image": {
       "type": "string",
-      "description": "Set to AUTO to create a private repo for your own images. Otherwises attempts to pull image from public dockerhub"
+      "description": "Set to AUTO to create a private repo for your own images. Otherwises attempts to pull image from public dockerhub",
+      "default": "AUTO"
     },
     "min_containers": {
       "type": "integer",

--- a/modules/aws_k8s_service/aws-k8s-service.yaml
+++ b/modules/aws_k8s_service/aws-k8s-service.yaml
@@ -42,7 +42,7 @@ inputs:
     user_facing: true
     validator: str(required=True)
     description: Set to AUTO to create a private repo for your own images. Otherwises attempts to pull image from public dockerhub
-    default: null
+    default: AUTO
   - name: port
     user_facing: true
     validator: any(include('service_port'), required=False)

--- a/modules/azure_k8s_service/azure-k8s-service.json
+++ b/modules/azure_k8s_service/azure-k8s-service.json
@@ -8,7 +8,8 @@
     },
     "image": {
       "type": "string",
-      "description": "Set to AUTO to create a private repo for your own images. Otherwises attempts to pull image from public dockerhub"
+      "description": "Set to AUTO to create a private repo for your own images. Otherwises attempts to pull image from public dockerhub",
+      "default": "AUTO"
     },
     "min_containers": {
       "type": "integer",

--- a/modules/azure_k8s_service/azure-k8s-service.yaml
+++ b/modules/azure_k8s_service/azure-k8s-service.yaml
@@ -34,7 +34,7 @@ inputs: # (what users see)
     user_facing: true
     validator: str(required=True)
     description: Set to AUTO to create a private repo for your own images. Otherwises attempts to pull image from public dockerhub
-    default: null
+    default: AUTO
   - name: port
     user_facing: true
     validator: any(include('service_port'), required=False)

--- a/modules/gcp_k8s_service/gcp-k8s-service.json
+++ b/modules/gcp_k8s_service/gcp-k8s-service.json
@@ -12,7 +12,8 @@
     },
     "image": {
       "type": "string",
-      "description": "Set to AUTO to create a private repo for your own images. Otherwises attempts to pull image from public dockerhub"
+      "description": "Set to AUTO to create a private repo for your own images. Otherwises attempts to pull image from public dockerhub",
+      "default": "AUTO"
     },
     "min_containers": {
       "type": "integer",

--- a/modules/gcp_k8s_service/gcp-k8s-service.yaml
+++ b/modules/gcp_k8s_service/gcp-k8s-service.yaml
@@ -38,7 +38,7 @@ inputs:
     user_facing: true
     validator: str(required=True)
     description: Set to AUTO to create a private repo for your own images. Otherwises attempts to pull image from public dockerhub
-    default: null
+    default: AUTO
   - name: port
     user_facing: true
     validator: any(include('service_port'), required=False)


### PR DESCRIPTION
# Description
Make AUTO default for k8s-service image.
This is to fix the UI where we can download the opta configuration without Image value.

# Safety checklist
* [ ] This change is backwards compatible and safe to apply by existing users
* [ ] This change will NOT lead to data loss
* [ ] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
