### PR TITLE
Added extra proxy injector exclusion as kube-system in values

### DIFF
--- a/modules/aws_k8s_base/tf_module/values-ha.yaml
+++ b/modules/aws_k8s_base/tf_module/values-ha.yaml
@@ -66,3 +66,19 @@ tapResources: *controller_resources
 
 # web configuration
 webResources: *controller_resources
+# proxy injector configuration
+proxyInjector:
+  # -- Namespace selector used by admission webhook. If not set defaults to all
+  # namespaces without the annotation
+  # config.linkerd.io/admission-webhooks=disabled
+  namespaceSelector:
+    matchExpressions:
+    - key: config.linkerd.io/admission-webhooks
+      operator: NotIn
+      values:
+      - disabled
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kube-system
+    

--- a/modules/azure_k8s_base/tf_module/values-ha.yaml
+++ b/modules/azure_k8s_base/tf_module/values-ha.yaml
@@ -66,3 +66,19 @@ tapResources: *controller_resources
 
 # web configuration
 webResources: *controller_resources
+# proxy injector configuration
+proxyInjector:
+  # -- Namespace selector used by admission webhook. If not set defaults to all
+  # namespaces without the annotation
+  # config.linkerd.io/admission-webhooks=disabled
+  namespaceSelector:
+    matchExpressions:
+    - key: config.linkerd.io/admission-webhooks
+      operator: NotIn
+      values:
+      - disabled
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kube-system
+    

--- a/modules/gcp_k8s_base/tf_module/values-ha.yaml
+++ b/modules/gcp_k8s_base/tf_module/values-ha.yaml
@@ -66,3 +66,20 @@ tapResources: *controller_resources
 
 # web configuration
 webResources: *controller_resources
+
+# proxy injector configuration
+proxyInjector:
+  # -- Namespace selector used by admission webhook. If not set defaults to all
+  # namespaces without the annotation
+  # config.linkerd.io/admission-webhooks=disabled
+  namespaceSelector:
+    matchExpressions:
+    - key: config.linkerd.io/admission-webhooks
+      operator: NotIn
+      values:
+      - disabled
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kube-system
+    


### PR DESCRIPTION
# Description
Use matchlabel to keep kube-system out of the linkerd proxy. Alternative to https://github.com/run-x/opta/pull/728

# Safety checklist
* [ X] This change is backwards compatible and safe to apply by existing users
* [X ] This change will NOT lead to data loss
* [ X] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
Circle CI
