### PR TITLE
Added value to make nginx default ingress class

### DIFF
--- a/modules/aws_k8s_base/tf_module/ingress_nginx.tf
+++ b/modules/aws_k8s_base/tf_module/ingress_nginx.tf
@@ -63,6 +63,10 @@ resource "helm_release" "ingress-nginx" {
           }
         }
         containerPort : local.container_ports
+        ingressClassResource: {
+          default: true
+        }
+
         service : {
           loadBalancerSourceRanges : ["0.0.0.0/0"]
           externalTrafficPolicy : "Local"

--- a/modules/aws_k8s_base/tf_module/ingress_nginx.tf
+++ b/modules/aws_k8s_base/tf_module/ingress_nginx.tf
@@ -63,8 +63,8 @@ resource "helm_release" "ingress-nginx" {
           }
         }
         containerPort : local.container_ports
-        ingressClassResource: {
-          default: true
+        ingressClassResource : {
+          default : true
         }
 
         service : {

--- a/modules/azure_k8s_base/tf_module/ingress_nginx.tf
+++ b/modules/azure_k8s_base/tf_module/ingress_nginx.tf
@@ -108,6 +108,9 @@ resource "helm_release" "ingress-nginx" {
             ]
           }
         }
+        ingressClassResource: {
+          default: true
+        }
         containerPort : local.container_ports
         service : {
           loadBalancerIP : azurerm_public_ip.opta.ip_address

--- a/modules/azure_k8s_base/tf_module/ingress_nginx.tf
+++ b/modules/azure_k8s_base/tf_module/ingress_nginx.tf
@@ -108,8 +108,8 @@ resource "helm_release" "ingress-nginx" {
             ]
           }
         }
-        ingressClassResource: {
-          default: true
+        ingressClassResource : {
+          default : true
         }
         containerPort : local.container_ports
         service : {

--- a/modules/gcp_k8s_base/tf_module/ingress_nginx.tf
+++ b/modules/gcp_k8s_base/tf_module/ingress_nginx.tf
@@ -61,8 +61,8 @@ resource "helm_release" "ingress-nginx" {
             ]
           }
         }
-        ingressClassResource: {
-          default: true
+        ingressClassResource : {
+          default : true
         }
         containerPort : local.container_ports
         service : {

--- a/modules/gcp_k8s_base/tf_module/ingress_nginx.tf
+++ b/modules/gcp_k8s_base/tf_module/ingress_nginx.tf
@@ -30,6 +30,9 @@ resource "helm_release" "ingress-nginx" {
           enabled : var.nginx_high_availability ? true : false
           minReplicas : var.nginx_high_availability ? 3 : 1
         }
+        ingressClassResource: {
+          default: true
+        }
         affinity : {
           podAntiAffinity : {
             preferredDuringSchedulingIgnoredDuringExecution : [

--- a/modules/gcp_k8s_base/tf_module/ingress_nginx.tf
+++ b/modules/gcp_k8s_base/tf_module/ingress_nginx.tf
@@ -30,9 +30,6 @@ resource "helm_release" "ingress-nginx" {
           enabled : var.nginx_high_availability ? true : false
           minReplicas : var.nginx_high_availability ? 3 : 1
         }
-        ingressClassResource: {
-          default: true
-        }
         affinity : {
           podAntiAffinity : {
             preferredDuringSchedulingIgnoredDuringExecution : [
@@ -63,6 +60,9 @@ resource "helm_release" "ingress-nginx" {
               }
             ]
           }
+        }
+        ingressClassResource: {
+          default: true
         }
         containerPort : local.container_ports
         service : {


### PR DESCRIPTION
# Description

See this slack discussion: https://runx-dev.slack.com/archives/C01HZ9Z2QSU/p1645804226685129

With this change we get
```
sachin@sachin-bigbitbus-iwl:~$ kubectl describe ingressclass nginx 
Name:         nginx
Labels:       app.kubernetes.io/component=controller
              app.kubernetes.io/instance=ingress-nginx
              app.kubernetes.io/managed-by=Helm
              app.kubernetes.io/name=ingress-nginx
              app.kubernetes.io/part-of=ingress-nginx
              app.kubernetes.io/version=1.1.1
              helm.sh/chart=ingress-nginx-4.0.17
Annotations:  ingressclass.kubernetes.io/is-default-class: true
              meta.helm.sh/release-name: ingress-nginx
              meta.helm.sh/release-namespace: ingress-nginx
Controller:   k8s.io/ingress-nginx
Events:       <none>
```

Note the  ingressclass.kubernetes.io/is-default-class: true annotation.



# Safety checklist
* [X ] This change is backwards compatible and safe to apply by existing users
* [X ] This change will NOT lead to data loss
* [X ] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
Manual test
