### PR TITLE
Use current latest version of External DNS helm chart

### DIFF
--- a/modules/aws_k8s_base/tf_module/external_dns.tf
+++ b/modules/aws_k8s_base/tf_module/external_dns.tf
@@ -53,7 +53,7 @@ resource "helm_release" "external-dns" {
   create_namespace = true
   atomic           = true
   cleanup_on_fail  = true
-  version          = "3.7.0"
+  version          = "6.1.8"
   values = [
     yamlencode({
       provider : "aws"

--- a/modules/aws_k8s_base/tf_module/external_dns.tf
+++ b/modules/aws_k8s_base/tf_module/external_dns.tf
@@ -53,7 +53,7 @@ resource "helm_release" "external-dns" {
   create_namespace = true
   atomic           = true
   cleanup_on_fail  = true
-  version          = "6.1.8"
+  version          = "6.2.1"
   values = [
     yamlencode({
       provider : "aws"


### PR DESCRIPTION
# Description
Upgrade the External DNS Helm chart version used for AWS.

# Safety checklist
* [x] This change is backwards compatible and safe to apply by existing users
* [x] This change will NOT lead to data loss
* [x] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
Tested Manually by upgrading from `3.7.0` to `6.2.1` and didn't see any downtime on the `Hello Opta` k8s-service. 
