### PR TITLE
fix cannot import name 'json' from 'itsdangerous'

### DIFF
--- a/examples/hello-app/Dockerfile
+++ b/examples/hello-app/Dockerfile
@@ -1,10 +1,10 @@
-FROM python:3.8-slim-buster
+FROM python:3.10-slim-buster
 
 ENV FLASK_APP=app
 
 WORKDIR /app
 
-RUN pip install Flask==0.12 
+RUN pip install Flask==2.0
 COPY . /app
 ENV PORT 80
 


### PR DESCRIPTION
# Description

fix
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/runpy.py", line 185, in _run_module_as_main
    mod_name, mod_spec, code = _get_module_details(mod_name, _Error)
  File "/usr/local/lib/python3.8/runpy.py", line 144, in _get_module_details
    return _get_module_details(pkg_main_name, error)
  File "/usr/local/lib/python3.8/runpy.py", line 111, in _get_module_details
    __import__(pkg_name)
  File "/usr/local/lib/python3.8/site-packages/flask/__init__.py", line 21, in <module>
    from .app import Flask, Request, Response
  File "/usr/local/lib/python3.8/site-packages/flask/app.py", line 26, in <module>
    from . import json, cli
  File "/usr/local/lib/python3.8/site-packages/flask/json.py", line 22, in <module>
    from itsdangerous import json as _json
ImportError: cannot import name 'json' from 'itsdangerous' (/usr/local/lib/python3.8/site-packages/itsdangerous/__init__.py)
```
https://stackoverflow.com/questions/71189819/python-docker-importerror-cannot-import-name-json-from-itsdangerous

note: 2.0 is the latest flask version available with the buster image

# Safety checklist
* [X] This change is backwards compatible and safe to apply by existing users
* [X] This change will NOT lead to data loss
* [X] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
local docker run
