### PR TITLE
Use correct default value

### DIFF
--- a/modules/aws_eks/tf_module/variables.tf
+++ b/modules/aws_eks/tf_module/variables.tf
@@ -61,7 +61,7 @@ variable "node_instance_type" {
 
 variable "k8s_version" {
   type    = string
-  default = "1.18"
+  default = "1.21"
 }
 
 variable "spot_instances" {


### PR DESCRIPTION
# Description
use the correct default k8s version as mentioned in yaml configuration.

# Safety checklist
* [ ] This change is backwards compatible and safe to apply by existing users
* [ ] This change will NOT lead to data loss
* [ ] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?

