### PR TITLE
Default ssl certs for AWS and GCP

### DIFF
--- a/modules/aws_k8s_base/aws-k8s-base.json
+++ b/modules/aws_k8s_base/aws-k8s-base.json
@@ -56,7 +56,7 @@
       },
       "default": []
     },
-    "expose_self_signed_cert": {
+    "expose_self_signed_ssl": {
       "type": "boolean",
       "description": "Expose the self-signed certificate for the ingress controller.",
       "default": false

--- a/modules/aws_k8s_base/aws-k8s-base.json
+++ b/modules/aws_k8s_base/aws-k8s-base.json
@@ -56,6 +56,11 @@
       },
       "default": []
     },
+    "expose_self_signed_cert": {
+      "type": "boolean",
+      "description": "Expose the self-signed certificate for the ingress controller.",
+      "default": false
+    },
     "type": {
       "description": "The name of this module",
       "enum": [

--- a/modules/aws_k8s_base/aws-k8s-base.json
+++ b/modules/aws_k8s_base/aws-k8s-base.json
@@ -58,7 +58,7 @@
     },
     "expose_self_signed_ssl": {
       "type": "boolean",
-      "description": "Expose the self-signed certificate for the ingress controller.",
+      "description": "Expose self-signed SSL certs.",
       "default": false
     },
     "type": {

--- a/modules/aws_k8s_base/aws-k8s-base.yaml
+++ b/modules/aws_k8s_base/aws-k8s-base.yaml
@@ -90,6 +90,11 @@ inputs:
     validator: list(int(min=1, max=65535), required=False)
     description: Which additional TCP ports should have TLS enabled
     default: []
+  - name: expose_self_signed_ssl
+    user_facing: true
+    validator: bool(required=False)
+    description: Expose self-signed SSL certs to the public internet.
+    default: false
 outputs:
   - name: load_balancer_raw_dns
     export: true

--- a/modules/aws_k8s_base/aws-k8s-base.yaml
+++ b/modules/aws_k8s_base/aws-k8s-base.yaml
@@ -93,7 +93,7 @@ inputs:
   - name: expose_self_signed_ssl
     user_facing: true
     validator: bool(required=False)
-    description: Expose self-signed SSL certs to the public internet.
+    description: Expose self-signed SSL certs.
     default: false
 outputs:
   - name: load_balancer_raw_dns

--- a/modules/aws_k8s_base/tf_module/ingress_nginx.tf
+++ b/modules/aws_k8s_base/tf_module/ingress_nginx.tf
@@ -14,7 +14,7 @@ resource "helm_release" "ingress-nginx" {
         podLabels : {
           "opta-ingress-healthcheck" : "yes"
         }
-        extraArgs : var.private_key == "" ? {} : { default-ssl-certificate : "ingress-nginx/secret-tls" }
+        extraArgs : { default-ssl-certificate : "ingress-nginx/secret-tls" }
         config : local.config
         podAnnotations : {
           "linkerd.io/inject" : "enabled"
@@ -66,7 +66,7 @@ resource "helm_release" "ingress-nginx" {
         service : {
           loadBalancerSourceRanges : ["0.0.0.0/0"]
           externalTrafficPolicy : "Local"
-          enableHttps : var.cert_arn == "" && var.private_key == "" ? false : true
+          enableHttps : true
           targetPorts : local.target_ports
           annotations : {
             "service.beta.kubernetes.io/aws-load-balancer-scheme" : "internet-facing"

--- a/modules/aws_k8s_base/tf_module/ingress_nginx.tf
+++ b/modules/aws_k8s_base/tf_module/ingress_nginx.tf
@@ -14,7 +14,7 @@ resource "helm_release" "ingress-nginx" {
         podLabels : {
           "opta-ingress-healthcheck" : "yes"
         }
-        extraArgs : { default-ssl-certificate : "ingress-nginx/secret-tls" }
+        extraArgs : var.private_key != "" || var.expose_self_signed_ssl ? { default-ssl-certificate : "ingress-nginx/secret-tls" } : {}
         config : local.config
         podAnnotations : {
           "linkerd.io/inject" : "enabled"
@@ -66,7 +66,7 @@ resource "helm_release" "ingress-nginx" {
         service : {
           loadBalancerSourceRanges : ["0.0.0.0/0"]
           externalTrafficPolicy : "Local"
-          enableHttps : true
+          enableHttps : var.cert_arn != "" || var.private_key != "" || var.expose_self_signed_ssl ? true : false
           targetPorts : local.target_ports
           annotations : {
             "service.beta.kubernetes.io/aws-load-balancer-scheme" : "internet-facing"

--- a/modules/aws_k8s_base/tf_module/opta_base.tf
+++ b/modules/aws_k8s_base/tf_module/opta_base.tf
@@ -1,6 +1,6 @@
 resource "tls_private_key" "nginx_ca" {
   algorithm = "RSA"
-  rsa_bits  = "4096"
+  rsa_bits  = "2048"
 }
 
 resource "tls_self_signed_cert" "nginx_ca" {
@@ -24,7 +24,7 @@ resource "tls_self_signed_cert" "nginx_ca" {
 }
 resource "tls_private_key" "default" {
   algorithm   = "RSA"
-  rsa_bits    = "4096"
+  rsa_bits    = "2048"
 }
 
 resource "tls_cert_request" "default_cert_request" {

--- a/modules/aws_k8s_base/tf_module/opta_base.tf
+++ b/modules/aws_k8s_base/tf_module/opta_base.tf
@@ -40,9 +40,9 @@ resource "tls_cert_request" "default_cert_request" {
   dns_names       = ["*.elb.${data.aws_region.current.name}.amazonaws.com"]
 
   subject {
-    common_name     = "*.elb.${data.aws_region.current.name}.amazonaws.com"
-    organization    = "Org"
-    street_address  = []
+    common_name    = "*.elb.${data.aws_region.current.name}.amazonaws.com"
+    organization   = "Org"
+    street_address = []
   }
 
   lifecycle {

--- a/modules/aws_k8s_base/tf_module/opta_base.tf
+++ b/modules/aws_k8s_base/tf_module/opta_base.tf
@@ -24,12 +24,6 @@ resource "tls_self_signed_cert" "nginx_ca" {
     "cert_signing",
     "crl_signing",
   ]
-
-  lifecycle {
-    ignore_changes = [
-      id
-    ]
-  }
 }
 resource "tls_private_key" "default" {
   count     = var.expose_self_signed_ssl ? 1 : 0

--- a/modules/aws_k8s_base/tf_module/opta_base.tf
+++ b/modules/aws_k8s_base/tf_module/opta_base.tf
@@ -5,7 +5,7 @@ resource "tls_private_key" "nginx_ca" {
 
 resource "tls_self_signed_cert" "nginx_ca" {
   key_algorithm     = "RSA"
-  private_key_pem   = "${tls_private_key.nginx_ca.private_key_pem}"
+  private_key_pem   = tls_private_key.nginx_ca.private_key_pem
   is_ca_certificate = true
 
   subject {
@@ -23,17 +23,17 @@ resource "tls_self_signed_cert" "nginx_ca" {
   ]
 }
 resource "tls_private_key" "default" {
-  algorithm   = "RSA"
-  rsa_bits    = "2048"
+  algorithm = "RSA"
+  rsa_bits  = "2048"
 }
 
 resource "tls_cert_request" "default_cert_request" {
   key_algorithm   = tls_private_key.default.algorithm
   private_key_pem = tls_private_key.default.private_key_pem
-  dns_names = ["*.elb.${data.aws_region.current.name}.amazonaws.com"]
+  dns_names       = ["*.elb.${data.aws_region.current.name}.amazonaws.com"]
 
   subject {
-    common_name = "*.elb.${data.aws_region.current.name}.amazonaws.com"
+    common_name  = "*.elb.${data.aws_region.current.name}.amazonaws.com"
     organization = "Org"
   }
 }
@@ -60,8 +60,8 @@ resource "helm_release" "opta_base" {
   values = [
     yamlencode({
       adminArns : var.admin_arns
-#      tls_key : base64encode(var.private_key),
-#      tls_crt : base64encode(join("\n", [var.certificate_body, var.certificate_chain])),
+      #      tls_key : base64encode(var.private_key),
+      #      tls_crt : base64encode(join("\n", [var.certificate_body, var.certificate_chain])),
       tls_key : base64encode(tls_private_key.default.private_key_pem),
       tls_crt : base64encode(tls_locally_signed_cert.default_cert.cert_pem)
     })

--- a/modules/aws_k8s_base/tf_module/opta_base.tf
+++ b/modules/aws_k8s_base/tf_module/opta_base.tf
@@ -1,3 +1,35 @@
+# Reusing CA authority made for linkerd
+resource "tls_private_key" "default" {
+  algorithm   = "RSA"
+#  ecdsa_curve = "P256"
+}
+
+resource "tls_cert_request" "default_cert_request" {
+  key_algorithm   = tls_private_key.issuer_key.algorithm
+  private_key_pem = tls_private_key.issuer_key.private_key_pem
+  dns_names = ["*.elb.${data.aws_region.current.name}.amazonaws.com"]
+
+  subject {
+    common_name = "*.elb.${data.aws_region.current.name}.amazonaws.com"
+    organization = "Org"
+  }
+}
+
+resource "tls_locally_signed_cert" "default_cert" {
+  cert_request_pem      = tls_cert_request.default_cert_request.cert_request_pem
+  ca_key_algorithm      = tls_private_key.trustanchor_key.algorithm
+  ca_private_key_pem    = tls_private_key.trustanchor_key.private_key_pem
+  ca_cert_pem           = tls_self_signed_cert.trustanchor_cert.cert_pem
+  validity_period_hours = 87600
+
+  allowed_uses = [
+    "crl_signing",
+    "cert_signing",
+    "server_auth",
+    "client_auth"
+  ]
+}
+
 resource "helm_release" "opta_base" {
   chart     = "${path.module}/opta-base"
   name      = "opta-base"
@@ -5,8 +37,10 @@ resource "helm_release" "opta_base" {
   values = [
     yamlencode({
       adminArns : var.admin_arns
-      tls_key : base64encode(var.private_key),
-      tls_crt : base64encode(join("\n", [var.certificate_body, var.certificate_chain]))
+#      tls_key : base64encode(var.private_key),
+#      tls_crt : base64encode(join("\n", [var.certificate_body, var.certificate_chain])),
+      tls_key : base64encode(tls_private_key.default.private_key_pem),
+      tls_crt : base64encode(tls_locally_signed_cert.default_cert.cert_pem)
     })
   ]
   depends_on = [

--- a/modules/aws_k8s_base/tf_module/variables.tf
+++ b/modules/aws_k8s_base/tf_module/variables.tf
@@ -110,3 +110,8 @@ variable "nginx_extra_tcp_ports_tls" {
   type    = list(number)
   default = []
 }
+
+variable "expose_self_signed_ssl" {
+  type    = bool
+  default = false
+}

--- a/modules/gcp_k8s_base/gcp-k8s-base.json
+++ b/modules/gcp_k8s_base/gcp-k8s-base.json
@@ -23,6 +23,11 @@
       "description": "Additional configuration for nginx ingress. [Available options](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#configuration-options)",
       "default": {}
     },
+    "expose_self_signed_ssl": {
+      "type": "boolean",
+      "description": "Expose the self signed ssl certificate to the public.",
+      "default": false
+    },
     "type": {
       "description": "The name of this module",
       "enum": [

--- a/modules/gcp_k8s_base/gcp-k8s-base.json
+++ b/modules/gcp_k8s_base/gcp-k8s-base.json
@@ -25,7 +25,7 @@
     },
     "expose_self_signed_ssl": {
       "type": "boolean",
-      "description": "Expose the self signed ssl certificate to the public.",
+      "description": "Expose self-signed SSL certs.",
       "default": false
     },
     "type": {

--- a/modules/gcp_k8s_base/gcp-k8s-base.yaml
+++ b/modules/gcp_k8s_base/gcp-k8s-base.yaml
@@ -66,6 +66,11 @@ inputs:
     validator: any(required=False)
     description: Additional configuration for nginx ingress. [Available options](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#configuration-options)
     default: {}
+  - name: expose_self_signed_ssl
+    user_facing: true
+    validator: bool(required=False)
+    description: Expose the self signed ssl certificate to the public.
+    default: false
 outputs:
   - name: load_balancer_raw_ip
     export: bool

--- a/modules/gcp_k8s_base/gcp-k8s-base.yaml
+++ b/modules/gcp_k8s_base/gcp-k8s-base.yaml
@@ -69,7 +69,7 @@ inputs:
   - name: expose_self_signed_ssl
     user_facing: true
     validator: bool(required=False)
-    description: Expose the self signed ssl certificate to the public.
+    description: Expose self-signed SSL certs.
     default: false
 outputs:
   - name: load_balancer_raw_ip

--- a/modules/gcp_k8s_base/tf_module/ingress_nginx.tf
+++ b/modules/gcp_k8s_base/tf_module/ingress_nginx.tf
@@ -13,7 +13,7 @@ resource "helm_release" "ingress-nginx" {
         podLabels : {
           "opta-ingress-healthcheck" : "yes"
         }
-        extraArgs : { default-ssl-certificate : "ingress-nginx/secret-tls" }
+        extraArgs : var.private_key != "" || var.expose_self_signed_ssl ? { default-ssl-certificate : "ingress-nginx/secret-tls" } : {}
         config : local.config
         podAnnotations : {
           "config.linkerd.io/skip-inbound-ports" : "80,443" // NOTE: should be removed when this is fixed: https://github.com/linkerd/linkerd2/issues/4219

--- a/modules/gcp_k8s_base/tf_module/ingress_nginx.tf
+++ b/modules/gcp_k8s_base/tf_module/ingress_nginx.tf
@@ -13,7 +13,7 @@ resource "helm_release" "ingress-nginx" {
         podLabels : {
           "opta-ingress-healthcheck" : "yes"
         }
-        extraArgs : var.private_key == "" ? {} : { default-ssl-certificate : "ingress-nginx/secret-tls" }
+        extraArgs : { default-ssl-certificate : "ingress-nginx/secret-tls" }
         config : local.config
         podAnnotations : {
           "config.linkerd.io/skip-inbound-ports" : "80,443" // NOTE: should be removed when this is fixed: https://github.com/linkerd/linkerd2/issues/4219

--- a/modules/gcp_k8s_base/tf_module/load_balancer.tf
+++ b/modules/gcp_k8s_base/tf_module/load_balancer.tf
@@ -6,9 +6,10 @@ resource "google_compute_ssl_certificate" "external" {
 }
 
 resource "google_compute_ssl_certificate" "default" {
+  count       = var.expose_self_signed_ssl ? 1 : 0
   name        = "opta-${var.layer_name}-default"
-  certificate = tls_locally_signed_cert.default_cert.cert_pem
-  private_key = tls_private_key.default.private_key_pem
+  certificate = tls_locally_signed_cert.default_cert[0].cert_pem
+  private_key = tls_private_key.default[0].private_key_pem
 }
 
 resource "google_compute_global_address" "load_balancer" {
@@ -61,6 +62,7 @@ resource "google_compute_url_map" "http" {
 }
 
 resource "google_compute_url_map" "https" {
+  count           = var.delegated || var.private_key != "" || var.expose_self_signed_ssl ? 1 : 0
   name            = "opta-${var.layer_name}-https"
   default_service = google_compute_backend_service.backend_service.id
 }
@@ -72,9 +74,10 @@ resource "google_compute_target_http_proxy" "proxy" {
 }
 
 resource "google_compute_target_https_proxy" "proxy" {
+  count            = var.delegated || var.private_key != "" || var.expose_self_signed_ssl ? 1 : 0
   name             = "opta-${var.layer_name}"
-  url_map          = google_compute_url_map.https.name
-  ssl_certificates = var.delegated ? [var.cert_self_link] : (var.private_key != "" ? [google_compute_ssl_certificate.external[0].self_link] : [google_compute_ssl_certificate.default.self_link])
+  url_map          = google_compute_url_map.https[0].name
+  ssl_certificates = var.delegated ? [var.cert_self_link] : (var.private_key != "" ? [google_compute_ssl_certificate.external[0].self_link] : [google_compute_ssl_certificate.default[0].self_link])
   ssl_policy       = google_compute_ssl_policy.policy.self_link
 }
 
@@ -86,8 +89,9 @@ resource "google_compute_global_forwarding_rule" "http" {
 }
 
 resource "google_compute_global_forwarding_rule" "https" {
+  count      = var.delegated || var.private_key != "" || var.expose_self_signed_ssl ? 1 : 0
   name       = "opta-${var.layer_name}-https"
-  target     = google_compute_target_https_proxy.proxy.self_link
+  target     = google_compute_target_https_proxy.proxy[0].self_link
   ip_address = google_compute_global_address.load_balancer.address
   port_range = "443"
 }

--- a/modules/gcp_k8s_base/tf_module/opta_base.tf
+++ b/modules/gcp_k8s_base/tf_module/opta_base.tf
@@ -5,7 +5,7 @@ resource "tls_private_key" "nginx_ca" {
 
 resource "tls_self_signed_cert" "nginx_ca" {
   key_algorithm     = "RSA"
-  private_key_pem   = "${tls_private_key.nginx_ca.private_key_pem}"
+  private_key_pem   = tls_private_key.nginx_ca.private_key_pem
   is_ca_certificate = true
 
   subject {
@@ -23,18 +23,18 @@ resource "tls_self_signed_cert" "nginx_ca" {
   ]
 }
 resource "tls_private_key" "default" {
-  algorithm   = "RSA"
-  rsa_bits    = "2048"
+  algorithm = "RSA"
+  rsa_bits  = "2048"
 }
 
 resource "tls_cert_request" "default_cert_request" {
   key_algorithm   = tls_private_key.default.algorithm
   private_key_pem = tls_private_key.default.private_key_pem
-  dns_names = ["optaisawesome.com"]
-  ip_addresses = ["${google_compute_global_address.load_balancer.address}"]
+  dns_names       = ["optaisawesome.com"]
+  ip_addresses    = ["${google_compute_global_address.load_balancer.address}"]
 
   subject {
-    common_name = "optaisawesome.com"
+    common_name  = "optaisawesome.com"
     organization = "Org"
   }
 }

--- a/modules/gcp_k8s_base/tf_module/opta_base.tf
+++ b/modules/gcp_k8s_base/tf_module/opta_base.tf
@@ -1,11 +1,67 @@
+resource "tls_private_key" "nginx_ca" {
+  algorithm = "RSA"
+  rsa_bits  = "2048"
+}
+
+resource "tls_self_signed_cert" "nginx_ca" {
+  key_algorithm     = "RSA"
+  private_key_pem   = "${tls_private_key.nginx_ca.private_key_pem}"
+  is_ca_certificate = true
+
+  subject {
+    common_name         = "Opta is awesome"
+    organization        = "Opta Self Signed"
+    organizational_unit = "opta"
+  }
+
+  validity_period_hours = 87600
+
+  allowed_uses = [
+    "digital_signature",
+    "cert_signing",
+    "crl_signing",
+  ]
+}
+resource "tls_private_key" "default" {
+  algorithm   = "RSA"
+  rsa_bits    = "2048"
+}
+
+resource "tls_cert_request" "default_cert_request" {
+  key_algorithm   = tls_private_key.default.algorithm
+  private_key_pem = tls_private_key.default.private_key_pem
+  dns_names = ["optaisawesome.com"]
+  ip_addresses = ["${google_compute_global_address.load_balancer.address}"]
+
+  subject {
+    common_name = "optaisawesome.com"
+    organization = "Org"
+  }
+}
+
+resource "tls_locally_signed_cert" "default_cert" {
+  cert_request_pem      = tls_cert_request.default_cert_request.cert_request_pem
+  ca_key_algorithm      = tls_private_key.nginx_ca.algorithm
+  ca_private_key_pem    = tls_private_key.nginx_ca.private_key_pem
+  ca_cert_pem           = tls_self_signed_cert.nginx_ca.cert_pem
+  validity_period_hours = 87600
+
+  allowed_uses = [
+    "key_encipherment",
+    "digital_signature",
+    "server_auth",
+    "client_auth"
+  ]
+}
+
 resource "helm_release" "opta_base" {
   chart     = "${path.module}/opta-base"
   name      = "opta-base"
   namespace = "default"
   values = [
     yamlencode({
-      tls_key : base64encode(var.private_key),
-      tls_crt : base64encode(join("\n", [var.certificate_body, var.certificate_chain]))
+      tls_key : var.private_key == "" ? base64encode(tls_private_key.default.private_key_pem) : base64encode(var.private_key),
+      tls_crt : var.private_key == "" ? base64encode(tls_locally_signed_cert.default_cert.cert_pem) : base64encode(join("\n", [var.certificate_body, var.certificate_chain]))
     })
   ]
   depends_on = [

--- a/modules/gcp_k8s_base/tf_module/opta_base.tf
+++ b/modules/gcp_k8s_base/tf_module/opta_base.tf
@@ -1,11 +1,13 @@
 resource "tls_private_key" "nginx_ca" {
+  count     = var.expose_self_signed_ssl ? 1 : 0
   algorithm = "RSA"
   rsa_bits  = "2048"
 }
 
 resource "tls_self_signed_cert" "nginx_ca" {
+  count             = var.expose_self_signed_ssl ? 1 : 0
   key_algorithm     = "RSA"
-  private_key_pem   = tls_private_key.nginx_ca.private_key_pem
+  private_key_pem   = tls_private_key.nginx_ca[0].private_key_pem
   is_ca_certificate = true
 
   subject {
@@ -23,13 +25,15 @@ resource "tls_self_signed_cert" "nginx_ca" {
   ]
 }
 resource "tls_private_key" "default" {
+  count     = var.expose_self_signed_ssl ? 1 : 0
   algorithm = "RSA"
   rsa_bits  = "2048"
 }
 
 resource "tls_cert_request" "default_cert_request" {
-  key_algorithm   = tls_private_key.default.algorithm
-  private_key_pem = tls_private_key.default.private_key_pem
+  count           = var.expose_self_signed_ssl ? 1 : 0
+  key_algorithm   = tls_private_key.default[0].algorithm
+  private_key_pem = tls_private_key.default[0].private_key_pem
   dns_names       = ["optaisawesome.com"]
   ip_addresses    = ["${google_compute_global_address.load_balancer.address}"]
 
@@ -40,10 +44,11 @@ resource "tls_cert_request" "default_cert_request" {
 }
 
 resource "tls_locally_signed_cert" "default_cert" {
-  cert_request_pem      = tls_cert_request.default_cert_request.cert_request_pem
-  ca_key_algorithm      = tls_private_key.nginx_ca.algorithm
-  ca_private_key_pem    = tls_private_key.nginx_ca.private_key_pem
-  ca_cert_pem           = tls_self_signed_cert.nginx_ca.cert_pem
+  count                 = var.expose_self_signed_ssl ? 1 : 0
+  cert_request_pem      = tls_cert_request.default_cert_request[0].cert_request_pem
+  ca_key_algorithm      = tls_private_key.nginx_ca[0].algorithm
+  ca_private_key_pem    = tls_private_key.nginx_ca[0].private_key_pem
+  ca_cert_pem           = tls_self_signed_cert.nginx_ca[0].cert_pem
   validity_period_hours = 87600
 
   allowed_uses = [
@@ -60,8 +65,8 @@ resource "helm_release" "opta_base" {
   namespace = "default"
   values = [
     yamlencode({
-      tls_key : var.private_key == "" ? base64encode(tls_private_key.default.private_key_pem) : base64encode(var.private_key),
-      tls_crt : var.private_key == "" ? base64encode(tls_locally_signed_cert.default_cert.cert_pem) : base64encode(join("\n", [var.certificate_body, var.certificate_chain]))
+      tls_crt : var.private_key == "" && var.expose_self_signed_ssl ? base64encode(tls_locally_signed_cert.default_cert[0].cert_pem) : base64encode(join("\n", [var.certificate_body, var.certificate_chain]))
+      tls_key : var.private_key == "" && var.expose_self_signed_ssl ? base64encode(tls_private_key.default[0].private_key_pem) : base64encode(var.private_key),
     })
   ]
   depends_on = [

--- a/modules/gcp_k8s_base/tf_module/variables.tf
+++ b/modules/gcp_k8s_base/tf_module/variables.tf
@@ -89,3 +89,8 @@ variable "certificate_chain" {
 variable "nginx_config" {
   default = {}
 }
+
+variable "expose_self_signed_ssl" {
+  type    = bool
+  default = false
+}


### PR DESCRIPTION
# Description
Now all AWS and GCP Opta deployments will start with a self-signed ssl cert for https! And yes, it works for grpc (once you set the insecure flag)!

# Safety checklist
* [x] This change is backwards compatible and safe to apply by existing users
* [x] This change will NOT lead to data loss
* [x] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
manually
