### PR TITLE
CircleCI test for Terraform generated State files for AWS.

### DIFF
--- a/.circleci/ci-tests/terraform-generated-aws/environment.yaml
+++ b/.circleci/ci-tests/terraform-generated-aws/environment.yaml
@@ -1,0 +1,10 @@
+name: awsenv-tg
+org_name: runx
+providers:
+  aws:
+    region: us-east-2
+    account_id: 693658092572
+modules:
+  - type: base
+  - type: k8s-cluster
+  - type: k8s-base

--- a/.circleci/ci-tests/terraform-generated-aws/service-http.yaml
+++ b/.circleci/ci-tests/terraform-generated-aws/service-http.yaml
@@ -1,0 +1,20 @@
+environments:
+  - name: env-tg
+    path: "environment.yaml"
+    variables:
+      max_containers: 2
+name: http-service
+modules:
+  - name: app
+    type: k8s-service
+    image: kennethreitz/httpbin
+    public_uri: "/"
+    min_containers: 1
+    max_containers: "{vars.max_containers}"
+    liveness_probe_path: "/get"
+    readiness_probe_path: "/get"
+    sticky_session: true
+    sticky_session_max_age: 20
+    keep_path_prefix: true
+    port:
+      http: 80

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -368,31 +368,24 @@ jobs:
     executor: ubuntu-machine
     steps:
       - install-opta-dependencies
-      # - checkout-opta
       - attach_workspace:
           at: ~/
       - run:
-          name: "Test Terraform Generated Environment"
+          name: "Create Terraform Generated Environment"
           command: |
             cd $HOME/generated-tf-files-aws
-            terraform init          
-      # - run:
-      #     name: "Create Terraform Generated Environment"
-      #     command: |
-      #       cd $HOME/generated-tf-files-aws
-      #       terraform init
-      #       terraform plan -compact-warnings -lock=false -input=false -out=tf.plan -target=module.base
-      #       terraform apply -compact-warnings -auto-approve tf.plan
-      #       terraform plan -compact-warnings -lock=false -input=false -out=tf.plan -target=module.k8scluster
-      #       terraform apply -compact-warnings -auto-approve tf.plan
-      #       terraform plan -compact-warnings -lock=false -input=false -out=tf.plan -target=module.k8sbase
-      #       terraform apply -compact-warnings -auto-approve tf.plan
+            terraform init
+            terraform plan -compact-warnings -lock=false -input=false -out=tf.plan -target=module.base
+            terraform apply -compact-warnings -auto-approve tf.plan
+            terraform plan -compact-warnings -lock=false -input=false -out=tf.plan -target=module.k8scluster
+            terraform apply -compact-warnings -auto-approve tf.plan
+            terraform plan -compact-warnings -lock=false -input=false -out=tf.plan -target=module.k8sbase
+            terraform apply -compact-warnings -auto-approve tf.plan
 
   aws-tg-test-service-http:
     executor: ubuntu-machine
     steps:
       - install-opta-dependencies
-      # - checkout-opta
       - attach_workspace:
           at: ~/
       - run:
@@ -400,47 +393,36 @@ jobs:
           command: |
             cd $HOME/generated-tf-files-aws
             terraform init
