### PR TITLE
Fixed generated yaml file location to be cwd since layer.path needs t…

### DIFF
--- a/opta/commands/local_flag.py
+++ b/opta/commands/local_flag.py
@@ -35,7 +35,7 @@ def _handle_local_flag(config: str, test: bool = False) -> Tuple[str, str]:
     y["environments"] = [{"name": "localopta", "path": env_yaml_path + "/localopta.yaml"}]
     y.pop("org_name", None)
     p = Path(config)
-    config = os.path.join(env_yaml_path, "opta-local-" + p.name)
+    config = os.path.join(p.parent, "opta-local-" + p.name)
     with open(config, "w") as fw:
         yaml.round_trip_dump(y, fw, explicit_start=True)
 

--- a/opta/commands/local_flag.py
+++ b/opta/commands/local_flag.py
@@ -9,9 +9,9 @@ from ruamel import yaml
 def _handle_local_flag(config: str, test: bool = False) -> Tuple[str, str]:
 
     with open(config, "r") as fr:
-        y = yaml.round_trip_load(fr, preserve_quotes=True)
-        if "org_name" in y:
-            org_name = y["org_name"]
+        yamlcontent = yaml.round_trip_load(fr, preserve_quotes=True)
+        if "org_name" in yamlcontent:
+            org_name = yamlcontent["org_name"]
         else:
             org_name = "localorg"
     env_yaml_path = os.path.join(Path.home(), ".opta", "local", org_name)
@@ -32,12 +32,14 @@ def _handle_local_flag(config: str, test: bool = False) -> Tuple[str, str]:
             },
             fw,
         )
-    y["environments"] = [{"name": "localopta", "path": env_yaml_path + "/localopta.yaml"}]
-    y.pop("org_name", None)
-    p = Path(config)
-    config = os.path.join(p.parent, "opta-local-" + p.name)
+    yamlcontent["environments"] = [
+        {"name": "localopta", "path": env_yaml_path + "/localopta.yaml"}
+    ]
+    yamlcontent.pop("org_name", None)
+    yamlpath = Path(config)
+    config = os.path.join(yamlpath.parent, "opta-local-" + yamlpath.name)
     with open(config, "w") as fw:
-        yaml.round_trip_dump(y, fw, explicit_start=True)
+        yaml.round_trip_dump(yamlcontent, fw, explicit_start=True)
 
     return config, env_yaml_path + "/localopta.yaml"
 

--- a/tests/commands/test_local_flag.py
+++ b/tests/commands/test_local_flag.py
@@ -1,6 +1,5 @@
 import os
 import unittest
-from pathlib import Path
 
 import yaml
 
@@ -10,9 +9,7 @@ from opta.commands.local_flag import _handle_local_flag
 class Local_Flag_Tests(unittest.TestCase):
     def setUp(self) -> None:
         self.serviceconfig = "/tmp/test_local_flag.yaml"
-        self.derivedconfig = os.path.join(
-            "/tmp","opta-local-test_local_flag.yaml"
-        )
+        self.derivedconfig = os.path.join("/tmp", "opta-local-test_local_flag.yaml")
         with open(self.serviceconfig, "w") as fw:
             yaml.dump(
                 {

--- a/tests/commands/test_local_flag.py
+++ b/tests/commands/test_local_flag.py
@@ -11,7 +11,7 @@ class Local_Flag_Tests(unittest.TestCase):
     def setUp(self) -> None:
         self.serviceconfig = "/tmp/test_local_flag.yaml"
         self.derivedconfig = os.path.join(
-            Path.home(), ".opta", "local", "whatever", "opta-local-test_local_flag.yaml"
+            "/tmp","opta-local-test_local_flag.yaml"
         )
         with open(self.serviceconfig, "w") as fw:
             yaml.dump(


### PR DESCRIPTION
…o be the same as orginal service file path

# Description
Fix path to cwd for the generated service file for local.

# Safety checklist
* [ X] This change is backwards compatible and safe to apply by existing users
* [ X] This change will NOT lead to data loss
* [ X] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
[Circle CI test](https://app.circleci.com/pipelines/github/run-x/opta/1140/workflows/565f0b0a-0204-47a0-9765-166dafed5fcf)
