### PR TITLE
Adding timeouts for k8s services

### DIFF
--- a/modules/aws_k8s_service/aws-k8s-service.json
+++ b/modules/aws_k8s_service/aws-k8s-service.json
@@ -55,6 +55,11 @@
       "default": 3,
       "minimum": 0
     },
+    "timeout": {
+      "type": "number",
+      "description": "Time in seconds to wait for deployment.",
+      "default": 600
+    },
     "autoscaling_target_cpu_percentage": {
       "type": "integer",
       "description": "See the [autoscaling](https://docs.opta.dev/reference/aws/modules/aws-k8s-service/#autoscaling) section.",

--- a/modules/aws_k8s_service/aws-k8s-service.json
+++ b/modules/aws_k8s_service/aws-k8s-service.json
@@ -58,7 +58,7 @@
     "timeout": {
       "type": "number",
       "description": "Time in seconds to wait for deployment.",
-      "default": 600
+      "default": 300
     },
     "autoscaling_target_cpu_percentage": {
       "type": "integer",

--- a/modules/aws_k8s_service/aws-k8s-service.yaml
+++ b/modules/aws_k8s_service/aws-k8s-service.yaml
@@ -205,7 +205,7 @@ inputs:
     user_facing: true
     validator: int(required=False)
     description: Time in seconds to wait for deployment.
-    default: 600
+    default: 300
 extra_validators:
   cron_job:
     commands: list(required=True)

--- a/modules/aws_k8s_service/aws-k8s-service.yaml
+++ b/modules/aws_k8s_service/aws-k8s-service.yaml
@@ -201,6 +201,11 @@ inputs:
     default: {}
     description: |
       These are extra annotations to add to k8s-service pod objects 
+  - name: timeout
+    user_facing: true
+    validator: int(required=False)
+    description: Time in seconds to wait for deployment.
+    default: 600
 extra_validators:
   cron_job:
     commands: list(required=True)

--- a/modules/aws_k8s_service/tf_module/main.tf
+++ b/modules/aws_k8s_service/tf_module/main.tf
@@ -59,5 +59,6 @@ resource "helm_release" "k8s-service" {
   ]
   atomic          = true
   cleanup_on_fail = true
+  timeout         = var.timeout
 }
 

--- a/modules/aws_k8s_service/tf_module/variables.tf
+++ b/modules/aws_k8s_service/tf_module/variables.tf
@@ -207,3 +207,7 @@ variable "pod_annotations" {
   default     = {}
   description = "values to add to the pod annotations for the k8s-service pods"
 }
+variable "timeout" {
+  type    = number
+  default = 300
+}

--- a/modules/azure_k8s_service/azure-k8s-service.json
+++ b/modules/azure_k8s_service/azure-k8s-service.json
@@ -23,6 +23,11 @@
       "default": 3,
       "minimum": 0
     },