-      # - run:
-      #     name: "Create Terraform Generated Http Service"
-      #     command: |
-      #       cd $HOME/generated-tf-files-aws
-      #       terraform init
-      #       terraform plan -compact-warnings -lock=false -input=false -out=tf.plan -target=module.app
-      #       terraform apply -compact-warnings -auto-approve tf.plan
-      # - run:
-      #     name: "Get Output"
-      #     command: |
-      #       cd .circleci/ci-tests/terraform-generated-aws/generated-tf-files
-      #       terraform output -json
-      # - run:
-      #     name: "Sleep 120 seconds"
-      #     command: |
-      #       sleep 120
-      # - run:
-      #     name: "Destroy Terraform Generated Http Service"
-      #     command: |
-      #       cd .circleci/ci-tests/terraform-generated-aws/generated-tf-files
-      #       terraform plan -compact-warnings -lock=false -input=false -out=tf.plan -target=module.app -destroy
-      #       terraform apply -compact-warnings -auto-approve tf.plan
+            terraform plan -compact-warnings -lock=false -input=false -out=tf.plan -target=module.app
+            terraform apply -compact-warnings -auto-approve tf.plan
+      - run:
+          name: "Get Output"
+          command: |
+            cd $HOME/generated-tf-files-aws
+            terraform output -json
+      - run:
+          name: "Sleep 120 seconds"
+          command: |
+            sleep 120
+      - run:
+          name: "Destroy Terraform Generated Http Service"
+          command: |
+            cd $HOME/generated-tf-files-aws
+            terraform plan -compact-warnings -lock=false -input=false -out=tf.plan -target=module.app -destroy
+            terraform apply -compact-warnings -auto-approve tf.plan
 
   aws-tg-destroy-env:
     executor: ubuntu-machine
     steps:
       - install-opta-dependencies
-      # - checkout-opta
       - attach_workspace:
           at: ~/
       - run:
-            name: "Test Terraform Generated Environment"
-            command: |
-              cd $HOME/generated-tf-files-aws
-              terraform init
-      # - run:
-      #     name: "Destroy Terraform Generated Environment"
-      #     command: |
-      #       cd .circleci/ci-tests/terraform-generated-aws/generated-tf-files
-      #       terraform plan -compact-warnings -lock=false -input=false -out=tf.plan -target=module.base -target=module.k8scluster -target=module.k8sbase -destroy
-      #       terraform apply -compact-warnings -auto-approve tf.plan
+          name: "Destroy Terraform Generated Environment"
+          command: |
+            cd $HOME/generated-tf-files-aws
+            terraform plan -compact-warnings -lock=false -input=false -out=tf.plan -target=module.base -target=module.k8scluster -target=module.k8sbase -destroy
+            terraform apply -compact-warnings -auto-approve tf.plan
 
   azure-create-env:
     executor: ubuntu-machine

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -381,6 +381,10 @@ jobs:
           root: ~/
           paths:
             - generated-tf-files-aws/tfstate/awsenv-tg.tfstate
+      - store_artifacts:
+          path: $HOME/generated-tf-files-aws/tfstate/awsenv-tg.tfstate
+          destination: tfstate-after-apply-env.tfstate
+
 
   aws-tg-test-service-http:
     executor: ubuntu-machine
@@ -423,6 +427,9 @@ jobs:
           root: ~/
           paths:
             - generated-tf-files-aws/tfstate/awsenv-tg.tfstate
+      - store_artifacts:
+          path: $HOME/generated-tf-files-aws/tfstate/awsenv-tg.tfstate
+          destination: tfstate-after-apply-svc-cnd.tfstate
 
   aws-tg-destroy-env:
     executor: ubuntu-machine
@@ -437,6 +444,9 @@ jobs:
             terraform init
             terraform plan -compact-warnings -lock=false -input=false -out=tf.plan -target=module.base -target=module.k8scluster -target=module.k8sbase -destroy
             terraform apply -compact-warnings -auto-approve tf.plan
+      - store_artifacts:
+          path: $HOME/generated-tf-files-aws/tfstate/awsenv-tg.tfstate
+          destination: tfstate-after-destroy.tfstate
 
   azure-create-env:
     executor: ubuntu-machine

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,6 +55,9 @@ parameters:
   ci-env-region-gcp:
     type: string
     default: 'us-central1'
+  run-opta-terraform-generate-test:
+    type: boolean
+    default: false
 
 orbs:
   terraform: circleci/terraform@3.0.0
