### PR TITLE
Adding label to kube-system namespace

### DIFF
--- a/modules/aws_k8s_base/aws_k8s_base.py
+++ b/modules/aws_k8s_base/aws_k8s_base.py
@@ -7,7 +7,12 @@ from ruamel.yaml.compat import StringIO
 
 from modules.base import AWSK8sModuleProcessor, K8sBaseModuleProcessor
 from opta.core.aws import AWS
-from opta.core.kubernetes import list_namespaces, load_opta_kube_config, set_kube_config
+from opta.core.kubernetes import (
+    add_linkerd_label_to_kubesystem,
+    list_namespaces,
+    load_opta_kube_config,
+    set_kube_config,
+)
 from opta.exceptions import UserErrors
 from opta.utils import yaml
 
@@ -74,7 +79,9 @@ class AwsK8sBaseProcessor(AWSK8sModuleProcessor, K8sBaseModuleProcessor):
 
     def pre_hook(self, module_idx: int) -> None:
         set_kube_config(self.layer)
+        add_linkerd_label_to_kubesystem()
         list_namespaces()
+
         super(AwsK8sBaseProcessor, self).pre_hook(module_idx)
 
     def post_hook(self, module_idx: int, exception: Optional[Exception]) -> None:

--- a/modules/aws_k8s_base/export.md
+++ b/modules/aws_k8s_base/export.md
@@ -1,0 +1,6 @@
+Exlude the `kube-system` namespace from the Linkerd proxy injector, like so:
+
+```
+kubectl label namespace kube-system config.linkerd.io/admission-webhooks=disabled
+```
+

--- a/modules/azure_k8s_base/azure_k8s_base.py
+++ b/modules/azure_k8s_base/azure_k8s_base.py
@@ -1,6 +1,11 @@
 from typing import TYPE_CHECKING
 
 from modules.base import ModuleProcessor
+from opta.core.kubernetes import (
+    add_linkerd_label_to_kubesystem,
+    list_namespaces,
+    set_kube_config,
+)
 
 if TYPE_CHECKING:
     from opta.layer import Layer
@@ -14,6 +19,12 @@ class AzureK8sBaseProcessor(ModuleProcessor):
                 f"The module {module.name} was expected to be of type k8s base"
             )
         super(AzureK8sBaseProcessor, self).__init__(module, layer)
+
+    def pre_hook(self, module_idx: int) -> None:
+        set_kube_config(self.layer)
+        add_linkerd_label_to_kubesystem()
+        list_namespaces()
+        super(AzureK8sBaseProcessor, self).pre_hook(module_idx)
 
     def process(self, module_idx: int) -> None:
         byo_cert_module = None

--- a/modules/azure_k8s_base/export.md
+++ b/modules/azure_k8s_base/export.md
@@ -1,0 +1,6 @@
+Exlude the `kube-system` namespace from the Linkerd proxy injector, like so:
+
+```
+kubectl label namespace kube-system config.linkerd.io/admission-webhooks=disabled
+```
+

--- a/modules/gcp_k8s_base/export.md
+++ b/modules/gcp_k8s_base/export.md
@@ -1,0 +1,6 @@
+Exlude the `kube-system` namespace from the Linkerd proxy injector, like so:
+
+```
+kubectl label namespace kube-system config.linkerd.io/admission-webhooks=disabled
+```
+

--- a/modules/gcp_k8s_base/gcp_k8s_base.py
+++ b/modules/gcp_k8s_base/gcp_k8s_base.py
@@ -2,6 +2,11 @@ from typing import TYPE_CHECKING
 
 from modules.base import GcpK8sModuleProcessor
 from opta.core.gcp import GCP
+from opta.core.kubernetes import (
+    add_linkerd_label_to_kubesystem,
+    list_namespaces,
+    set_kube_config,
+)
 
 if TYPE_CHECKING:
     from opta.layer import Layer
@@ -15,6 +20,12 @@ class GcpK8sBaseProcessor(GcpK8sModuleProcessor):
                 f"The module {module.name} was expected to be of type k8s base"
             )
         super(GcpK8sBaseProcessor, self).__init__(module, layer)
+
+    def pre_hook(self, module_idx: int) -> None:
+        set_kube_config(self.layer)
+        add_linkerd_label_to_kubesystem()
+        list_namespaces()
+        super(GcpK8sBaseProcessor, self).pre_hook(module_idx)
 
     def process(self, module_idx: int) -> None:
         byo_cert_module = None

--- a/opta/core/kubernetes.py
+++ b/opta/core/kubernetes.py
@@ -449,7 +449,7 @@ def add_linkerd_label_to_kubesystem() -> None:
     patch_obj = {
         "metadata": {"labels": {"config.linkerd.io/admission-webhooks": "disabled"}}
     }
-    v1.patch_namespace("kube_system", patch_obj)
+    v1.patch_namespace("kube-system", patch_obj)
 
 
 def create_secret_if_not_exists(namespace: str, secret_name: str) -> None:

--- a/opta/core/kubernetes.py
+++ b/opta/core/kubernetes.py
@@ -449,7 +449,7 @@ def add_linkerd_label_to_kubesystem() -> None:
     patch_obj = {
         "metadata": {"labels": {"config.linkerd.io/admission-webhooks": "disabled"}}
     }
-    v1.patch_namespace("kube_system", patch_obj, False)
+    v1.patch_namespace("kube_system", patch_obj)
 
 
 def create_secret_if_not_exists(namespace: str, secret_name: str) -> None:

--- a/opta/core/kubernetes.py
+++ b/opta/core/kubernetes.py
@@ -443,6 +443,15 @@ def create_namespace_if_not_exists(layer_name: str) -> None:
         )
 
 
+def add_linkerd_label_to_kubesystem() -> None:
+    load_opta_kube_config()
+    v1 = CoreV1Api()
+    patch_obj = {
+        "metadata": {"labels": {"config.linkerd.io/admission-webhooks": "disabled"}}
+    }
+    v1.patch_namespace("kube_system", patch_obj, False)
+
+
 def create_secret_if_not_exists(namespace: str, secret_name: str) -> None:
     """create the secret in the namespace if it doesn't exist"""
     load_opta_kube_config()


### PR DESCRIPTION
# Description
Add a label to kube-system because of this:
https://linkerd.io/2.10/features/ha/#proxy-injector-failure-policy

# Safety checklist
* [X ] This change is backwards compatible and safe to apply by existing users
* [X ] This change will NOT lead to data loss
* [X ] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
Circle Testing 
https://app.circleci.com/pipelines/github/run-x/opta?branch=feature%2Fadd-kube-system-label&filter=all

Also, verified that kube-system namespace has the required label in EKS.