### PR TITLE
aws-tg-destroy-env: retry terraform destroy on failure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -453,6 +453,14 @@ jobs:
             terraform init
             terraform plan -compact-warnings -lock=false -input=false -out=tf.plan -target=module.base -target=module.k8scluster -target=module.k8sbase -destroy
             terraform apply -compact-warnings -auto-approve tf.plan
+      - run:
+          name: "Destroy Terraform Generated Environment (retry)"
+          when: on_fail
+          command: |
+            cd $HOME/generated-tf-files-aws
+            terraform init
+            terraform plan -compact-warnings -lock=false -input=false -out=tf.plan -target=module.base -target=module.k8scluster -target=module.k8sbase -destroy
+            terraform apply -compact-warnings -auto-approve tf.plan
       - store_artifacts:
           path: ../generated-tf-files-aws/tfstate/awsenv-tg.tfstate
           destination: tfstate-after-destroy.tfstate


### PR DESCRIPTION
# Description
retry `terraform destroy` if failed.
note: this will not fix the test, but we can have the logs from the 1st and 2nd run together.

# Safety checklist
* [X] This change is backwards compatible and safe to apply by existing users
* [X] This change will NOT lead to data loss
* [X] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
to test on CI
