### PR TITLE
Use K8s version from variables not data

### DIFF
--- a/modules/aws_eks/aws-eks.yaml
+++ b/modules/aws_eks/aws-eks.yaml
@@ -110,6 +110,9 @@ outputs:
   - name: k8s_node_group_security_id
     export: true
     description: The id of the security group of the cluster nodepools.
+  - name: k8s_version
+    export: true
+    description: The version of the K8s Cluster
 output_providers:
   helm:
     kubernetes:

--- a/modules/aws_eks/tf_module/outputs.tf
+++ b/modules/aws_eks/tf_module/outputs.tf
@@ -21,3 +21,7 @@ output "k8s_openid_provider_arn" {
 output "k8s_node_group_security_id" {
   value = aws_eks_cluster.cluster.vpc_config[0].cluster_security_group_id
 }
+
+output "k8s_version" {
+  value = aws_eks_cluster.cluster.version
+}

--- a/modules/aws_k8s_base/aws-k8s-base.yaml
+++ b/modules/aws_k8s_base/aws-k8s-base.yaml
@@ -18,6 +18,10 @@ inputs:
     user_facing: false
     description: Name of k8s cluster we're building on.
     default: None
+  - name: k8s_version
+    user_facing: false
+    description: Version of k8s cluster we're building on.
+    default: None
   - name: eks_cluster_name
     user_facing: false
     description: The eks cluster name

--- a/modules/aws_k8s_base/aws_k8s_base.py
+++ b/modules/aws_k8s_base/aws_k8s_base.py
@@ -69,6 +69,7 @@ class AwsK8sBaseProcessor(AWSK8sModuleProcessor, K8sBaseModuleProcessor):
         self.module.data[
             "k8s_cluster_name"
         ] = f"${{{{module.{aws_eks_module.name}.k8s_cluster_name}}}}"
+        self.module.data["k8s_version"] = f"${{{{module.{aws_eks_module.name}.k8s_version}}}}"
 
         super(AwsK8sBaseProcessor, self).process(module_idx)
 

--- a/modules/aws_k8s_base/tf_module/ingress_nginx.tf
+++ b/modules/aws_k8s_base/tf_module/ingress_nginx.tf
@@ -3,7 +3,7 @@ resource "helm_release" "ingress-nginx" {
   chart            = "ingress-nginx"
   name             = "ingress-nginx"
   repository       = "https://kubernetes.github.io/ingress-nginx"
-  version          = data.aws_eks_cluster.current.version == "1.18" ? "3.40.0" : "4.0.17"
+  version          = contains(["1.19", "1.20", "1.21", "1.22"], var.k8s_version) ? "4.0.17" : "3.40.0"
   namespace        = "ingress-nginx"
   create_namespace = true
   atomic           = true

--- a/modules/aws_k8s_base/tf_module/variables.tf
+++ b/modules/aws_k8s_base/tf_module/variables.tf
@@ -54,6 +54,10 @@ variable "k8s_cluster_name" {
   type = string
 }
 
+variable "k8s_version" {
+  type = string
+}
+
 variable "openid_provider_url" {
   type = string
 }


### PR DESCRIPTION
# Description
Data is available only during the apply phase, so we are getting a mismatch in the plan created and the plan executed. 
Using k8s version from `aws-eks` module output.

# Safety checklist
* [ ] This change is backwards compatible and safe to apply by existing users
* [ ] This change will NOT lead to data loss
* [ ] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
YOUR_ANSWER
