### PR TITLE
Exclude examples dir when linting

### DIFF
--- a/scripts/lint.py
+++ b/scripts/lint.py
@@ -49,14 +49,13 @@ def py_check(files_changed: Collection[str], precommit: bool, apply: bool) -> in
     isort = "pipenv run isort --check-only"
     black = "pipenv run black --check"
     flake8 = "pipenv run flake8 --exclude examples"
-
     mypy = "pipenv run mypy --exclude examples"
 
     if precommit or apply:
         isort = "pipenv run isort"
         black = "pipenv run black"
-        flake8 = "pipenv run flake8"
-        mypy = "pipenv run mypy"
+        flake8 = "pipenv run flake8 --exclude examples"
+        mypy = "pipenv run mypy --exclude examples"
 
     cmd = f"{isort} {' '.join(files_changed)}\
         && {black} {' '.join(files_changed)}\


### PR DESCRIPTION
# Description
Always exclude `examples` dir when running flake8 or mypy linters.

# Safety checklist
* [X] This change is backwards compatible and safe to apply by existing users
* [X] This change will NOT lead to data loss
* [X] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
Ran `make lint` locally.