@@ -151,6 +154,7 @@ jobs:
             echo "ci-env-name:                " << pipeline.parameters.ci-env-name >>
             echo "ci-env-region-aws:          " << pipeline.parameters.ci-env-region-aws >>
             echo "ci-env-region-gcp:          " << pipeline.parameters.ci-env-region-gcp >>
+            echo "run-opta-terraform-generate-test: " << pipeline.parameters.run-opta-terraform-generate-test >>
 
   no-pdb:
     executor: ubuntu-machine
@@ -352,17 +356,6 @@ jobs:
           root: ~/
           paths:
             - generated-tf-files-aws
-
-  aws-test-terraform-generated-files:
-    executor: ubuntu-machine
-    steps:
-      - attach_workspace:
-          at: ~/
-      - run:
-          name: "Test Terraform Generated Files"
-          command: |
-            cd $HOME/generated-tf-files-aws
-            ls -la
 
   aws-tg-create-env:
     executor: ubuntu-machine
@@ -2216,17 +2209,14 @@ workflows:
           requires:
             - build-opta-binary
 
-  test:
-    when: << pipeline.parameters.test >>
+  run-opta-terraform-generate-test:
+    when: << pipeline.parameters.run-opta-terraform-generate-test >>
     jobs:
       - get-all-parameter-values
       - build-opta-binary
       - aws-generate-terraform-language-files:
           requires:
             - build-opta-binary
-      - aws-test-terraform-generated-files:
-          requires:
-            - aws-generate-terraform-language-files
       - aws-tg-create-env:
           requires:
             - aws-generate-terraform-language-files

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -382,7 +382,7 @@ jobs:
           paths:
             - generated-tf-files-aws/tfstate/awsenv-tg.tfstate
       - store_artifacts:
-          path: $HOME/generated-tf-files-aws/tfstate/awsenv-tg.tfstate
+          path: ./generated-tf-files-aws/tfstate/awsenv-tg.tfstate
           destination: tfstate-after-apply-env.tfstate
 
 
@@ -428,7 +428,7 @@ jobs:
           paths:
             - generated-tf-files-aws/tfstate/awsenv-tg.tfstate
       - store_artifacts:
-          path: $HOME/generated-tf-files-aws/tfstate/awsenv-tg.tfstate
+          path: ./generated-tf-files-aws/tfstate/awsenv-tg.tfstate
           destination: tfstate-after-apply-svc-cnd.tfstate
 
   aws-tg-destroy-env:
@@ -445,7 +445,7 @@ jobs:
             terraform plan -compact-warnings -lock=false -input=false -out=tf.plan -target=module.base -target=module.k8scluster -target=module.k8sbase -destroy
             terraform apply -compact-warnings -auto-approve tf.plan
       - store_artifacts:
-          path: $HOME/generated-tf-files-aws/tfstate/awsenv-tg.tfstate
+          path: ./generated-tf-files-aws/tfstate/awsenv-tg.tfstate
           destination: tfstate-after-destroy.tfstate
 
   azure-create-env:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -404,12 +404,17 @@ jobs:
             terraform apply -compact-warnings -auto-approve tf.plan
             cat ./tfstate/awsenv-tg.tfstate
       - run:
+          name: "Sleep 120 seconds"
+          command: |
+            sleep 120
+      - run:
           name: "Get Output and Test Load Balancer"
           command: |
             cd $HOME/generated-tf-files-aws
             terraform output -json >> terraform_output.json
-            export LOAD_BALANCER=`cat output.json | jq -r '.load_balancer_raw_dns' |jq -r '.value'`
+            export LOAD_BALANCER=`cat terraform_output.json | jq -r '.load_balancer_raw_dns' |jq -r '.value'`
             echo $LOAD_BALANCER
+            curl $LOAD_BALANCER
             echo "1"
       - run:
           name: "Sleep 120 seconds"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -377,10 +377,17 @@ jobs:
             terraform init
             terraform plan -compact-warnings -lock=false -input=false -out=tf.plan -target=module.base
             terraform apply -compact-warnings -auto-approve tf.plan
