### PR TITLE
Add RunX CI user before downloading Opta

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -284,6 +284,11 @@ jobs:
       OPTA_DISABLE_REPORTING: "true"
     steps:
       - run:
+          name: "Set git user"
+          command: |
+            git config --global user.email "runx-ci@runx.dev"
+            git config --global user.name "Runx CI"
+      - run:
           name: "Download Latest Opta Binary"
           command: /bin/bash -c "$(curl -fsSL https://docs.opta.dev/install.sh)"
       - install-opta-dependencies


### PR DESCRIPTION
# Description
Add git user to the opta ci for opta binary install.

# Safety checklist
* [ ] This change is backwards compatible and safe to apply by existing users
* [ ] This change will NOT lead to data loss
* [ ] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?

