### PR TITLE
Update python version for Circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,8 +85,8 @@ commands:
       - run:
           name: "Installing python version 3.8"
           command: |
-            pyenv install 3.8.0
-            pyenv global 3.8.0
+            pyenv install 3.8.12
+            pyenv global 3.8.12
   install-python-dependencies:
     steps:
       - run:


### PR DESCRIPTION
# Description
Update the Python version for Circle CI from 3.8.0 to 3.8.12

# Safety checklist
* [x] This change is backwards compatible and safe to apply by existing users
* [x] This change will NOT lead to data loss
* [x] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
[Circle CI Link](https://app.circleci.com/pipelines/github/run-x/opta/1733/workflows/4961831c-dbe5-4f0f-9518-792b5bd14d95)