+            cat ./tfstate/awsenv-tg.tfstate
             terraform plan -compact-warnings -lock=false -input=false -out=tf.plan -target=module.k8scluster
             terraform apply -compact-warnings -auto-approve tf.plan
+            cat ./tfstate/awsenv-tg.tfstate
             terraform plan -compact-warnings -lock=false -input=false -out=tf.plan -target=module.k8sbase
             terraform apply -compact-warnings -auto-approve tf.plan
+            cat ./tfstate/awsenv-tg.tfstate
+      - persist_to_workspace:
+          root: ~/
+          paths:
+            - generated-tf-files-aws/tfstate/awsenv-tg.tfstate
 
   aws-tg-test-service-http:
     executor: ubuntu-machine
@@ -395,6 +402,7 @@ jobs:
             terraform init
             terraform plan -compact-warnings -lock=false -input=false -out=tf.plan -target=module.app
             terraform apply -compact-warnings -auto-approve tf.plan
+            cat ./tfstate/awsenv-tg.tfstate
       - run:
           name: "Get Output"
           command: |
@@ -410,6 +418,10 @@ jobs:
             cd $HOME/generated-tf-files-aws
             terraform plan -compact-warnings -lock=false -input=false -out=tf.plan -target=module.app -destroy
             terraform apply -compact-warnings -auto-approve tf.plan
+      - persist_to_workspace:
+          root: ~/
+          paths:
+            - generated-tf-files-aws/tfstate/awsenv-tg.tfstate
 
   aws-tg-destroy-env:
     executor: ubuntu-machine
@@ -423,6 +435,11 @@ jobs:
             cd $HOME/generated-tf-files-aws
             terraform plan -compact-warnings -lock=false -input=false -out=tf.plan -target=module.base -target=module.k8scluster -target=module.k8sbase -destroy
             terraform apply -compact-warnings -auto-approve tf.plan
+            cat ./tfstate/awsenv-tg.tfstate
+      - persist_to_workspace:
+          root: ~/
+          paths:
+            - generated-tf-files-aws/tfstate/awsenv-tg.tfstate
 
   azure-create-env:
     executor: ubuntu-machine

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -433,9 +433,9 @@ jobs:
           name: "Destroy Terraform Generated Environment"
           command: |
             cd $HOME/generated-tf-files-aws
+            terraform init
             terraform plan -compact-warnings -lock=false -input=false -out=tf.plan -target=module.base -target=module.k8scluster -target=module.k8sbase -destroy
             terraform apply -compact-warnings -auto-approve tf.plan
-            cat ./tfstate/awsenv-tg.tfstate
       - persist_to_workspace:
           root: ~/
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -365,6 +365,68 @@ jobs:
             cd .circleci/ci-tests/terraform-generated-aws/generated-tf-files
             ls -la
 
