### PR TITLE
Fix warnings caused by invalid Python string escape sequences

### DIFF
--- a/opta/utils/__init__.py
+++ b/opta/utils/__init__.py
@@ -25,11 +25,11 @@ class SensitiveFormatter(Formatter):
     regex_and_replacements: List[Tuple[str, str]] = [
         (
             r"([\"\: \'\n])[0-9]{12}([\"\: \'\n])",
-            "\g<1>REDACTED\g<2>",  # noqa: W605
+            r"\g<1>REDACTED\g<2>",
         ),  # An AWS Account ID is always exactly 12 digits
         (
             r"([\"\: \'\n]?)project([\"\: \'\n]?): ([\"\: \'\n]?)[a-zA-Z0-9_\-]+([\"\: \'\n]?)",
-            "\g<1>project\g<2>: \g<3>REDACTED\g<4>",  # noqa: W605
+            r"\g<1>project\g<2>: \g<3>REDACTED\g<4>",
         ),
         (r"projects/[a-zA-Z0-9_\-]+/", "projects/REDACTED/"),
         (


### PR DESCRIPTION
# Description
Those escape sequences are regex escapes, not native Python string escapes. Currently, they print DeprecationWarnings but in the future, they will be syntax errors.

# Safety checklist
* [X] This change is backwards compatible and safe to apply by existing users
* [X] This change will NOT lead to data loss
* [X] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
None, relying on tests, which should be safe for these changes.
