### PR TITLE
Prevent duplicate module names within a layer.

### DIFF
--- a/opta/layer.py
+++ b/opta/layer.py
@@ -164,6 +164,7 @@ class Layer:
                     f"The module name {module.name} is used multiple time in the "
                     "layer. Module names must be unique per layer"
                 )
+            module_names.add(module.name)
         self.stateless_mode = stateless_mode
 
     def get_cluster_name(self) -> str:


### PR DESCRIPTION
# Description
The for loop in the code would not trigger even if there were duplicate module names inside the layer.

# Safety checklist
* [ ] This change is backwards compatible and safe to apply by existing users
* [ ] This change will NOT lead to data loss
* [ ] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
Manual test - two modules of same name in the layer.