+  aws-tg-create-env:
+    executor: ubuntu-machine
+    steps:
+      - install-opta-dependencies
+      - checkout-opta
+      - attach_workspace:
+          at: ./
+      - run:
+          name: "Create Terraform Generated Environment"
+          command: |
+            cd .circleci/ci-tests/terraform-generated-aws/generated-tf-files
+            terraform init
+            terraform plan -compact-warnings -lock=false -input=false -out=tf.plan -target=module.base
+            terraform apply -compact-warnings -auto-approve tf.plan
+            terraform plan -compact-warnings -lock=false -input=false -out=tf.plan -target=module.k8scluster
+            terraform apply -compact-warnings -auto-approve tf.plan
+            terraform plan -compact-warnings -lock=false -input=false -out=tf.plan -target=module.k8sbase
+            terraform apply -compact-warnings -auto-approve tf.plan
+
+  aws-tg-test-service-http:
+    executor: ubuntu-machine
+    steps:
+      - install-opta-dependencies
+      - checkout-opta
+      - attach_workspace:
+          at: ./
+      - run:
+          name: "Create Terraform Generated Http Service"
+          command: |
+            cd .circleci/ci-tests/terraform-generated-aws/generated-tf-files
+            terraform plan -compact-warnings -lock=false -input=false -out=tf.plan -target=module.app
+            terraform apply -compact-warnings -auto-approve tf.plan
+      - run:
+          name: "Get Output"
+          command: |
+            cd .circleci/ci-tests/terraform-generated-aws/generated-tf-files
+            terraform output -json
+      - run:
+          name: "Sleep 120 seconds"
+          command: |
+            sleep 120
+      - run:
+          name: "Destroy Terraform Generated Http Service"
+          command: |
+            cd .circleci/ci-tests/terraform-generated-aws/generated-tf-files
+            terraform plan -compact-warnings -lock=false -input=false -out=tf.plan -target=module.app -destroy
+            terraform apply -compact-warnings -auto-approve tf.plan
+
+  aws-tg-destroy-env:
+    executor: ubuntu-machine
+    steps:
+      - install-opta-dependencies
+      - checkout-opta
+      - attach_workspace:
+          at: ./
+      - run:
+          name: "Destroy Terraform Generated Environment"
+          command: |
+            cd .circleci/ci-tests/terraform-generated-aws/generated-tf-files
+            terraform plan -compact-warnings -lock=false -input=false -out=tf.plan -target=module.base -target=module.k8scluster -target=module.k8sbase -destroy
+            terraform apply -compact-warnings -auto-approve tf.plan
+
   azure-create-env:
     executor: ubuntu-machine
     environment:
@@ -2140,9 +2202,15 @@ workflows:
       - aws-generate-terraform-language-files:
           requires:
             - build-opta-binary
-      - aws-test-terraform-generated-files:
+      - aws-tg-create-env:
           requires:
             - aws-generate-terraform-language-files
+      - aws-tg-test-service-http:
+          requires:
+            - aws-tg-create-env
+      - aws-tg-destroy-env:
+          requires:
+            - aws-tg-test-service-http
 
   nightly:
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -437,10 +437,6 @@ jobs:
             terraform init
             terraform plan -compact-warnings -lock=false -input=false -out=tf.plan -target=module.base -target=module.k8scluster -target=module.k8sbase -destroy
             terraform apply -compact-warnings -auto-approve tf.plan
-      - persist_to_workspace:
-          root: ~/
-          paths:
-            - generated-tf-files-aws/tfstate/awsenv-tg.tfstate
 
   azure-create-env:
     executor: ubuntu-machine

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -404,10 +404,13 @@ jobs:
             terraform apply -compact-warnings -auto-approve tf.plan
             cat ./tfstate/awsenv-tg.tfstate
       - run:
-          name: "Get Output"
+          name: "Get Output and Test Load Balancer"
           command: |
             cd $HOME/generated-tf-files-aws
-            terraform output -json
+            terraform output -json >> terraform_output.json
+            export LOAD_BALANCER=`cat output.json | jq -r '.load_balancer_raw_dns' |jq -r '.value'`
+            echo $LOAD_BALANCER
+            echo "1"
       - run:
           name: "Sleep 120 seconds"
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -340,10 +340,10 @@ jobs:
           name: "Generate Terraform Language Files"
           command: |
             mkdir ./.circleci/ci-tests/terraform-generated-aws/generated-tf-files
-            ./dist/dist/opta generate-terraform \
+            ./dist/opta/opta generate-terraform \
             --config ./.circleci/ci-tests/terraform-generated-aws/environment.yaml \
             --directory ./.circleci/ci-tests/terraform-generated-aws/generated-tf-files
