### PR TITLE
Upgrade helm chart form GCP

### DIFF
--- a/modules/gcp_k8s_base/tf_module/cert_manager.tf
+++ b/modules/gcp_k8s_base/tf_module/cert_manager.tf
@@ -6,7 +6,7 @@ resource "helm_release" "cert_manager" {
   create_namespace = true
   atomic           = true
   cleanup_on_fail  = true
-  version          = "1.3.1"
+  version          = "1.7.1"
   values = [
     yamlencode({
       installCRDs : true

--- a/modules/gcp_k8s_base/tf_module/linkerd.tf
+++ b/modules/gcp_k8s_base/tf_module/linkerd.tf
@@ -59,7 +59,7 @@ resource "helm_release" "linkerd" {
   chart      = "linkerd2"
   name       = "linkerd"
   repository = "https://helm.linkerd.io/stable"
-  version    = "2.11.1"
+  version    = "2.10.2"
 
   values = var.linkerd_high_availability ? [
     file("${path.module}/values-ha.yaml"), # Adding the high-availability default values.

--- a/modules/gcp_k8s_base/tf_module/linkerd.tf
+++ b/modules/gcp_k8s_base/tf_module/linkerd.tf
@@ -59,7 +59,7 @@ resource "helm_release" "linkerd" {
   chart      = "linkerd2"
   name       = "linkerd"
   repository = "https://helm.linkerd.io/stable"
-  version    = "2.10.2"
+  version    = "2.11.1"
 
   values = var.linkerd_high_availability ? [
     file("${path.module}/values-ha.yaml"), # Adding the high-availability default values.


### PR DESCRIPTION
# Description
Upgrade the Helm Chart versions.

Following are the upgrades:

```bash
| ------------ | -------------- | ---------------- |
| Helm Chart   | Older Version  | Updated Version  |
| ------------ | -------------- | ---------------- |
| Cert Manager | 1.3.1          | 1.7.1            |
| ------------ | -------------- | ---------------- |
```

# Safety checklist
* [x] This change is backwards compatible and safe to apply by existing users
* [x] This change will NOT lead to data loss
* [x] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
Tested manually.

## Follow Up:
[Discussion around LInkerd Upgrade](https://github.com/linkerd/linkerd2/discussions/8051)
[Linkerd Issue](https://github.com/linkerd/linkerd2/issues/6495)
[Slack Thread](https://linkerd.slack.com/archives/C89RTCWJF/p1647020660446349)