### PR TITLE
Only import mypy type def modules during type checking

### DIFF
--- a/opta/core/aws.py
+++ b/opta/core/aws.py
@@ -6,9 +6,12 @@ from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, TypedDict
 import boto3
 from botocore.config import Config
 from botocore.exceptions import ClientError
-from mypy_boto3_dynamodb import DynamoDBClient
-from mypy_boto3_eks import EKSClient
-from mypy_boto3_s3 import S3Client
+
+if TYPE_CHECKING:
+    # Only present when dev dependencies installed
+    from mypy_boto3_dynamodb import DynamoDBClient
+    from mypy_boto3_eks import EKSClient
+    from mypy_boto3_s3 import S3Client
 
 import opta.constants as constants
 from opta.constants import ONE_WEEK_UNIX, yaml

--- a/opta/core/aws.py
+++ b/opta/core/aws.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from os import remove
 from os.path import exists, getmtime
 from time import sleep, time

--- a/tests/core/test_aws.py
+++ b/tests/core/test_aws.py
@@ -1,9 +1,13 @@
 from datetime import datetime
+from typing import TYPE_CHECKING
 from unittest.mock import Mock
 
 from botocore.response import StreamingBody
-from mypy_boto3_dynamodb import DynamoDBClient
-from mypy_boto3_s3 import S3Client
+
+if TYPE_CHECKING:
+    from mypy_boto3_dynamodb import DynamoDBClient
+    from mypy_boto3_s3 import S3Client
+
 from pytest import fixture
 from pytest_mock import MockFixture
 

--- a/tests/core/test_aws.py
+++ b/tests/core/test_aws.py
@@ -1,12 +1,9 @@
 from datetime import datetime
-from typing import TYPE_CHECKING
 from unittest.mock import Mock
 
 from botocore.response import StreamingBody
-
-if TYPE_CHECKING:
-    from mypy_boto3_dynamodb import DynamoDBClient
-    from mypy_boto3_s3 import S3Client
+from mypy_boto3_dynamodb import DynamoDBClient
+from mypy_boto3_s3 import S3Client
 
 from pytest import fixture
 from pytest_mock import MockFixture

--- a/tests/core/test_aws.py
+++ b/tests/core/test_aws.py
@@ -4,7 +4,6 @@ from unittest.mock import Mock
 from botocore.response import StreamingBody
 from mypy_boto3_dynamodb import DynamoDBClient
 from mypy_boto3_s3 import S3Client
-
 from pytest import fixture
 from pytest_mock import MockFixture
 


### PR DESCRIPTION
# Description
Fix potential module import errors. These aren't installed anymore in prod installations, so we want to make sure there aren't failures due to the modules not being present.

# Safety checklist
* [X] This change is backwards compatible and safe to apply by existing users
* [X] This change will NOT lead to data loss
* [X] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
None