-            ./dist/dist/opta generate-terraform \
+            ./dist/opta/opta generate-terraform \
             --config ./.circleci/ci-tests/terraform-generated-aws/service-http.yaml \
             --directory ./.circleci/ci-tests/terraform-generated-aws/generated-tf-files
       - persist_to_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -342,10 +342,12 @@ jobs:
             mkdir ./.circleci/ci-tests/terraform-generated-aws/generated-tf-files
             ./dist/opta/opta generate-terraform \
             --config ./.circleci/ci-tests/terraform-generated-aws/environment.yaml \
-            --directory ./.circleci/ci-tests/terraform-generated-aws/generated-tf-files
+            --directory ./.circleci/ci-tests/terraform-generated-aws/generated-tf-files \
+            --auto-approve
             ./dist/opta/opta generate-terraform \
             --config ./.circleci/ci-tests/terraform-generated-aws/service-http.yaml \
-            --directory ./.circleci/ci-tests/terraform-generated-aws/generated-tf-files
+            --directory ./.circleci/ci-tests/terraform-generated-aws/generated-tf-files \
+            --auto-approve
       - persist_to_workspace:
           root: ./
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -382,7 +382,7 @@ jobs:
           paths:
             - generated-tf-files-aws/tfstate/awsenv-tg.tfstate
       - store_artifacts:
-          path: ./generated-tf-files-aws/tfstate/awsenv-tg.tfstate
+          path: ../generated-tf-files-aws/tfstate/awsenv-tg.tfstate
           destination: tfstate-after-apply-env.tfstate
 
 
@@ -428,7 +428,7 @@ jobs:
           paths:
             - generated-tf-files-aws/tfstate/awsenv-tg.tfstate
       - store_artifacts:
-          path: ./generated-tf-files-aws/tfstate/awsenv-tg.tfstate
+          path: ../generated-tf-files-aws/tfstate/awsenv-tg.tfstate
           destination: tfstate-after-apply-svc-cnd.tfstate
 
   aws-tg-destroy-env:
@@ -445,7 +445,7 @@ jobs:
             terraform plan -compact-warnings -lock=false -input=false -out=tf.plan -target=module.base -target=module.k8scluster -target=module.k8sbase -destroy
             terraform apply -compact-warnings -auto-approve tf.plan
       - store_artifacts:
-          path: ./generated-tf-files-aws/tfstate/awsenv-tg.tfstate
+          path: ../generated-tf-files-aws/tfstate/awsenv-tg.tfstate
           destination: tfstate-after-destroy.tfstate
 
   azure-create-env:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -329,6 +329,40 @@ jobs:
             - todo-api
             - todo-frontend
 
+  aws-generate-terraform-language-files:
+    executor: ubuntu-machine
+    steps:
+      - checkout-opta
+      - attach_workspace:
+          at: ./
+      - install-opta-dependencies
+      - run:
+          name: "Generate Terraform Language Files"
+          command: |
+            mkdir ./.circleci/ci-tests/terraform-generated-aws/generated-tf-files
+            ./dist/dist/opta generate-terraform \
+            --config ./.circleci/ci-tests/terraform-generated-aws/environment.yaml \
+            --directory ./.circleci/ci-tests/terraform-generated-aws/generated-tf-files
+            ./dist/dist/opta generate-terraform \
+            --config ./.circleci/ci-tests/terraform-generated-aws/service-http.yaml \
+            --directory ./.circleci/ci-tests/terraform-generated-aws/generated-tf-files
+      - persist_to_workspace:
+          root: ./
+          paths:
+            - .circleci/ci-tests/terraform-generated-aws/generated-tf-files
+
+  aws-test-terraform-generated-files:
+    executor: ubuntu-machine
+    steps:
+      - checkout-opta
+      - attach_workspace:
+          at: ./
+      - run:
+          name: "Test Terraform Generated Files"
+          command: |
+            cd .circleci/ci-tests/terraform-generated-aws/generated-tf-files
+            ls -la
+
   azure-create-env:
     executor: ubuntu-machine
     environment:
