### PR TITLE
regroup service and environment modules in documentation, cloud documentation pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,9 +70,9 @@ Opta supports the 3 major clouds - AWS, GCP and Azure. It has modules for the mo
 * Object storage (S3, GCS)
 
 Additionally, we bake in best practices like:
-* [Observability](https://docs.opta.dev/observability/) (Datadog, LogDNA)
+* [Observability](https://docs.opta.dev/features/observability/) (Datadog, LogDNA)
 * [SOC2 compliance](https://docs.opta.dev/compliance/)
-* [Continuous Deployment](https://docs.opta.dev/tutorials/continuous_deployment/)
+* [Continuous Deployment](https://docs.opta.dev/features/continuous_deployment/)
 * Hardened network and security configurations ([AWS](https://docs.opta.dev/architecture/aws/), [GCP](https://docs.opta.dev/architecture/gcp/), [Azure](https://docs.opta.dev/architecture/azure))
 * Auto-scaling and high availability (HA)
 
@@ -81,7 +81,7 @@ Additionally, we bake in best practices like:
 Opta aims to be compatible with your existing Infrastructure setup. You can:
 
 * Import existing Terraform infrastructure into Opta
-* Write [custom Terraform modules](https://docs.opta.dev/reference/aws/environment_modules/custom-terraform/) (for services that Opta doesn't support yet)
+* Write [custom Terraform modules](https://docs.opta.dev/reference/aws/modules/custom-terraform/) (for services that Opta doesn't support yet)
 * Run Opta in existing VPCs (WIP)
 * Export the generated Terraform
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -9,10 +9,10 @@ In some rare cases, upgrading an Opta version can cause a few minutes of downtim
 ## Upgrading Kubernetes version
 
 ### AWS
-Checkout our AWS EKS version upgrade guide [here](https://docs.opta.dev/tutorials/upgrading_eks/)
+Checkout our AWS EKS version upgrade guide [here](https://docs.opta.dev/reference/aws/eks_upgrade/)
 
 ### GCP
-Checkout our GCP GKE version upgrade guide [here](https://docs.opta.dev/tutorials/upgrade_gke/)
+Checkout our GCP GKE version upgrade guide [here](https://docs.opta.dev/reference/google/gke_upgrade/)
 
 ## Upgrading database version
 

--- a/config/registry/aws/deploy_to_aws_button.md
+++ b/config/registry/aws/deploy_to_aws_button.md
@@ -1,0 +1,91 @@
+---
+title: "Deploy to AWS Button"
+linkTitle: "Deploy to AWS Button"
+date: 2021-07-21
+weight: 1
+description: >
+  Allow your users to fill out their AWS Opta templates with the click of a button.
+---
+
+## Overview
+
+Opta's Deploy to AWS button allows users to deploy complex applications using Opta by simply filling out a form, downloading a file, and running `opta deploy`. This button is great to put into README files or on your website.
+
+Below is an example button that deploys an open source tool called Retool.
+
+[![Deploy to AWS Button](https://raw.githubusercontent.com/run-x/opta/main/assets/deploy-to-aws-button.svg)](http://app.runx.dev/deploy-with-aws?url=https%3A%2F%2Fgithub.com%2Frun-x%2Ftest-opta-template%2Fblob%2Fmain%2Fopta%2Ftemplate.yaml&name=Retool)
+
+## Creating a button
+
+### Step 1: Creating an Opta Template File
+
+The first step in creating your button is creating an Opta template. The format of a template is simple: it's a normal opta.yaml, except some parts of replaced with variables. The format of a variable is: `<<variable_name::variable_type::description>>`.
+
+Here is an example of an template file for a service called Retool:
+
+```yaml
+name: retool
+org_name: <<org_name::org_name::Your Organization Name>>
+providers:
+  aws:
+    region: <<region::aws_region::Your AWS Region>>
+    account_id: <<account_id::aws_account_id::Your AWS Account ID>>
+modules:
+  - type: base
+  - type: k8s-cluster
+    node_instance_type: t3.medium
+    max_nodes: 5
+    spot_instances: true
+  - type: k8s-base
+  - type: dns
+    domain: <<domain::string::The dns domain for your Retool deployment>>
+    delegated: false
+  - name: postgres
+    type: postgres
+  - type: helm-chart
+    name: console
+    chart: retool
+    repository: https://charts.retool.com
+    chart_version: "4.5.0"
+    values:
+      postgresql:
+        enabled: false
+      config:
+        encryptionKey: abcdefghijklmnopqrstuvwxyz
+        jwtSecret: abcdefghijklmnopqrstuvwxyq
+        postgresql:
+          port: 5432
+          user: "${{module.postgres.db_user}}"
+          host: "${{module.postgres.db_host}}"
+          db: "${{module.postgres.db_name}}"
+          password: "${{module.postgres.db_password}}"
+      image:
+        tag: <<image_tag::string::The docker image to deploy>>
+      ingress:
+        enabled: true
+        apiVersion: "networking.k8s.io/v1beta1"
+        hostName: "{module.dns.domain}"
+```
+
+You might notice that some of the variable "types" like `org_name`, `aws_region`, and `aws_account_id` in the above template are pretty specific. These types are associated with all sorts of special validations that will help make this deployment process more dummy-proof for your users. You can find the full list of types in the [Types Section](#types) of this page.
+
+Once you're done creating your yaml file, upload it to your public Github repository.
+
+#### Types
+
+Below is a list of all of the types currently available to use in your Opta template.
+
+| Name             | Description                                             |
+| ---------------- | ------------------------------------------------------- |
+| `org_name`       | The name of an Opta organization                        |
+| `aws_region`     | The aws region where an application will be deployed    |
+| `aws_account_id` | The ID of an AWS account                                |
+| `string`         | A vanilla string with no other special validation rules |
+
+### Step 2: Generating Button HTML and Testing
+
+To create your button, simply go to [our button creation UI](http://app.runx.dev/make-aws-button) and enter what you would like to name your template as well as the URL of your opta template. The UI will render your button. Click on the button and make sure that the resulting form looks like you expect it to.
+
+### Step 3: Putting the button everywhere!
+
+Once you're sure that everything's working as you expected, copy and paste the HTML from the button creation page, and put it whereever you'd like!

--- a/config/registry/aws/eks_upgrade.md
+++ b/config/registry/aws/eks_upgrade.md
@@ -1,0 +1,153 @@
+---
+title: "EKS Upgrade"
+linkTitle: "EKS Upgrade"
+date: 2022-01-03
+draft: false
+weight: 1
+description: >
+  How to upgrade the version of your EKS cluster created by opta.
+---
+
+## Overview
+As Kubernetes is constantly [releasing new versions](https://kubernetes.io/releases/), and
+deprecating older versions, so to are the cloud provider implementations like EKS which Opta
+uses for Kubernetes on AWS. Unlike in GKE, in EKS these upgrades are not handled automatically
+and the users are expected to 
+[manually update their cluster themselves](https://docs.aws.amazon.com/eks/latest/userguide/update-cluster.html).
+Fortunately for Opta users, this process does not need to be difficult and we have written an abridged version
+which should cover Opta-managed EKS setups.
+
+> The guide below does the update via the AWS Console, but you can do the commands via the cli as well if you so wish
+> Please refer to [here](https://docs.aws.amazon.com/eks/latest/userguide/update-cluster.html) for more details.
+
+## Steps
+As Kubernetes always [maintains 1 minor version compatibility backwards or forwards](https://kubernetes.io/releases/version-skew-policy/),
+all Kubernetes upgrades should be done one minor version at a time. EKS actually enforces this process. This
+means that if, for example, one wishes to go from version 1.18 to 1.21, they will need to do the update of
+1.18 -> 1.19, then 1.19 -> 1.20 and finally 1.20 -> 1.21. You can often do these repetitions in quick succession,
+but please read the [Breaking Changes](#breaking-changes) section carefully as some upgrades may require
+extra steps.
+
+To begin the upgrade, go to your AWS console UI, to the EKS section, and to the details of the cluster in question
+(make sure that you are in the correct region or otherwise you will not see the cluster's details). The name of your 
+cluster should be of the form "opta-{NAME OF YOUR ENV}". You should see a screeen like the following:
+
+<p>
+<a href="/images/eks_upgrade_1.png" target="_blank">
+  <img src="/images/eks_upgrade_1.png" align="center"/>
+</a>
+</p>
+
+### Step 1: Upgrade the Control Plane
+We will begin by updating the [Kubernetes control plane](https://kubernetes.io/docs/concepts/overview/components/#control-plane-components).
+
+To begin, simply click on the `Update Now` button which should be on your screen. It will lead you to a pop-up like so:
+
+<p>
+<a href="/images/eks_upgrade_2.png" target="_blank">
+  <img src="/images/eks_upgrade_2.png" align="center"/>
+</a>
+</p>
+
+**THIS IS IMPORTANT**: The control plane not only manages the container orchestration, but also the API through which 
+users interact, meaning that no new deployments or `kubectl` access should be attempted while this step is being done 
+(~20 minutes). Your _currently_ running applications will NOT be impacted. Please schedule the upgrade time accordingly.
+
+Click `Update`, and wait until the update is complete.
+
+### Step 2: Upgrade the Nodes
+Once the control plane is upgraded, you will need to upgrade the individual nodes running your workloads. As Opta uses
+managed node groups (and by default installs at least 1), one can mass-upgrade the nodes by upgrading the managed node group.
+You can do this by going to the `Configuration` tab of your EKS cluster and clicking on the `Compute` section. You should
+see your managed node groups listed like so:
+
+<p>
+<a href="/images/eks_upgrade_3.png" target="_blank">
+  <img src="/images/eks_upgrade_3.png" align="center"/>
+</a>
+</p>
+
+If Step 1 was completed successfully, you should see an `Update now` link like in the example above. Click there to
+begin configuring the K8s upgrade. It will lead you to a pop-up like so:
+
+<p>
+<a href="/images/eks_upgrade_4.png" target="_blank">
+  <img src="/images/eks_upgrade_4.png" align="center"/>
+</a>
+</p>
+
+**THIS IS IMPORTANT**: Because all the nodes will be replaced, there will be a minute or two of downtime if you did not
+set the nginx ingress to high availability on your [k8s-base](/reference/aws/modules/aws-k8s-base) instance, 
+and all the containers will be restarted, including the nginx pods (which is where the downtime originates from). You 
+may incur additional downtime if you containers take some time to start up. Please schedule the upgrade time accordingly. 
+Furthermore, note that the `Update strategy` is set to `Rolling update`-- this ensures that your nodes are not 
+mass-destroyed meaning that your workloads can slowly migrate over to the new hosts instead of all dying and restarting 
+at once.
+
+To begin, simply click the `Update` button, and the upgrade should take ~20 minutes. If you're interested, you will be
+able to trace the progress using `kubectl get nodes` and `kubectl get pods -A` as the new nodes are created, the pods
+are migrated, and the old nodes killed.
+
+Remember to rerun this step for each node group. As infrastructure changes should be done slowly and carefully
+(and the backwards compatibility of kubernetes allows us to take things slowly), **do not do more than one at a time**.
+
+### Step 3: Update the k8s version in Opta
+Once all the manual migration is done, you must update the Opta specs to reflect the kubernetes version upgrade.
+To do so, set the `k8s_version` field in the `k8s-cluster` block of your environment's yaml to your new kubernetes version.
+
+**NOTE**: The `k8s_version` field may not be currently specified in your yaml as it comes with a default. Opta 
+continuously updates this default but in order to not force downtime on the users the changes in the default do not
+affect existing clusters, only new ones. Please refer to [here](https://docs.opta.dev/reference/aws/modules/aws-eks/)
+for more details of the `k8s-cluster` block.
+
+For example, if you just upgraded to kubernetes version 1.21, then your environment yaml may change from looking like 
+this:
+
+```yaml
+name: staging # name of the environment
+org_name: my-org # A unique identifier for your organization
+providers:
+  aws:
+    region: us-east-1
+    account_id: XXXXXXXXX
+modules:
+  - type: base
+  - type: dns
+    domain: your.domain.com
+    delegated: false
+  - type: k8s-cluster
+  - type: k8s-base
+```
+
+To looking like this:
+
+```yaml
+name: staging # name of the environment
+org_name: my-org # A unique identifier for your organization
+providers:
+  aws:
+    region: us-east-1
+    account_id: XXXXXXXXX
+modules:
+  - type: base
+  - type: dns
+    domain: your.domain.com
+    delegated: false
+  - type: k8s-cluster
+    k8s_version: "1.21"
+  - type: k8s-base
+```
+
+## Breaking Changes
+### Outside of Opta
+Opta will provide warnings and documentation for upgrading all of our managed components, but you should make sure that 
+none of the third party helm charts/kubernetes manifests you have installed on your Kubernetes cluster have any version 
+incompatibility either. Please refer to this [Kubernetes API deprecation guide](https://kubernetes.io/docs/reference/using-api/deprecation-guide/) 
+to change your code accordingly.
+
+### 1.18 through 1.21
+No breaking changes or extra steps identified. You're good to go.
+
+### References
+https://docs.aws.amazon.com/eks/latest/userguide/update-cluster.html
+https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html

--- a/config/registry/aws/vpc_peering.md
+++ b/config/registry/aws/vpc_peering.md
@@ -1,0 +1,88 @@
+---
+title: "AWS VPC Peering"
+linkTitle: "AWS VPC Peering"
+date: 2021-07-21
+draft: false
+weight: 1
+description: Guide on how to peer AWS VPCs
+---
+
+## What is VPC Peering?
+VPC peering is the standard way of opening _private_ network communication between 2 AWS VPCs. This means a 
+server/lambda function/container/etc... in one VPC can send requests to a private IP (e.g. another server, a database, 
+etc...) in the other network, without touching the public internet. 
+
+This ability is extremely useful if one wishes to connect different Opta environments (or a pre-existing VPC and an 
+Opta environment) together without any serious security risk. This guide will show you step-by-step instructions on 
+how to do it.
+
+## Limitations
+VPCs can peer from cross AWS account and even cross region with minimal difficulties, but they can never peer
+with another VPC that shares an overlapping CIDR block.
+
+There are also a series of limitations on the connection but, from our experience, the only one seriously encountered
+is that AWS security groups do not work across VPC peerings in different regions or accounts. You will need to whitelist 
+by individual IPs or CIDR blocks.
+
+Click [here](AWS security groups do not work across VPC peerings) for the official list of limitations.
+
+## Send the VPC Peering
+The first step in peering a VPC is to send the peering request on behalf of one of them. It does not matter which VPC
+initiates as the peering described here will be symmetric. To do so, go to the AWS UI console on your web browser,
+open the VPC service homepage, and on the left bar search for "Peering Connections". CLick it
+
+<a href="/images/aws_peering_1.png" target="_blank">
+  <img src="/images/aws_peering_1.png" align="center"/>
+</a>
+
+You should now see all your existing VPC peering requests. We shall now be creating a new one, so go ahead and click the
+button at the top right to begin. The UI will now prompt you for details about the connection. Go ahead and give the
+connection a proper name, and add your initiating VPC id as the requester. Enter the data for the accepter VPC and hit 
+the button to create the peering connection.
+
+<a href="/images/aws_peering_2.png" target="_blank">
+  <img src="/images/aws_peering_2.png" align="center"/>
+</a>
+
+## Accept the Peering Connection
+Once the peering request is sent, go to your accepter VPC's account and region and under the peering connection listings
+you should see the new request pending. Select it and accept it. Your VPC is technically now peered, but there are 
+additional steps we need to do.
+
+
+<a href="/images/aws_peering_3.png" target="_blank">
+  <img src="/images/aws_peering_3.png" align="center"/>
+</a>
+
+## Set the Requester VPC's Route Tables
+Now that the peering is established, we need to set the routes in your subnet route tables to direct appropriate traffic
+to the peering connection. On the VPC page of the AWS console in your request VPC's account, go to the route table
+section and filter by your VPC id. You should now see the route tables for your VPC listed in the console. For each of
+them, click on the routes tab and select to edit routes. You will now add a new route with the destination being
+the accepter's CIDR block, and the target being the peering connection established. Do this for each route table.
+
+
+<a href="/images/aws_peering_4.png" target="_blank">
+  <img src="/images/aws_peering_4.png" align="center"/>
+</a>
+
+## Set the Accepter VPC's Route Tables
+Repeat the process for the accepter VPC's route tables, and set the destination to the requester's CIDR block.
+
+## Enable DNS Resolution
+
+Lastly, if you are using private hosted zones, then you might also want to enable DNS resolution. This allows your
+private hosted zones to be recognized across the peering connection in the other VPC. To do so, simply go back
+to the peering connection details, and under the DNS tab, click to edit DNS settings. In there, click to accept DNS
+resolution-- you need to accept for both VPC (so to check boxes total) and will need to look in the peering connection
+description in both VPC regions/accounts if the connection is cross region or account.
+
+
+<a href="/images/aws_peering_5.png" target="_blank">
+  <img src="/images/aws_peering_5.png" align="center"/>
+</a>
+
+## Further Guides
+
+[Official AWS Guide](https://docs.aws.amazon.com/vpc/latest/peering/what-is-vpc-peering.html)
+

--- a/config/registry/aws/vpc_peering.md
+++ b/config/registry/aws/vpc_peering.md
@@ -1,6 +1,6 @@
 ---
-title: "AWS VPC Peering"
-linkTitle: "AWS VPC Peering"
+title: "VPC Peering"
+linkTitle: "VPC Peering"
 date: 2021-07-21
 draft: false
 weight: 1

--- a/config/registry/google/gke_upgrade.md
+++ b/config/registry/google/gke_upgrade.md
@@ -1,0 +1,31 @@
+---
+title: "GKE Upgrade"
+linkTitle: "GKE Upgrade"
+date: 2022-01-03
+draft: false
+weight: 1
+description: >
+  How to upgrade the version of your GKE cluster created by opta.
+---
+
+# Upgrading Google Kubernetes Engine Version
+
+The Kubernetes Project releases minor version updates every quarter, and users are expected to update their infrastructure to at least within a few minor versions of the latest Kubernetes release. With Google GKE, Opta relies on GCP's [release channels](https://cloud.google.com/kubernetes-engine/docs/concepts/release-channels) to automatically upgrade the Kubernetes control plane and worker nodes. When Opta installs your GKE cluster, it uses the "regular" GKE channel. Currently (Feb 1, 2022), this channel will install a Kubernetes 1.21.x cluster. You can run the `kubectl version` command and look for the "Server Version" key to know what version your cluster is currently running.
+
+In the next days the GKE regular channel will start updating Kubernetes to 1.22.x; which will mean that your opta-deployed Kubernetes cluster will be automatically upgraded to a 1.22.x version. This version of Kubernetes removes several deprecated Kubernetes APIs (read the GKE deprecation guide [here](https://cloud.google.com/kubernetes-engine/docs/deprecations/apis-1-22)).
+
+
+Before the upgrade to Kubernetes v1.22.x, you should verify that the Kubernetes API used in Kubernetes v1.22.x version still supports your helm charts and kubernetes manifests. Please refer to [this]( https://kubernetes.io/docs/reference/using-api/deprecation-guide/) Kubernetes API deprecation guide to change your code accordingly; we recommend paying particular attention to the [Ingress changes](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#ingress-v122): `extensions/v1beta1` and `networking.k8s.io/v1beta1` APIs that are removed in Kubernetes v1.22.x; replace these with the corresponding `networking.k8s.io/v1` API objects. You can also use code-scanners such as [Pluto](https://github.com/FairwindsOps/pluto) to help with this process.
+
+Next, you should go ahead and upgrade Opta and your Kubernetes clusters:
+
+1. Update your opta version to v0.25.0 or newer and run `opta apply` on your gcp environment(s). This may cause your ingress resources to be unavailable for about a minute, so we recommend you do this change in a pre-determined change window.
+   
+2. Run `opta apply` or `opta deploy` on any service opta files you use to deploy Kubernetes deployments (services) or helm charts. Confirm everything works as expected. 
+
+To validate these changes in your dev/staging environment you can upgrade to 1.22 sooner by proceeding to the [gke UI](https://console.cloud.google.com/kubernetes) and click on upgrade cluster master version (See screenshot below); you can choose a 1.22.x version if that is available in the regular channel when you are reading this for example (see screenshot). Opta sets up auto-upgrading nodepools in GKE, so once the cluster upgrade is complete your Kubernetes worker nodes should automatically upgrade (on a rolling basis and without downtime) after a few hours. Watch for any errors and as always, feel free to reach out to us on our [slack](https://slack.opta.dev/).
+
+<p>
+<a href="/images/upgrade-gke-1.png" target="_blank">
+  <img src="/images/upgrade-gke-1.png" align="center"/>
+</p>

--- a/modules/aws_dns/aws-dns.json
+++ b/modules/aws_dns/aws-dns.json
@@ -9,7 +9,7 @@
     },
     "delegated": {
       "type": "boolean",
-      "description": "Set to true once the extra [dns setup is complete](/tutorials/ingress) and it will add the ssl certs.",
+      "description": "Set to true once the extra [dns setup is complete](/features/dns) and it will add the ssl certs.",
       "default": false
     },
     "upload_cert": {

--- a/modules/aws_dns/aws-dns.md
+++ b/modules/aws_dns/aws-dns.md
@@ -10,7 +10,7 @@ description: Adds dns to your environment
 This module creates a [Route53 hosted zone](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/hosted-zones-working-with.html) for
 your given domain. The [k8s-base]({{< relref "#k8s-base" >}}) module automatically hooks up the load balancer to it
 for the domain and subdomain specified, but in order for this to actually receive traffic you will need to complete
-the [dns setup](/tutorials/ingress).
+the [dns setup](/features/dns).
 
 
 ## Changing dns domains

--- a/modules/aws_dns/aws-dns.yaml
+++ b/modules/aws_dns/aws-dns.yaml
@@ -23,7 +23,7 @@ inputs:
   - name: delegated
     user_facing: true
     validator: bool(required=False)
-    description: Set to true once the extra [dns setup is complete](/tutorials/ingress) and it will add the ssl certs.
+    description: Set to true once the extra [dns setup is complete](/features/dns) and it will add the ssl certs.
     default: false
   - name: upload_cert
     user_facing: true

--- a/modules/aws_eks/aws-eks.md
+++ b/modules/aws_eks/aws-eks.md
@@ -12,4 +12,4 @@ nodegroup to host your applications in. This needs to be added in the environmen
 as Opta services run on Kubernetes.
 
 For information about the default IAM permissions given to the node group please see
-[here](/reference/aws/environment_modules/aws-nodegroup).
+[here](/reference/aws/modules/aws-nodegroup).

--- a/modules/aws_k8s_service/aws-k8s-service.json
+++ b/modules/aws_k8s_service/aws-k8s-service.json
@@ -57,21 +57,21 @@
     },
     "autoscaling_target_cpu_percentage": {
       "type": "integer",
-      "description": "See the [autoscaling](https://docs.opta.dev/reference/aws/service_modules/aws-k8s-service/#autoscaling) section.",
+      "description": "See the [autoscaling](https://docs.opta.dev/reference/aws/modules/aws-k8s-service/#autoscaling) section.",
       "default": 80,
       "minimum": 0,
       "maximum": 100
     },
     "autoscaling_target_mem_percentage": {
       "type": "integer",
-      "description": "See the [autoscaling](https://docs.opta.dev/reference/aws/service_modules/aws-k8s-service/#autoscaling) section.",
+      "description": "See the [autoscaling](https://docs.opta.dev/reference/aws/modules/aws-k8s-service/#autoscaling) section.",
       "default": 80,
       "minimum": 0,
       "maximum": 100
     },
     "secrets": {
       "type": "array",
-      "description": "Deprecated, see [secrets instructions](/tutorials/secrets).",
+      "description": "Deprecated, see [secrets instructions](/features/secrets).",
       "items": {
         "type": "string"
       },
@@ -84,7 +84,7 @@
     },
     "healthcheck_path": {
       "type": "string",
-      "description": "See the See the [liveness/readiness](https://docs.opta.dev/reference/aws/service_modules/aws-k8s-service/#healthcheck-probe) section. Default `null` (i.e., no user-specified healthchecks)"
+      "description": "See the See the [liveness/readiness](https://docs.opta.dev/reference/aws/modules/aws-k8s-service/#healthcheck-probe) section. Default `null` (i.e., no user-specified healthchecks)"
     },
     "liveness_probe_path": {
       "type": "string",
@@ -119,7 +119,7 @@
       "default": 86400
     },
     "resource_request": {
-      "description": "See the [container resources](https://docs.opta.dev/reference/aws/service_modules/aws-k8s-service/#container-resources) section. Default\n```yaml\ncpu: 100 # in millicores\nmemory: 128 # in megabytes\n```\nCPU is given in millicores, and Memory is in megabytes.\n",
+      "description": "See the [container resources](https://docs.opta.dev/reference/aws/modules/aws-k8s-service/#container-resources) section. Default\n```yaml\ncpu: 100 # in millicores\nmemory: 128 # in megabytes\n```\nCPU is given in millicores, and Memory is in megabytes.\n",
       "type": "object",
       "properties": {
         "cpu": {

--- a/modules/aws_k8s_service/aws-k8s-service.md
+++ b/modules/aws_k8s_service/aws-k8s-service.md
@@ -50,7 +50,7 @@ _NOTE_ We expose the resource requests and set the limits to twice the request v
 ### Ingress
 
 You can control if and how you want to expose your app to the world! Check out
-the [Ingress](/tutorials/ingress) docs for more details.
+the [Ingress](/features/dns) docs for more details.
 
 ### Persistent Storage
 A user can now specify persistent storage to be provisioned for your servers and kept intact over your different

--- a/modules/aws_k8s_service/aws-k8s-service.yaml
+++ b/modules/aws_k8s_service/aws-k8s-service.yaml
@@ -76,17 +76,17 @@ inputs:
   - name: autoscaling_target_cpu_percentage
     user_facing: true
     validator: any(str(), int(), required=False)
-    description: See the [autoscaling](https://docs.opta.dev/reference/aws/service_modules/aws-k8s-service/#autoscaling) section.
+    description: See the [autoscaling](https://docs.opta.dev/reference/aws/modules/aws-k8s-service/#autoscaling) section.
     default: 80
   - name: autoscaling_target_mem_percentage
     user_facing: true
     validator: any(str(), int(), required=False)
-    description: See the [autoscaling](https://docs.opta.dev/reference/aws/service_modules/aws-k8s-service/#autoscaling) section.
+    description: See the [autoscaling](https://docs.opta.dev/reference/aws/modules/aws-k8s-service/#autoscaling) section.
     default: 80
   - name: secrets
     user_facing: true
     validator: list(str(), required=False)
-    description: Deprecated, see [secrets instructions](/tutorials/secrets).
+    description: Deprecated, see [secrets instructions](/features/secrets).
     default: []
   - name: env_vars
     user_facing: true
@@ -101,7 +101,7 @@ inputs:
   - name: healthcheck_path
     user_facing: true
     validator: str(required=False)
-    description: See the See the [liveness/readiness](https://docs.opta.dev/reference/aws/service_modules/aws-k8s-service/#healthcheck-probe) section. Default `null` (i.e., no user-specified healthchecks)
+    description: See the See the [liveness/readiness](https://docs.opta.dev/reference/aws/modules/aws-k8s-service/#healthcheck-probe) section. Default `null` (i.e., no user-specified healthchecks)
     default: null
   - name: liveness_probe_path
     user_facing: true
@@ -142,7 +142,7 @@ inputs:
     user_facing: true
     validator: any(required=False)
     description: |
-      See the [container resources](https://docs.opta.dev/reference/aws/service_modules/aws-k8s-service/#container-resources) section. Default
+      See the [container resources](https://docs.opta.dev/reference/aws/modules/aws-k8s-service/#container-resources) section. Default
       ```yaml
       cpu: 100 # in millicores
       memory: 128 # in megabytes

--- a/modules/aws_s3/aws-s3.md
+++ b/modules/aws_s3/aws-s3.md
@@ -54,7 +54,7 @@ Opta will also catch any changes to the files on the next `opta apply` and will 
 extensive MIME parsing, so it also makes sure to set the content type correctly.
 
 ### Cloudfront
-This module can be [linked to Opta's cloudfront module](/reference/aws/service_modules/cloudfront-distribution/) in order to serve static files.
+This module can be [linked to Opta's cloudfront module](/reference/aws/modules/cloudfront-distribution/) in order to serve static files.
 
 To securely work with cloudfront, the module additionally creates a Cloudfront Origin Access Identity with read 
 privileges to be used by cloudfront to access its contents.

--- a/modules/aws_ses/aws-ses.md
+++ b/modules/aws_ses/aws-ses.md
@@ -9,5 +9,5 @@ description: Sets up AWS SES for sending emails via your root domain
 
 ### Notes
 
-- It's required to set up the [`aws-dns`]({{< ref "/reference/aws/environment_modules/aws-dns" >}} "aws-dns") module with this.
+- It's required to set up the [`aws-dns`]({{< ref "/reference/aws/modules/aws-dns" >}} "aws-dns") module with this.
 - Opta also files a ticket with AWS support to get out of SES sandbox mode.

--- a/modules/azure_k8s_service/azure-k8s-service.json
+++ b/modules/azure_k8s_service/azure-k8s-service.json
@@ -25,21 +25,21 @@
     },
     "autoscaling_target_cpu_percentage": {
       "type": "integer",
-      "description": "See the [autoscaling](https://docs.opta.dev/reference/azurerm/service_modules/azure-k8s-service/#autoscaling) section.",
+      "description": "See the [autoscaling](https://docs.opta.dev/reference/azurerm/modules/azure-k8s-service/#autoscaling) section.",
       "default": 80,
       "minimum": 0,
       "maximum": 100
     },
     "autoscaling_target_mem_percentage": {
       "type": "integer",
-      "description": "See the [autoscaling](https://docs.opta.dev/reference/azurerm/service_modules/azure-k8s-service/#autoscaling) section.",
+      "description": "See the [autoscaling](https://docs.opta.dev/reference/azurerm/modules/azure-k8s-service/#autoscaling) section.",
       "default": 80,
       "minimum": 0,
       "maximum": 100
     },
     "secrets": {
       "type": "array",
-      "description": "Deprecated, see [secrets instructions](/tutorials/secrets).",
+      "description": "Deprecated, see [secrets instructions](/features/secrets).",
       "items": {
         "type": "string"
       },
@@ -52,7 +52,7 @@
     },
     "healthcheck_path": {
       "type": "string",
-      "description": "See the See the [liveness/readiness](https://docs.opta.dev/reference/azurerm/service_modules/azure-k8s-service/#healthcheck-probe) section. Default `null` (i.e., no user-specified healthchecks)"
+      "description": "See the See the [liveness/readiness](https://docs.opta.dev/reference/azurerm/modules/azure-k8s-service/#healthcheck-probe) section. Default `null` (i.e., no user-specified healthchecks)"
     },
     "liveness_probe_path": {
       "type": "string",
@@ -87,7 +87,7 @@
       "default": 86400
     },
     "resource_request": {
-      "description": "See the [container resources](https://docs.opta.dev/reference/azurerm/service_modules/azure-k8s-service/#container-resources) section. Default\n```yaml\ncpu: 100 # in millicores\nmemory: 128 # in megabytes\n```\nCPU is given in millicores, and Memory is in megabytes.\n",
+      "description": "See the [container resources](https://docs.opta.dev/reference/azurerm/modules/azure-k8s-service/#container-resources) section. Default\n```yaml\ncpu: 100 # in millicores\nmemory: 128 # in megabytes\n```\nCPU is given in millicores, and Memory is in megabytes.\n",
       "type": "object",
       "properties": {
         "cpu": {

--- a/modules/azure_k8s_service/azure-k8s-service.md
+++ b/modules/azure_k8s_service/azure-k8s-service.md
@@ -49,7 +49,7 @@ _NOTE_ We expose the resource requests and set the limits to twice the request v
 ### Ingress
 
 You can control if and how you want to expose your app to the world! Check out
-the [Ingress](/tutorials/ingress) docs for more details.
+the [Ingress](/features/dns) docs for more details.
 
 ### Persistent Storage
 A user can now specify persistent storage to be provisioned for your servers and kept intact over your different

--- a/modules/azure_k8s_service/azure-k8s-service.yaml
+++ b/modules/azure_k8s_service/azure-k8s-service.yaml
@@ -62,17 +62,17 @@ inputs: # (what users see)
   - name: autoscaling_target_cpu_percentage
     user_facing: true
     validator: any(str(), int(), required=False)
-    description: See the [autoscaling](https://docs.opta.dev/reference/azurerm/service_modules/azure-k8s-service/#autoscaling) section.
+    description: See the [autoscaling](https://docs.opta.dev/reference/azurerm/modules/azure-k8s-service/#autoscaling) section.
     default: 80
   - name: autoscaling_target_mem_percentage
     user_facing: true
     validator: any(str(), int(), required=False)
-    description: See the [autoscaling](https://docs.opta.dev/reference/azurerm/service_modules/azure-k8s-service/#autoscaling) section.
+    description: See the [autoscaling](https://docs.opta.dev/reference/azurerm/modules/azure-k8s-service/#autoscaling) section.
     default: 80
   - name: secrets
     user_facing: true
     validator: list(str(), required=False)
-    description: Deprecated, see [secrets instructions](/tutorials/secrets).
+    description: Deprecated, see [secrets instructions](/features/secrets).
     default: []
   - name: env_vars
     user_facing: true
@@ -87,7 +87,7 @@ inputs: # (what users see)
   - name: healthcheck_path
     user_facing: true
     validator: str(required=False)
-    description: See the See the [liveness/readiness](https://docs.opta.dev/reference/azurerm/service_modules/azure-k8s-service/#healthcheck-probe) section. Default `null` (i.e., no user-specified healthchecks)
+    description: See the See the [liveness/readiness](https://docs.opta.dev/reference/azurerm/modules/azure-k8s-service/#healthcheck-probe) section. Default `null` (i.e., no user-specified healthchecks)
     default: null
   - name: liveness_probe_path
     user_facing: true
@@ -128,7 +128,7 @@ inputs: # (what users see)
     user_facing: true
     validator: any(required=False)
     description: |
-      See the [container resources](https://docs.opta.dev/reference/azurerm/service_modules/azure-k8s-service/#container-resources) section. Default
+      See the [container resources](https://docs.opta.dev/reference/azurerm/modules/azure-k8s-service/#container-resources) section. Default
       ```yaml
       cpu: 100 # in millicores
       memory: 128 # in megabytes

--- a/modules/datadog/datadog.md
+++ b/modules/datadog/datadog.md
@@ -8,5 +8,5 @@ description: Integrates datadog for observability
 ---
 
 This module setups the [Datadog Kubernetes](https://docs.datadoghq.com/agent/kubernetes/?tab=helm) integration onto
-the kubernetes cluster created for this environment. Please read the [datadog tutorial](/observability/datadog) for all the
+the kubernetes cluster created for this environment. Please read the [Datadog Integration](/features/observability/datadog) for all the
 details of the features.

--- a/modules/external_ssl_cert/external-ssl-cert.md
+++ b/modules/external_ssl_cert/external-ssl-cert.md
@@ -8,5 +8,5 @@ description: External SSL Certicate
 ---
 
 This is the external ssl certificate module used to pass in pre-existing ssl cerificates to add to the opta
-environment in the case dns delegation is not preferred. Please see the [ingress docs](/tutorials/ingress)
+environment in the case dns delegation is not preferred. Please see the [ingress docs](/features/dns)
 for more details.

--- a/modules/gcp_dns/gcp-dns.json
+++ b/modules/gcp_dns/gcp-dns.json
@@ -9,7 +9,7 @@
     },
     "delegated": {
       "type": "boolean",
-      "description": "The  Set to true once the extra [dns setup is complete](/tutorials/ingress) and it will add the ssl certs.",
+      "description": "The  Set to true once the extra [dns setup is complete](/features/dns) and it will add the ssl certs.",
       "default": false
     },
     "subdomains": {

--- a/modules/gcp_dns/gcp-dns.md
+++ b/modules/gcp_dns/gcp-dns.md
@@ -10,7 +10,7 @@ description: Adds dns to your environment
 This module creates a GCP [managed zone](https://cloud.google.com/dns/docs/zones) for
 your given domain. The [k8s-base]({{< relref "#k8s-base" >}}) module automatically hooks up the load balancer to it
 for the domain and subdomain specified, but in order for this to actually receive traffic you will need to complete
-the [dns setup](/tutorials/ingress).
+the [dns setup](/features/dns).
 
 ## Changing dns domains
 Currently, Opta does not support multiple domains (except subdomains) per environment, although that may change

--- a/modules/gcp_dns/gcp-dns.yaml
+++ b/modules/gcp_dns/gcp-dns.yaml
@@ -22,7 +22,7 @@ inputs:
   - name: delegated
     user_facing: true
     validator: bool(required=False)
-    description: The  Set to true once the extra [dns setup is complete](/tutorials/ingress) and it will add the ssl certs.
+    description: The  Set to true once the extra [dns setup is complete](/features/dns) and it will add the ssl certs.
     default: false
   - name: subdomains
     user_facing: true

--- a/modules/gcp_gke/gcp-gke.md
+++ b/modules/gcp_gke/gcp-gke.md
@@ -12,4 +12,4 @@ node pool to host your applications in. This needs to be added in the environmen
 as Opta services run on Kubernetes.
 
 For information about the default IAM permissions given to the node pool please see 
-[here](/reference/google/environment_modules/gcp-nodepool).
+[here](/reference/google/modules/gcp-nodepool).

--- a/modules/gcp_k8s_service/gcp-k8s-service.json
+++ b/modules/gcp_k8s_service/gcp-k8s-service.json
@@ -42,21 +42,21 @@
     },
     "autoscaling_target_cpu_percentage": {
       "type": "integer",
-      "description": "See the [autoscaling](https://docs.opta.dev/reference/google/service_modules/gcp-k8s-service/#autoscaling) section.",
+      "description": "See the [autoscaling](https://docs.opta.dev/reference/google/modules/gcp-k8s-service/#autoscaling) section.",
       "default": 80,
       "minimum": 0,
       "maximum": 100
     },
     "autoscaling_target_mem_percentage": {
       "type": "integer",
-      "description": "See the [autoscaling](https://docs.opta.dev/reference/google/service_modules/gcp-k8s-service/#autoscaling) section.",
+      "description": "See the [autoscaling](https://docs.opta.dev/reference/google/modules/gcp-k8s-service/#autoscaling) section.",
       "default": 80,
       "minimum": 0,
       "maximum": 100
     },
     "secrets": {
       "type": "array",
-      "description": "Deprecated, see [secrets instructions](/tutorials/secrets).",
+      "description": "Deprecated, see [secrets instructions](/features/secrets).",
       "items": {
         "type": "string"
       },
@@ -69,7 +69,7 @@
     },
     "healthcheck_path": {
       "type": "string",
-      "description": "See the See the [liveness/readiness](https://docs.opta.dev/reference/google/service_modules/gcp-k8s-service/#healthcheck-probe) section. Default `null` (i.e., no user-specified healthchecks)"
+      "description": "See the See the [liveness/readiness](https://docs.opta.dev/reference/google/modules/gcp-k8s-service/#healthcheck-probe) section. Default `null` (i.e., no user-specified healthchecks)"
     },
     "liveness_probe_path": {
       "type": "string",
@@ -104,7 +104,7 @@
       "default": 86400
     },
     "resource_request": {
-      "description": "See the [container resources](https://docs.opta.dev/reference/google/service_modules/gcp-k8s-service/#container-resources) section. Default\n```yaml\ncpu: 100 # in millicores\nmemory: 128 # in megabytes\n```\nCPU is given in millicores, and Memory is in megabytes.\n",
+      "description": "See the [container resources](https://docs.opta.dev/reference/google/modules/gcp-k8s-service/#container-resources) section. Default\n```yaml\ncpu: 100 # in millicores\nmemory: 128 # in megabytes\n```\nCPU is given in millicores, and Memory is in megabytes.\n",
       "type": "object",
       "properties": {
         "cpu": {

--- a/modules/gcp_k8s_service/gcp-k8s-service.md
+++ b/modules/gcp_k8s_service/gcp-k8s-service.md
@@ -50,7 +50,7 @@ _NOTE_ We expose the resource requests and set the limits to twice the request v
 ### Ingress
 
 You can control if and how you want to expose your app to the world! Check out
-the [Ingress](/tutorials/ingress) docs for more details.
+the [Ingress](/features/dns) docs for more details.
 
 ### Persistent Storage
 A user can now specify persistent storage to be provisioned for your servers and kept intact over your different

--- a/modules/gcp_k8s_service/gcp-k8s-service.yaml
+++ b/modules/gcp_k8s_service/gcp-k8s-service.yaml
@@ -66,17 +66,17 @@ inputs:
   - name: autoscaling_target_cpu_percentage
     user_facing: true
     validator: any(str(), int(), required=False)
-    description: See the [autoscaling](https://docs.opta.dev/reference/google/service_modules/gcp-k8s-service/#autoscaling) section.
+    description: See the [autoscaling](https://docs.opta.dev/reference/google/modules/gcp-k8s-service/#autoscaling) section.
     default: 80
   - name: autoscaling_target_mem_percentage
     user_facing: true
     validator: any(str(), int(), required=False)
-    description: See the [autoscaling](https://docs.opta.dev/reference/google/service_modules/gcp-k8s-service/#autoscaling) section.
+    description: See the [autoscaling](https://docs.opta.dev/reference/google/modules/gcp-k8s-service/#autoscaling) section.
     default: 80
   - name: secrets
     user_facing: true
     validator: list(str(), required=False)
-    description: Deprecated, see [secrets instructions](/tutorials/secrets).
+    description: Deprecated, see [secrets instructions](/features/secrets).
     default: []
   - name: env_vars
     user_facing: true
@@ -91,7 +91,7 @@ inputs:
   - name: healthcheck_path
     user_facing: true
     validator: str(required=False)
-    description: See the See the [liveness/readiness](https://docs.opta.dev/reference/google/service_modules/gcp-k8s-service/#healthcheck-probe) section. Default `null` (i.e., no user-specified healthchecks)
+    description: See the See the [liveness/readiness](https://docs.opta.dev/reference/google/modules/gcp-k8s-service/#healthcheck-probe) section. Default `null` (i.e., no user-specified healthchecks)
     default: null
   - name: liveness_probe_path
     user_facing: true
@@ -133,7 +133,7 @@ inputs:
     user_facing: true
     validator: any(required=False)
     description: |
-      See the [container resources](https://docs.opta.dev/reference/google/service_modules/gcp-k8s-service/#container-resources) section. Default
+      See the [container resources](https://docs.opta.dev/reference/google/modules/gcp-k8s-service/#container-resources) section. Default
       ```yaml
       cpu: 100 # in millicores
       memory: 128 # in megabytes

--- a/modules/local_k8s_service/local-k8s-service.json
+++ b/modules/local_k8s_service/local-k8s-service.json
@@ -57,7 +57,7 @@
     },
     "secrets": {
       "type": "array",
-      "description": "Deprecated, see [secrets instructions](/tutorials/secrets).",
+      "description": "Deprecated, see [secrets instructions](/features/secrets).",
       "items": {
         "type": "string"
       },

--- a/modules/local_k8s_service/local-k8s-service.yaml
+++ b/modules/local_k8s_service/local-k8s-service.yaml
@@ -72,7 +72,7 @@ inputs:
   - name: secrets
     user_facing: true
     validator: list(str(), required=False)
-    description: Deprecated, see [secrets instructions](/tutorials/secrets).
+    description: Deprecated, see [secrets instructions](/features/secrets).
     default: []
   - name: env_vars
     user_facing: true

--- a/opta/commands/deploy.py
+++ b/opta/commands/deploy.py
@@ -68,7 +68,7 @@ def deploy(
 
     opta deploy -c my-service.yaml -i my-image:latest --local
 
-    Documentation: https://docs.opta.dev/tutorials/custom_image/
+    Documentation: https://docs.opta.dev/features/custom_image/
 
     """
 

--- a/opta/commands/push.py
+++ b/opta/commands/push.py
@@ -162,7 +162,7 @@ def push(image: str, config: str, env: Optional[str], tag: Optional[str]) -> Non
             fmt_msg(
                 """
             Opta push can only run on service yaml files. This is an environment yaml file.
-            ~See https://docs.runx.dev/docs/reference/service_modules/ for more details.
+            ~See https://docs.runx.dev/docs/reference/modules/ for more details.
             ~
             ~(We know that this is an environment yaml file, because service yaml must
             ~specify the "environments" field).

--- a/opta/commands/secret.py
+++ b/opta/commands/secret.py
@@ -58,7 +58,7 @@ def secret() -> None:
 
     opta secret view -c my-service.yaml "MY_SECRET_1"
 
-    Documentation: https://docs.opta.dev/tutorials/secrets/
+    Documentation: https://docs.opta.dev/features/secrets/
     """
     pass
 


### PR DESCRIPTION
# Description
- For each cloud documentation, `environment_modules` and `service_modules` are now regrouped under `modules`
- The cloud specific documentation is now defined in the cloud references. These pages were moved from opta-docs repo to this repo
  - EKS Upgrade
  - AWS VPC Peering
  - Deploy to AWS Button
  - GKE Upgrade
- updated the links

# Safety checklist
* [X] This change is backwards compatible and safe to apply by existing users
* [X] This change will NOT lead to data loss
* [X] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
ran `/scripts/docs` and used it with local hugo install 