+    "timeout": {
+      "type": "number",
+      "description": "Time in seconds to wait for deployment.",
+      "default": 600
+    },
     "autoscaling_target_cpu_percentage": {
       "type": "integer",
       "description": "See the [autoscaling](https://docs.opta.dev/reference/azurerm/modules/azure-k8s-service/#autoscaling) section.",

--- a/modules/azure_k8s_service/azure-k8s-service.json
+++ b/modules/azure_k8s_service/azure-k8s-service.json
@@ -26,7 +26,7 @@
     "timeout": {
       "type": "number",
       "description": "Time in seconds to wait for deployment.",
-      "default": 600
+      "default": 300
     },
     "autoscaling_target_cpu_percentage": {
       "type": "integer",

--- a/modules/azure_k8s_service/azure-k8s-service.yaml
+++ b/modules/azure_k8s_service/azure-k8s-service.yaml
@@ -172,6 +172,11 @@ inputs: # (what users see)
     default: {}
     description: |
       These are extra annotations to add to k8s-service pod objects
+  - name: timeout
+    user_facing: true
+    validator: int(required=False)
+    description: Time in seconds to wait for deployment.
+    default: 600
 extra_validators:
   persistent_storage:
     size: int(required=True)

--- a/modules/azure_k8s_service/azure-k8s-service.yaml
+++ b/modules/azure_k8s_service/azure-k8s-service.yaml
@@ -176,7 +176,7 @@ inputs: # (what users see)
     user_facing: true
     validator: int(required=False)
     description: Time in seconds to wait for deployment.
-    default: 600
+    default: 300
 extra_validators:
   persistent_storage:
     size: int(required=True)

--- a/modules/azure_k8s_service/tf_module/main.tf
+++ b/modules/azure_k8s_service/tf_module/main.tf
@@ -56,5 +56,6 @@ resource "helm_release" "k8s-service" {
   ]
   atomic          = true
   cleanup_on_fail = true
+  timeout         = var.timeout
 }
 

--- a/modules/azure_k8s_service/tf_module/variables.tf
+++ b/modules/azure_k8s_service/tf_module/variables.tf
@@ -196,3 +196,7 @@ variable "pod_annotations" {
   default     = {}
   description = "values to add to the pod annotations for the k8s-service pods"
 }
+variable "timeout" {
+  type    = number
+  default = 300
+}

--- a/modules/gcp_k8s_service/gcp-k8s-service.json
+++ b/modules/gcp_k8s_service/gcp-k8s-service.json
@@ -24,7 +24,7 @@
     "timeout": {
       "type": "number",
       "description": "Time in seconds to wait for deployment.",
-      "default": 600
+      "default": 300
     },
     "max_containers": {
       "type": "integer",

--- a/modules/gcp_k8s_service/gcp-k8s-service.json
+++ b/modules/gcp_k8s_service/gcp-k8s-service.json
@@ -21,6 +21,11 @@
       "default": 1,
       "minimum": 0
     },
+    "timeout": {
+      "type": "number",
+      "description": "Time in seconds to wait for deployment.",
+      "default": 600
+    },
     "max_containers": {
       "type": "integer",
       "description": "The maximum number of replicas your app can autoscale to.",

--- a/modules/gcp_k8s_service/gcp-k8s-service.yaml
+++ b/modules/gcp_k8s_service/gcp-k8s-service.yaml
@@ -192,6 +192,11 @@ inputs:
     default: {}
     description: |
       These are extra annotations to add to k8s-service pod objects
+  - name: timeout
+    user_facing: true
+    validator: int(required=False)
+    description: Time in seconds to wait for deployment.
+    default: 600
 extra_validators:
   cron_job:
     commands: list(required=True)

--- a/modules/gcp_k8s_service/gcp-k8s-service.yaml
+++ b/modules/gcp_k8s_service/gcp-k8s-service.yaml
@@ -196,7 +196,7 @@ inputs:
     user_facing: true
     validator: int(required=False)
     description: Time in seconds to wait for deployment.
-    default: 600
+    default: 300
 extra_validators:
   cron_job:
     commands: list(required=True)

--- a/modules/gcp_k8s_service/tf_module/main.tf
+++ b/modules/gcp_k8s_service/tf_module/main.tf
@@ -58,4 +58,5 @@ resource "helm_release" "k8s-service" {
   ]
   atomic          = true
   cleanup_on_fail = true
+  timeout         = var.timeout
 }

--- a/modules/gcp_k8s_service/tf_module/variables.tf
+++ b/modules/gcp_k8s_service/tf_module/variables.tf
@@ -210,3 +210,7 @@ variable "pod_annotations" {
   default     = {}
   description = "values to add to the pod annotations for the k8s-service pods"
 }
+variable "timeout" {
+  type    = number
+  default = 300
+}


### PR DESCRIPTION
# Description
Now folks can pass in timeouts to specify if deployments take longer than 5 minutes


# Safety checklist
* [x] This change is backwards compatible and safe to apply by existing users
* [x] This change will NOT lead to data loss
* [x] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
YOUR_ANSWER
