### PR TITLE
Feature/tfsec tighten security of opta

### DIFF
--- a/modules/aws_eks/tf_module/eks.tf
+++ b/modules/aws_eks/tf_module/eks.tf
@@ -38,7 +38,7 @@ resource "aws_eks_cluster" "cluster" {
     security_group_ids      = [aws_security_group.eks.id]
     endpoint_private_access = false # TODO: make this true once we got VPN figured out
     #tfsec:ignore:aws-eks-no-public-cluster-access
-    endpoint_public_access  = true  # TODO: make this false once we got VPN figured out
+    endpoint_public_access = true # TODO: make this false once we got VPN figured out
   }
 
   encryption_config {

--- a/modules/aws_eks/tf_module/eks.tf
+++ b/modules/aws_eks/tf_module/eks.tf
@@ -20,6 +20,8 @@ resource "aws_security_group" "eks" {
     from_port   = 0
     to_port     = 0
     protocol    = "-1"
+    # To be fixed - for now user can create an SG manually to override.
+    #tfsec:ignore:aws-vpc-no-public-egress-sgr
     cidr_blocks = ["0.0.0.0/0"]
   }
 }
@@ -29,10 +31,13 @@ resource "aws_eks_cluster" "cluster" {
   role_arn = aws_iam_role.cluster_role.arn
   version  = var.k8s_version
 
+  # To be fixed, although early opta users need this - Cluster allows access from a public CIDR: 0.0.0.0/0
+  #tfsec:ignore:aws-eks-no-public-cluster-access-to-cidr
   vpc_config {
     subnet_ids              = var.private_subnet_ids
     security_group_ids      = [aws_security_group.eks.id]
     endpoint_private_access = false # TODO: make this true once we got VPN figured out
+    #tfsec:ignore:aws-eks-no-public-cluster-access
     endpoint_public_access  = true  # TODO: make this false once we got VPN figured out
   }
 

--- a/modules/external_ssl_cert/tf_module/variables.tf
+++ b/modules/external_ssl_cert/tf_module/variables.tf
@@ -14,7 +14,7 @@ variable "module_name" {
 }
 
 variable "private_key_file" {
-  type    = string
+  type = string
   # Ignore since this default value is never used, its for a logical if condition checking if user specified no private_key_file.
   #tfsec:ignore:general-secrets-no-plaintext-exposure
   default = ""

--- a/modules/external_ssl_cert/tf_module/variables.tf
+++ b/modules/external_ssl_cert/tf_module/variables.tf
@@ -15,6 +15,8 @@ variable "module_name" {
 
 variable "private_key_file" {
   type    = string
+  # Ignore since this default value is never used, its for a logical if condition checking if user specified no private_key_file.
+  #tfsec:ignore:general-secrets-no-plaintext-exposure
   default = ""
 }
 

--- a/modules/gcp_gke/tf_module/default_node_group.tf
+++ b/modules/gcp_gke/tf_module/default_node_group.tf
@@ -15,6 +15,7 @@ resource "google_container_node_pool" "default" {
   }
 
   node_config {
+    image_type = "COS_CONTAINERD"
     preemptible  = var.preemptible
     machine_type = var.node_instance_type
     disk_size_gb = var.node_disk_size

--- a/modules/gcp_gke/tf_module/default_node_group.tf
+++ b/modules/gcp_gke/tf_module/default_node_group.tf
@@ -15,7 +15,7 @@ resource "google_container_node_pool" "default" {
   }
 
   node_config {
-    image_type = "COS_CONTAINERD"
+    image_type   = "COS_CONTAINERD"
     preemptible  = var.preemptible
     machine_type = var.node_instance_type
     disk_size_gb = var.node_disk_size

--- a/modules/gcp_gke/tf_module/gke.tf
+++ b/modules/gcp_gke/tf_module/gke.tf
@@ -1,3 +1,6 @@
+  # PSP is deprecated in Kubernetes, no point adding it.
+  #tfsec:ignore:google-gke-enforce-pod-security-policy
+   #tfsec:ignore:google-gke-enable-master-networks
 resource "google_container_cluster" "primary" {
   name           = var.cluster_name
   location       = data.google_client_config.current.region

--- a/modules/gcp_gke/tf_module/gke.tf
+++ b/modules/gcp_gke/tf_module/gke.tf
@@ -1,6 +1,6 @@
-  # PSP is deprecated in Kubernetes, no point adding it.
-  #tfsec:ignore:google-gke-enforce-pod-security-policy
-   #tfsec:ignore:google-gke-enable-master-networks
+# PSP is deprecated in Kubernetes, no point adding it.
+#tfsec:ignore:google-gke-enforce-pod-security-policy
+#tfsec:ignore:google-gke-enable-master-networks
 resource "google_container_cluster" "primary" {
   name           = var.cluster_name
   location       = data.google_client_config.current.region

--- a/modules/gcp_k8s_base/tf_module/variables.tf
+++ b/modules/gcp_k8s_base/tf_module/variables.tf
@@ -78,7 +78,7 @@ variable "private_key" {
 }
 
 variable "certificate_body" {
-  type    = string
+  type = string
   # Ignore since this default value is never used, its for a logical if condition checking if user specified no cert.
   #tfsec:ignore:general-secrets-no-plaintext-exposure
   default = ""

--- a/modules/gcp_k8s_base/tf_module/variables.tf
+++ b/modules/gcp_k8s_base/tf_module/variables.tf
@@ -70,13 +70,17 @@ variable "zone_names" {
   type    = list(string)
   default = []
 }
-
 variable "private_key" {
+  # Ignore since this default value is never used, its for a logical if condition checking if user specified no private_key only.
+  #tfsec:ignore:general-secrets-no-plaintext-exposure
   type    = string
+  default = ""
 }
 
 variable "certificate_body" {
   type    = string
+  # Ignore since this default value is never used, its for a logical if condition checking if user specified no cert.
+  #tfsec:ignore:general-secrets-no-plaintext-exposure
   default = ""
 }
 

--- a/modules/gcp_k8s_base/tf_module/variables.tf
+++ b/modules/gcp_k8s_base/tf_module/variables.tf
@@ -73,7 +73,6 @@ variable "zone_names" {
 
 variable "private_key" {
   type    = string
-  default = ""
 }
 
 variable "certificate_body" {

--- a/modules/gcp_mysql/tf_module/main.tf
+++ b/modules/gcp_mysql/tf_module/main.tf
@@ -24,7 +24,9 @@ resource "google_sql_database_instance" "instance" {
     ip_configuration {
       ipv4_enabled    = false
       private_network = data.google_compute_network.vpc.id
-      require_ssl     = false
+      # Ignore since this requires client certs, VPC is private in anycase
+      #tfsec:ignore:google-sql-encrypt-in-transit-data
+      require_ssl = false
     }
     backup_configuration {
       enabled            = true

--- a/modules/gcp_postgres/tf_module/main.tf
+++ b/modules/gcp_postgres/tf_module/main.tf
@@ -24,7 +24,9 @@ resource "google_sql_database_instance" "instance" {
     ip_configuration {
       ipv4_enabled    = false
       private_network = data.google_compute_network.vpc.id
-      require_ssl     = false
+      # Ignore since this requires client certs, VPC is private in anycase
+      #tfsec:ignore:google-sql-encrypt-in-transit-data
+      require_ssl = false
     }
     backup_configuration {
       enabled    = true

--- a/modules/gcp_postgres/tf_module/main.tf
+++ b/modules/gcp_postgres/tf_module/main.tf
@@ -50,7 +50,7 @@ resource "google_sql_database_instance" "instance" {
     }
     database_flags {
       name  = "log_temp_files"
-      value = 0
+      value = "0"
     }
   }
 

--- a/modules/lambda_function/tf_module/main.tf
+++ b/modules/lambda_function/tf_module/main.tf
@@ -55,7 +55,7 @@ data "aws_iam_policy_document" "lambda_cloudwatch" {
     actions = ["logs:CreateLogGroup",
       "logs:CreateLogStream",
     "logs:PutLogEvents"]
-    resources = ["${aws_cloudwatch_log_group.arn}"]
+    resources = ["${aws_cloudwatch_log_group.logs.arn}"]
   }
 }
 

--- a/modules/lambda_function/tf_module/main.tf
+++ b/modules/lambda_function/tf_module/main.tf
@@ -55,7 +55,7 @@ data "aws_iam_policy_document" "lambda_cloudwatch" {
     actions = ["logs:CreateLogGroup",
       "logs:CreateLogStream",
     "logs:PutLogEvents"]
-    resources = ["arn:aws:logs:*:*:*"]
+    resources = ["${aws_cloudwatch_log_group.arn}"]
   }
 }
 

--- a/modules/local_mongodb/tf_module/variables.tf
+++ b/modules/local_mongodb/tf_module/variables.tf
@@ -22,7 +22,9 @@ variable "db_user" {
 variable "db_password" {
   description = "Database password"
   type        = string
-  default     = "mongodbpassword"
+  # Ignore since local is within PC, not designed to secure secrets.
+  #tfsec:ignore:general-secrets-no-plaintext-exposure
+  default = "mongodbpassword"
 }
 variable "db_name" {
   description = "Database name"

--- a/modules/local_mysql/tf_module/variables.tf
+++ b/modules/local_mysql/tf_module/variables.tf
@@ -22,7 +22,9 @@ variable "db_user" {
 variable "db_password" {
   description = "Database password"
   type        = string
-  default     = "mysqlpassword"
+  # Ignore since local is within PC, not designed to secure secrets.
+  #tfsec:ignore:general-secrets-no-plaintext-exposure
+  default = "mysqlpassword"
 }
 variable "db_name" {
   description = "Database name"

--- a/modules/local_postgres/tf_module/variables.tf
+++ b/modules/local_postgres/tf_module/variables.tf
@@ -22,7 +22,9 @@ variable "db_user" {
 variable "db_password" {
   description = "Database password"
   type        = string
-  default     = "pgpassword"
+  # Ignore since local is within PC, not designed to secure secrets.
+  #tfsec:ignore:general-secrets-no-plaintext-exposure
+  default = "pgpassword"
 }
 variable "db_name" {
   description = "Database name"


### PR DESCRIPTION
# Description
Tightening opta security. Based on tfsec recommendations.

# Safety checklist
* [ ] This change is backwards compatible and safe to apply by existing users
* [ ] This change will NOT lead to data loss
* [ ] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
Passing CIrcleci - ignore Azure since thats not related to these changes.
 
https://app.circleci.com/pipelines/github/run-x/opta/1722/workflows/da589318-0ec7-457e-94d4-5dc9631cba87