### PR TITLE
docs: put cloud modules first

### DIFF
--- a/config/registry/aws/deploy_to_aws_button.md
+++ b/config/registry/aws/deploy_to_aws_button.md
@@ -2,7 +2,7 @@
 title: "Deploy to AWS Button"
 linkTitle: "Deploy to AWS Button"
 date: 2021-07-21
-weight: 1
+weight: 2
 description: >
   Allow your users to fill out their AWS Opta templates with the click of a button.
 ---

--- a/config/registry/aws/eks_upgrade.md
+++ b/config/registry/aws/eks_upgrade.md
@@ -3,7 +3,7 @@ title: "EKS Upgrade"
 linkTitle: "EKS Upgrade"
 date: 2022-01-03
 draft: false
-weight: 1
+weight: 2
 description: >
   How to upgrade the version of your EKS cluster created by opta.
 ---

--- a/config/registry/aws/vpc_peering.md
+++ b/config/registry/aws/vpc_peering.md
@@ -3,7 +3,7 @@ title: "VPC Peering"
 linkTitle: "VPC Peering"
 date: 2021-07-21
 draft: false
-weight: 1
+weight: 2
 description: Guide on how to peer AWS VPCs
 ---
 

--- a/config/registry/google/gke_upgrade.md
+++ b/config/registry/google/gke_upgrade.md
@@ -3,7 +3,7 @@ title: "GKE Upgrade"
 linkTitle: "GKE Upgrade"
 date: 2022-01-03
 draft: false
-weight: 1
+weight: 2
 description: >
   How to upgrade the version of your GKE cluster created by opta.
 ---


### PR DESCRIPTION
# Description
Current
<img width="218" alt="Screen Shot 2022-03-10 at 12 01 16 PM" src="https://user-images.githubusercontent.com/9467584/157745147-c4ee118e-8277-4d25-9c67-ca4f27efa6d9.png">

with this PR:
<img width="262" alt="Screen Shot 2022-03-10 at 11 57 43 AM" src="https://user-images.githubusercontent.com/9467584/157745048-12f20cbb-9336-496b-b703-55b8c7891fea.png">


# Safety checklist
* [X] This change is backwards compatible and safe to apply by existing users
* [X] This change will NOT lead to data loss
* [X] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
locally with docker-compose