@@ -2101,12 +2135,12 @@ workflows:
     jobs:
       - get-all-parameter-values
       - build-opta-binary
-      - aws-create-env:
+      - aws-generate-terraform-language-files:
           requires:
             - build-opta-binary
-      - aws-destroy-env:
+      - aws-test-terraform-generated-files:
           requires:
-            - aws-create-env
+            - aws-generate-terraform-language-files
 
   nightly:
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -339,93 +339,108 @@ jobs:
       - run:
           name: "Generate Terraform Language Files"
           command: |
-            mkdir ./.circleci/ci-tests/terraform-generated-aws/generated-tf-files
+            mkdir $HOME/generated-tf-files-aws
             ./dist/opta/opta generate-terraform \
             --config ./.circleci/ci-tests/terraform-generated-aws/environment.yaml \
-            --directory ./.circleci/ci-tests/terraform-generated-aws/generated-tf-files \
+            --directory $HOME/generated-tf-files-aws \
             --auto-approve
             ./dist/opta/opta generate-terraform \
             --config ./.circleci/ci-tests/terraform-generated-aws/service-http.yaml \
-            --directory ./.circleci/ci-tests/terraform-generated-aws/generated-tf-files \
+            --directory $HOME/generated-tf-files-aws \
             --auto-approve
       - persist_to_workspace:
-          root: ./
+          root: ~/
           paths:
-            - .circleci/ci-tests/terraform-generated-aws/generated-tf-files
+            - generated-tf-files-aws
 
   aws-test-terraform-generated-files:
     executor: ubuntu-machine
     steps:
-      - checkout-opta
       - attach_workspace:
-          at: ./
+          at: ~/
       - run:
           name: "Test Terraform Generated Files"
           command: |
-            cd .circleci/ci-tests/terraform-generated-aws/generated-tf-files
+            cd $HOME/generated-tf-files-aws
             ls -la
 
   aws-tg-create-env:
     executor: ubuntu-machine
     steps:
       - install-opta-dependencies
-      - checkout-opta
+      # - checkout-opta
       - attach_workspace:
-          at: ./
+          at: ~/
       - run:
-          name: "Create Terraform Generated Environment"
+          name: "Test Terraform Generated Environment"
           command: |
-            cd .circleci/ci-tests/terraform-generated-aws/generated-tf-files
-            terraform init
-            terraform plan -compact-warnings -lock=false -input=false -out=tf.plan -target=module.base
-            terraform apply -compact-warnings -auto-approve tf.plan
-            terraform plan -compact-warnings -lock=false -input=false -out=tf.plan -target=module.k8scluster
-            terraform apply -compact-warnings -auto-approve tf.plan
-            terraform plan -compact-warnings -lock=false -input=false -out=tf.plan -target=module.k8sbase
-            terraform apply -compact-warnings -auto-approve tf.plan
+            cd $HOME/generated-tf-files-aws
+            terraform init          
+      # - run:
+      #     name: "Create Terraform Generated Environment"
+      #     command: |
+      #       cd $HOME/generated-tf-files-aws
+      #       terraform init
+      #       terraform plan -compact-warnings -lock=false -input=false -out=tf.plan -target=module.base
+      #       terraform apply -compact-warnings -auto-approve tf.plan
+      #       terraform plan -compact-warnings -lock=false -input=false -out=tf.plan -target=module.k8scluster
+      #       terraform apply -compact-warnings -auto-approve tf.plan
+      #       terraform plan -compact-warnings -lock=false -input=false -out=tf.plan -target=module.k8sbase
+      #       terraform apply -compact-warnings -auto-approve tf.plan
 
   aws-tg-test-service-http:
     executor: ubuntu-machine
     steps:
       - install-opta-dependencies
-      - checkout-opta
+      # - checkout-opta
       - attach_workspace:
-          at: ./
+          at: ~/
       - run:
           name: "Create Terraform Generated Http Service"
           command: |
