### PR TITLE
TFsec - Remove egress from database, documentdb and elasticcache SGs

### DIFF
--- a/modules/aws_base/tf_module/log_bucket.tf
+++ b/modules/aws_base/tf_module/log_bucket.tf
@@ -13,6 +13,16 @@ resource "aws_s3_bucket" "log_bucket" {
   }
 }
 
+resource "aws_s3_bucket_public_access_block" "log_bucket" {
+  bucket = aws_s3_bucket.log_bucket.id
+
+  block_public_acls   = true
+  block_public_policy = true
+  restrict_public_buckets = true
+  ignore_public_acls = true
+
+}
+
 resource "aws_s3_bucket_acl" "log_bucket" {
   bucket = aws_s3_bucket.log_bucket.id
   acl    = "log-delivery-write"
@@ -25,6 +35,10 @@ resource "aws_s3_bucket_versioning" "log_bucket" {
   }
 }
 
+# Opta makes a design choice and uses public cloud provider managed encryption keys
+# They are very well administered by the cloud providers, and save the user from
+# a lot of key management overhead.
+#tfsec:ignore:aws-s3-encryption-customer-key
 resource "aws_s3_bucket_server_side_encryption_configuration" "log_bucket" {
   bucket = aws_s3_bucket.log_bucket.id
   rule {

--- a/modules/aws_base/tf_module/log_bucket.tf
+++ b/modules/aws_base/tf_module/log_bucket.tf
@@ -16,10 +16,10 @@ resource "aws_s3_bucket" "log_bucket" {
 resource "aws_s3_bucket_public_access_block" "log_bucket" {
   bucket = aws_s3_bucket.log_bucket.id
 
-  block_public_acls   = true
-  block_public_policy = true
+  block_public_acls       = true
+  block_public_policy     = true
   restrict_public_buckets = true
-  ignore_public_acls = true
+  ignore_public_acls      = true
 
 }
 

--- a/modules/aws_base/tf_module/security_groups.tf
+++ b/modules/aws_base/tf_module/security_groups.tf
@@ -25,7 +25,7 @@ resource "aws_security_group" "elasticache" {
   description = "For usage by elasticache to give access to resources in the vpc"
   vpc_id      = local.vpc_id
 
-# https://docs.aws.amazon.com/AmazonElastiCache/latest/mem-ug/elasticache-vpc-accessing.html
+  # https://docs.aws.amazon.com/AmazonElastiCache/latest/mem-ug/elasticache-vpc-accessing.html
   ingress {
     description = "redis"
     from_port   = 6379

--- a/modules/aws_base/tf_module/security_groups.tf
+++ b/modules/aws_base/tf_module/security_groups.tf
@@ -18,13 +18,6 @@ resource "aws_security_group" "db" {
     protocol    = "tcp"
     cidr_blocks = local.vpc_cidr_blocks
   }
-
-  egress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
 }
 
 resource "aws_security_group" "elasticache" {
@@ -32,6 +25,7 @@ resource "aws_security_group" "elasticache" {
   description = "For usage by elasticache to give access to resources in the vpc"
   vpc_id      = local.vpc_id
 
+# https://docs.aws.amazon.com/AmazonElastiCache/latest/mem-ug/elasticache-vpc-accessing.html
   ingress {
     description = "redis"
     from_port   = 6379
@@ -40,12 +34,6 @@ resource "aws_security_group" "elasticache" {
     cidr_blocks = local.vpc_cidr_blocks
   }
 
-  egress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
 }
 
 resource "aws_security_group" "documentdb" {
@@ -53,18 +41,12 @@ resource "aws_security_group" "documentdb" {
   description = "For usage by documentdb to give access to resources in the vpc"
   vpc_id      = local.vpc_id
 
+  # https://docs.aws.amazon.com/documentdb/latest/developerguide/db-cluster-create.html
   ingress {
     description = "documentdb"
     from_port   = 27017
     to_port     = 27017
     protocol    = "tcp"
     cidr_blocks = local.vpc_cidr_blocks
-  }
-
-  egress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
   }
 }

--- a/modules/aws_base/tf_module/vpc.tf
+++ b/modules/aws_base/tf_module/vpc.tf
@@ -60,7 +60,8 @@ resource "aws_iam_role_policy" "vpc_flow_log" {
   count = local.create_vpc ? 1 : 0
   name  = "opta-${var.env_name}-vpc-flow"
   role  = aws_iam_role.vpc_flow_log[0].id
-
+#Ignore 
+#tfsec:ignore:aws-iam-no-policy-wildcards
   policy = <<EOF
 {
   "Version": "2012-10-17",

--- a/modules/aws_base/tf_module/vpc.tf
+++ b/modules/aws_base/tf_module/vpc.tf
@@ -60,8 +60,8 @@ resource "aws_iam_role_policy" "vpc_flow_log" {
   count = local.create_vpc ? 1 : 0
   name  = "opta-${var.env_name}-vpc-flow"
   role  = aws_iam_role.vpc_flow_log[0].id
-#Ignore 
-#tfsec:ignore:aws-iam-no-policy-wildcards
+  #Ignore 
+  #tfsec:ignore:aws-iam-no-policy-wildcards
   policy = <<EOF
 {
   "Version": "2012-10-17",

--- a/modules/aws_k8s_base/tf_module/autoscaler.tf
+++ b/modules/aws_k8s_base/tf_module/autoscaler.tf
@@ -1,4 +1,6 @@
 data "aws_iam_policy_document" "autoscaler" {
+#Ignore 
+#tfsec:ignore:aws-iam-no-policy-wildcards
   statement {
     actions = [
       "autoscaling:DescribeAutoScalingGroups",

--- a/modules/aws_k8s_base/tf_module/autoscaler.tf
+++ b/modules/aws_k8s_base/tf_module/autoscaler.tf
@@ -1,6 +1,6 @@
 data "aws_iam_policy_document" "autoscaler" {
-#Ignore 
-#tfsec:ignore:aws-iam-no-policy-wildcards
+  #Ignore 
+  #tfsec:ignore:aws-iam-no-policy-wildcards
   statement {
     actions = [
       "autoscaling:DescribeAutoScalingGroups",

--- a/modules/aws_k8s_base/tf_module/load_balancer_controller.tf
+++ b/modules/aws_k8s_base/tf_module/load_balancer_controller.tf
@@ -16,6 +16,8 @@ data "aws_iam_policy_document" "load_balancer" {
   statement {
     sid       = "1"
     effect    = "Allow"
+#Ignore 
+#tfsec:ignore:aws-iam-no-policy-wildcards
     resources = ["*"]
 
     actions = [
@@ -112,6 +114,8 @@ data "aws_iam_policy_document" "load_balancer" {
     }
   }
 
+#Ignore 
+#tfsec:ignore:aws-iam-no-policy-wildcards
   statement {
     sid    = "6"
     effect = "Allow"
@@ -186,7 +190,8 @@ data "aws_iam_policy_document" "load_balancer" {
       "elasticloadbalancing:DeleteRule",
     ]
   }
-
+#Ignore 
+#tfsec:ignore:aws-iam-no-policy-wildcards
   statement {
     sid    = "10"
     effect = "Allow"

--- a/modules/aws_k8s_base/tf_module/load_balancer_controller.tf
+++ b/modules/aws_k8s_base/tf_module/load_balancer_controller.tf
@@ -14,10 +14,10 @@ data "aws_iam_policy_document" "load_balancer" {
   }
   #tfsec:ignore:aws-iam-no-policy-wildcards
   statement {
-    sid       = "1"
-    effect    = "Allow"
-#Ignore 
-#tfsec:ignore:aws-iam-no-policy-wildcards
+    sid    = "1"
+    effect = "Allow"
+    #Ignore 
+    #tfsec:ignore:aws-iam-no-policy-wildcards
     resources = ["*"]
 
     actions = [
@@ -114,8 +114,8 @@ data "aws_iam_policy_document" "load_balancer" {
     }
   }
 
-#Ignore 
-#tfsec:ignore:aws-iam-no-policy-wildcards
+  #Ignore 
+  #tfsec:ignore:aws-iam-no-policy-wildcards
   statement {
     sid    = "6"
     effect = "Allow"
@@ -180,7 +180,6 @@ data "aws_iam_policy_document" "load_balancer" {
   statement {
     sid    = "9"
     effect = "Allow"
-
     resources = ["*"]
 
     actions = [
@@ -190,8 +189,8 @@ data "aws_iam_policy_document" "load_balancer" {
       "elasticloadbalancing:DeleteRule",
     ]
   }
-#Ignore 
-#tfsec:ignore:aws-iam-no-policy-wildcards
+  #Ignore 
+  #tfsec:ignore:aws-iam-no-policy-wildcards
   statement {
     sid    = "10"
     effect = "Allow"

--- a/modules/aws_k8s_base/tf_module/load_balancer_controller.tf
+++ b/modules/aws_k8s_base/tf_module/load_balancer_controller.tf
@@ -178,8 +178,8 @@ data "aws_iam_policy_document" "load_balancer" {
   }
   #tfsec:ignore:aws-iam-no-policy-wildcards
   statement {
-    sid    = "9"
-    effect = "Allow"
+    sid       = "9"
+    effect    = "Allow"
     resources = ["*"]
 
     actions = [

--- a/modules/aws_k8s_base/tf_module/variables.tf
+++ b/modules/aws_k8s_base/tf_module/variables.tf
@@ -82,8 +82,11 @@ variable "admin_arns" {
   default = []
 }
 
+
 variable "private_key" {
   type    = string
+  # Ignore since this default value is never used, its for a logical if condition checking if user specified no private_key only.
+  #tfsec:ignore:general-secrets-no-plaintext-exposure
   default = ""
 }
 

--- a/modules/aws_k8s_base/tf_module/variables.tf
+++ b/modules/aws_k8s_base/tf_module/variables.tf
@@ -84,7 +84,7 @@ variable "admin_arns" {
 
 
 variable "private_key" {
-  type    = string
+  type = string
   # Ignore since this default value is never used, its for a logical if condition checking if user specified no private_key only.
   #tfsec:ignore:general-secrets-no-plaintext-exposure
   default = ""


### PR DESCRIPTION
# Description

Databases don't need egress rules to 0.0.0.0/0 to all ports. Only ingress needed.

# Safety checklist
* [ ] This change is backwards compatible and safe to apply by existing users
* [ ] This change will NOT lead to data loss
* [ ] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
CircleCI tbd.
CircleCI (look at only the AWS cloud passing tests - https://app.circleci.com/pipelines/github/run-x/opta/2168/workflows/3a5e7976-8f35-4d82-8a53-f77aeb9ca111)