### PR TITLE
Fixed permission for autoscale

### DIFF
--- a/modules/aws_k8s_base/tf_module/autoscaler.tf
+++ b/modules/aws_k8s_base/tf_module/autoscaler.tf
@@ -7,7 +7,8 @@ data "aws_iam_policy_document" "autoscaler" {
       "autoscaling:DescribeTags",
       "autoscaling:SetDesiredCapacity",
       "autoscaling:TerminateInstanceInAutoScalingGroup",
-      "ec2:DescribeLaunchTemplateVersions"
+      "ec2:DescribeLaunchTemplateVersions",
+      "ec2:DescribeInstanceTypes"
     ]
     resources = ["*"]
     sid       = "autoscaling"


### PR DESCRIPTION
# Description

Missing a permission for AWS EC2 autoscaling.

See jira ticket https://run-x.atlassian.net/browse/RUNX-1162

# Safety checklist
* [X ] This change is backwards compatible and safe to apply by existing users
* [X ] This change will NOT lead to data loss
* [X ] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
Manual test