-            cd .circleci/ci-tests/terraform-generated-aws/generated-tf-files
-            terraform plan -compact-warnings -lock=false -input=false -out=tf.plan -target=module.app
-            terraform apply -compact-warnings -auto-approve tf.plan
-      - run:
-          name: "Get Output"
-          command: |
-            cd .circleci/ci-tests/terraform-generated-aws/generated-tf-files
-            terraform output -json
-      - run:
-          name: "Sleep 120 seconds"
-          command: |
-            sleep 120
-      - run:
-          name: "Destroy Terraform Generated Http Service"
-          command: |
-            cd .circleci/ci-tests/terraform-generated-aws/generated-tf-files
-            terraform plan -compact-warnings -lock=false -input=false -out=tf.plan -target=module.app -destroy
-            terraform apply -compact-warnings -auto-approve tf.plan
+            cd $HOME/generated-tf-files-aws
+            terraform init
+      # - run:
+      #     name: "Create Terraform Generated Http Service"
+      #     command: |
+      #       cd $HOME/generated-tf-files-aws
+      #       terraform init
+      #       terraform plan -compact-warnings -lock=false -input=false -out=tf.plan -target=module.app
+      #       terraform apply -compact-warnings -auto-approve tf.plan
+      # - run:
+      #     name: "Get Output"
+      #     command: |
+      #       cd .circleci/ci-tests/terraform-generated-aws/generated-tf-files
+      #       terraform output -json
+      # - run:
+      #     name: "Sleep 120 seconds"
+      #     command: |
+      #       sleep 120
+      # - run:
+      #     name: "Destroy Terraform Generated Http Service"
+      #     command: |
+      #       cd .circleci/ci-tests/terraform-generated-aws/generated-tf-files
+      #       terraform plan -compact-warnings -lock=false -input=false -out=tf.plan -target=module.app -destroy
+      #       terraform apply -compact-warnings -auto-approve tf.plan
 
   aws-tg-destroy-env:
     executor: ubuntu-machine
     steps:
       - install-opta-dependencies
-      - checkout-opta
+      # - checkout-opta
       - attach_workspace:
-          at: ./
+          at: ~/
       - run:
-          name: "Destroy Terraform Generated Environment"
-          command: |
-            cd .circleci/ci-tests/terraform-generated-aws/generated-tf-files
-            terraform plan -compact-warnings -lock=false -input=false -out=tf.plan -target=module.base -target=module.k8scluster -target=module.k8sbase -destroy
-            terraform apply -compact-warnings -auto-approve tf.plan
+            name: "Test Terraform Generated Environment"
+            command: |
+              cd $HOME/generated-tf-files-aws
+              terraform init
+      # - run:
+      #     name: "Destroy Terraform Generated Environment"
+      #     command: |
+      #       cd .circleci/ci-tests/terraform-generated-aws/generated-tf-files
+      #       terraform plan -compact-warnings -lock=false -input=false -out=tf.plan -target=module.base -target=module.k8scluster -target=module.k8sbase -destroy
+      #       terraform apply -compact-warnings -auto-approve tf.plan
 
   azure-create-env:
     executor: ubuntu-machine
@@ -2202,6 +2217,9 @@ workflows:
       - aws-generate-terraform-language-files:
           requires:
             - build-opta-binary
+      - aws-test-terraform-generated-files:
+          requires:
+            - aws-generate-terraform-language-files
       - aws-tg-create-env:
           requires:
             - aws-generate-terraform-language-files


### PR DESCRIPTION
# Description
Using the State files generated using the command `opta generate-terraform`

# Safety checklist
* [ ] This change is backwards compatible and safe to apply by existing users
* [ ] This change will NOT lead to data loss
* [ ] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
Successful CircleCI test: **https://app.circleci.com/pipelines/github/run-x/opta/1431/workflows/af39af94-854e-4b8f-b487-8d80a1ecb344**