### PR TITLE
Add user variable for adding custom name for Databases

### DIFF
--- a/modules/aws_documentdb/aws-documentdb.json
+++ b/modules/aws_documentdb/aws-documentdb.json
@@ -24,6 +24,11 @@
       "description": "A value that indicates whether the DB cluster has deletion protection enabled. The database can't be deleted when deletion protection is enabled. By default, deletion protection is disabled.",
       "default": false
     },
+    "identifier": {
+      "type": "string",
+      "description": "Name for the documentdb cluster.  If not specified, it will be look like opta-<layer_name>-<module_name>-<random_string>",
+      "default": "None"
+    },
     "type": {
       "description": "The name of this module",
       "enum": [

--- a/modules/aws_documentdb/aws-documentdb.json
+++ b/modules/aws_documentdb/aws-documentdb.json
@@ -26,8 +26,7 @@
     },
     "identifier": {
       "type": "string",
-      "description": "Name for the documentdb cluster.  If not specified, it will default to opta-<layer_name>-<module_name>-<random_string>",
-      "default": "None"
+      "description": "Name for the documentdb cluster.  If not specified, it will default to opta-<layer_name>-<module_name>-<random_string>"
     },
     "type": {
       "description": "The name of this module",

--- a/modules/aws_documentdb/aws-documentdb.json
+++ b/modules/aws_documentdb/aws-documentdb.json
@@ -26,7 +26,7 @@
     },
     "identifier": {
       "type": "string",
-      "description": "Name for the documentdb cluster.  If not specified, it will be look like opta-<layer_name>-<module_name>-<random_string>",
+      "description": "Name for the documentdb cluster.  If not specified, it will default to opta-<layer_name>-<module_name>-<random_string>",
       "default": "None"
     },
     "type": {

--- a/modules/aws_documentdb/aws-documentdb.yaml
+++ b/modules/aws_documentdb/aws-documentdb.yaml
@@ -37,7 +37,7 @@ inputs:
   - name: identifier
     user_facing: true
     validator: str(required=False)
-    description: Name for the documentdb cluster.  If not specified, it will be look like opta-<layer_name>-<module_name>-<random_string>
+    description: Name for the documentdb cluster.  If not specified, it will default to opta-<layer_name>-<module_name>-<random_string>
     default: None
 outputs:
   - name: db_host

--- a/modules/aws_documentdb/aws-documentdb.yaml
+++ b/modules/aws_documentdb/aws-documentdb.yaml
@@ -38,7 +38,7 @@ inputs:
     user_facing: true
     validator: str(required=False)
     description: Name for the documentdb cluster.  If not specified, it will default to opta-<layer_name>-<module_name>-<random_string>
-    default: None
+    default: null
 outputs:
   - name: db_host
     export: true

--- a/modules/aws_documentdb/aws-documentdb.yaml
+++ b/modules/aws_documentdb/aws-documentdb.yaml
@@ -34,6 +34,11 @@ inputs:
     validator: bool(required=False)
     description: A value that indicates whether the DB cluster has deletion protection enabled. The database can't be deleted when deletion protection is enabled. By default, deletion protection is disabled.
     default: false
+  - name: identifier
+    user_facing: true
+    validator: str(required=False)
+    description: Name for the documentdb cluster.  If not specified, it will be look like opta-<layer_name>-<module_name>-<random_string>
+    default: None
 outputs:
   - name: db_host
     export: true

--- a/modules/aws_documentdb/tf_module/main.tf
+++ b/modules/aws_documentdb/tf_module/main.tf
@@ -17,9 +17,13 @@ resource "random_string" "db_name_hash" {
   upper   = false
 }
 
+locals {
+  identifier = var.identifier == null ? "opta-${var.layer_name}-${var.module_name}-${random_string.db_name_hash.result}" : var.identifier
+}
+
 resource "aws_docdb_cluster_instance" "cluster_instances" {
   count                      = var.instance_count
-  identifier                 = "opta-${var.layer_name}-${var.module_name}-${random_string.db_name_hash.result}-${count.index}"
+  identifier                 = "${local.identifier}-${count.index}"
   cluster_identifier         = aws_docdb_cluster.cluster.id
   instance_class             = var.instance_class
   apply_immediately          = true
@@ -30,7 +34,7 @@ resource "aws_docdb_cluster_instance" "cluster_instances" {
 }
 
 resource "aws_docdb_cluster" "cluster" {
-  cluster_identifier      = "opta-${var.layer_name}-${var.module_name}-${random_string.db_name_hash.result}"
+  cluster_identifier      = local.identifier
   master_username         = "master_user"
   master_password         = random_password.documentdb_auth.result
   db_subnet_group_name    = "opta-${var.env_name}-docdb"

--- a/modules/aws_documentdb/tf_module/variables.tf
+++ b/modules/aws_documentdb/tf_module/variables.tf
@@ -35,6 +35,6 @@ variable "deletion_protection" {
 }
 
 variable "identifier" {
-  type        = string
-  default     = null
+  type    = string
+  default = null
 }

--- a/modules/aws_documentdb/tf_module/variables.tf
+++ b/modules/aws_documentdb/tf_module/variables.tf
@@ -33,3 +33,8 @@ variable "deletion_protection" {
   default     = false
   description = "A value that indicates whether the DB cluster has deletion protection enabled. The database can't be deleted when deletion protection is enabled."
 }
+
+variable "identifier" {
+  type        = string
+  default     = null
+}

--- a/modules/aws_dynamodb/aws-dynamodb.json
+++ b/modules/aws_dynamodb/aws-dynamodb.json
@@ -62,7 +62,7 @@
       "default": "None"
     },
     "identifier": {
-      "description": "Name for the dynamodb table. If not specified, it will be look like opta-<layer_name>-<module_name>-<random_string>",
+      "description": "Name for the dynamodb table. If not specified, it will default to opta-<layer_name>-<module_name>-<random_string>",
       "type": "string",
       "default": "None"
     },

--- a/modules/aws_dynamodb/aws-dynamodb.json
+++ b/modules/aws_dynamodb/aws-dynamodb.json
@@ -63,8 +63,7 @@
     },
     "identifier": {
       "description": "Name for the dynamodb table. If not specified, it will default to opta-<layer_name>-<module_name>-<random_string>",
-      "type": "string",
-      "default": "None"
+      "type": "string"
     },
     "type": {
       "description": "The name of this module",

--- a/modules/aws_dynamodb/aws-dynamodb.json
+++ b/modules/aws_dynamodb/aws-dynamodb.json
@@ -61,6 +61,11 @@
       },
       "default": "None"
     },
+    "identifier": {
+      "description": "Name for the dynamodb table. If not specified, it will be look like opta-<layer_name>-<module_name>-<random_string>",
+      "type": "string",
+      "default": "None"
+    },
     "type": {
       "description": "The name of this module",
       "enum": [

--- a/modules/aws_dynamodb/aws-dynamodb.yaml
+++ b/modules/aws_dynamodb/aws-dynamodb.yaml
@@ -47,7 +47,7 @@ inputs:
   - name: identifier
     user_facing: true
     validator: str(required=False)
-    description: Name for the dynamodb table. If not specified, it will be look like opta-<layer_name>-<module_name>-<random_string>
+    description: Name for the dynamodb table. If not specified, it will default to opta-<layer_name>-<module_name>-<random_string>
     default: None
 extra_validators:
   attributes:

--- a/modules/aws_dynamodb/aws-dynamodb.yaml
+++ b/modules/aws_dynamodb/aws-dynamodb.yaml
@@ -48,7 +48,7 @@ inputs:
     user_facing: true
     validator: str(required=False)
     description: Name for the dynamodb table. If not specified, it will default to opta-<layer_name>-<module_name>-<random_string>
-    default: None
+    default: null
 extra_validators:
   attributes:
     name: str(required=True)

--- a/modules/aws_dynamodb/aws-dynamodb.yaml
+++ b/modules/aws_dynamodb/aws-dynamodb.yaml
@@ -44,6 +44,11 @@ inputs:
     validator: list(include('attributes'), required=True)
     description: The list of attributes (name and type) for this dynamodb table
     default: None
+  - name: identifier
+    user_facing: true
+    validator: str(required=False)
+    description: Name for the dynamodb table. If not specified, it will be look like opta-<layer_name>-<module_name>-<random_string>
+    default: None
 extra_validators:
   attributes:
     name: str(required=True)

--- a/modules/aws_dynamodb/tf_module/main.tf
+++ b/modules/aws_dynamodb/tf_module/main.tf
@@ -4,10 +4,14 @@ resource "random_string" "db_name_hash" {
   upper   = false
 }
 
+locals {
+  identifier = var.identifier == null ? "opta-${var.layer_name}-${var.module_name}-${random_string.db_name_hash.result}" : var.identifier
+}
+
 resource "aws_dynamodb_table" "table_no_range" {
   count          = var.range_key == null ? 1 : 0
   hash_key       = var.hash_key
-  name           = "opta-${var.layer_name}-${var.module_name}-${random_string.db_name_hash.result}"
+  name           = local.identifier
   read_capacity  = var.read_capacity
   write_capacity = var.write_capacity
   server_side_encryption {
@@ -30,7 +34,7 @@ resource "aws_dynamodb_table" "table_with_range" {
   count          = var.range_key == null ? 0 : 1
   hash_key       = var.hash_key
   range_key      = var.range_key
-  name           = "opta-${var.layer_name}-${var.module_name}-${random_string.db_name_hash.result}"
+  name           = local.identifier
   read_capacity  = var.read_capacity
   write_capacity = var.write_capacity
   server_side_encryption {

--- a/modules/aws_dynamodb/tf_module/main.tf
+++ b/modules/aws_dynamodb/tf_module/main.tf
@@ -54,4 +54,7 @@ resource "aws_dynamodb_table" "table_with_range" {
       type = attribute.value["type"]
     }
   }
+  lifecycle {
+    ignore_changes = [name]
+  }
 }

--- a/modules/aws_dynamodb/tf_module/main.tf
+++ b/modules/aws_dynamodb/tf_module/main.tf
@@ -28,6 +28,9 @@ resource "aws_dynamodb_table" "table_no_range" {
       type = attribute.value["type"]
     }
   }
+  lifecycle {
+    ignore_changes = [name]
+  }
 }
 
 resource "aws_dynamodb_table" "table_with_range" {

--- a/modules/aws_dynamodb/tf_module/variables.tf
+++ b/modules/aws_dynamodb/tf_module/variables.tf
@@ -44,3 +44,8 @@ variable "range_key" {
 variable "attributes" {
   type = list(map(string))
 }
+
+variable "identifier" {
+  type        = string
+  default     = null
+}

--- a/modules/aws_dynamodb/tf_module/variables.tf
+++ b/modules/aws_dynamodb/tf_module/variables.tf
@@ -46,6 +46,6 @@ variable "attributes" {
 }
 
 variable "identifier" {
-  type        = string
-  default     = null
+  type    = string
+  default = null
 }

--- a/modules/aws_mysql/aws-mysql.json
+++ b/modules/aws_mysql/aws-mysql.json
@@ -29,6 +29,11 @@
       "description": "Add deletion protection to stop accidental db deletions",
       "default": false
     },
+    "identifier": {
+      "type": "string",
+      "description": "Identifier for the RDS instance.",
+      "default": null
+    },
     "type": {
       "description": "The name of this module",
       "enum": [

--- a/modules/aws_mysql/aws-mysql.json
+++ b/modules/aws_mysql/aws-mysql.json
@@ -31,7 +31,7 @@
     },
     "identifier": {
       "type": "string",
-      "description": "Name for the RDS instance. If not specified, it will be look like opta-<layer_name>-<module_name>-<random_string>"
+      "description": "Name for the RDS instance. If not specified, it will default to opta-<layer_name>-<module_name>-<random_string>"
     },
     "type": {
       "description": "The name of this module",

--- a/modules/aws_mysql/aws-mysql.json
+++ b/modules/aws_mysql/aws-mysql.json
@@ -31,8 +31,7 @@
     },
     "identifier": {
       "type": "string",
-      "description": "Identifier for the RDS instance.",
-      "default": null
+      "description": "Identifier for the RDS instance."
     },
     "type": {
       "description": "The name of this module",

--- a/modules/aws_mysql/aws-mysql.json
+++ b/modules/aws_mysql/aws-mysql.json
@@ -31,7 +31,7 @@
     },
     "identifier": {
       "type": "string",
-      "description": "Identifier for the RDS instance."
+      "description": "Name for the RDS instance. If not specified, it will be look like opta-<layer_name>-<module_name>-<random_string>"
     },
     "type": {
       "description": "The name of this module",

--- a/modules/aws_mysql/aws-mysql.yaml
+++ b/modules/aws_mysql/aws-mysql.yaml
@@ -42,7 +42,7 @@ inputs:
   - name: identifier
     user_facing: true
     validator: str(required=False)
-    description: Name for the RDS instance. If not specified, it will be look like opta-<layer_name>-<module_name>-<random_string>
+    description: Name for the RDS instance. If not specified, it will default to opta-<layer_name>-<module_name>-<random_string>
     default: null
 outputs:
   - name: db_user

--- a/modules/aws_mysql/aws-mysql.yaml
+++ b/modules/aws_mysql/aws-mysql.yaml
@@ -39,6 +39,11 @@ inputs:
     validator: bool(required=False)
     description: Add deletion protection to stop accidental db deletions
     default: false
+  - name: identifier
+    user_facing: true
+    validator: str(required=False)
+    description: Identifier for the RDS instance.
+    default: null
 outputs:
   - name: db_user
     export: false

--- a/modules/aws_mysql/aws-mysql.yaml
+++ b/modules/aws_mysql/aws-mysql.yaml
@@ -42,7 +42,7 @@ inputs:
   - name: identifier
     user_facing: true
     validator: str(required=False)
-    description: Identifier for the RDS instance.
+    description: Name for the RDS instance. If not specified, it will be look like opta-<layer_name>-<module_name>-<random_string>
     default: null
 outputs:
   - name: db_user

--- a/modules/aws_mysql/tf_module/main.tf
+++ b/modules/aws_mysql/tf_module/main.tf
@@ -17,8 +17,12 @@ resource "random_string" "db_name_hash" {
   upper   = false
 }
 
+locals {
+  identifier = var.identifier == null ? "opta-${var.layer_name}-${var.module_name}-${random_string.db_name_hash.result}" : var.identifier
+}
+
 resource "aws_rds_cluster" "db_cluster" {
-  cluster_identifier      = "opta-${var.layer_name}-${var.module_name}-${random_string.db_name_hash.result}"
+  cluster_identifier      = local.identifier
   db_subnet_group_name    = "opta-${var.env_name}"
   database_name           = "app"
   engine                  = "aurora-mysql"
@@ -39,7 +43,7 @@ resource "aws_rds_cluster" "db_cluster" {
 
 resource "aws_rds_cluster_instance" "db_instance" {
   count                      = var.multi_az ? 2 : 1
-  identifier                 = "opta-${var.layer_name}-${var.module_name}-${random_string.db_name_hash.result}-${count.index}"
+  identifier                 = "${local.identifier}-${count.index}"
   cluster_identifier         = aws_rds_cluster.db_cluster.id
   instance_class             = var.instance_class
   engine                     = aws_rds_cluster.db_cluster.engine

--- a/modules/aws_mysql/tf_module/variables.tf
+++ b/modules/aws_mysql/tf_module/variables.tf
@@ -37,3 +37,8 @@ variable "multi_az" {
   type    = bool
   default = false
 }
+
+variable "identifier" {
+  type    = string
+  default = null
+}

--- a/modules/aws_postgres/aws-postgres.json
+++ b/modules/aws_postgres/aws-postgres.json
@@ -29,6 +29,11 @@
       "description": "Add deletion protection to stop accidental db deletions",
       "default": false
     },
+    "identifier": {
+      "type": "string",
+      "description": "Identifier for the RDS instance.",
+      "default": null
+    },
     "type": {
       "description": "The name of this module",
       "enum": [

--- a/modules/aws_postgres/aws-postgres.json
+++ b/modules/aws_postgres/aws-postgres.json
@@ -31,7 +31,7 @@
     },
     "identifier": {
       "type": "string",
-      "description": "Name for the RDS instance. If not specified, it will be look like opta-<layer_name>-<module_name>-<random_string>"
+      "description": "Name for the RDS instance. If not specified, it will default to opta-<layer_name>-<module_name>-<random_string>"
     },
     "type": {
       "description": "The name of this module",

--- a/modules/aws_postgres/aws-postgres.json
+++ b/modules/aws_postgres/aws-postgres.json
@@ -31,8 +31,7 @@
     },
     "identifier": {
       "type": "string",
-      "description": "Identifier for the RDS instance.",
-      "default": null
+      "description": "Identifier for the RDS instance."
     },
     "type": {
       "description": "The name of this module",

--- a/modules/aws_postgres/aws-postgres.json
+++ b/modules/aws_postgres/aws-postgres.json
@@ -31,7 +31,7 @@
     },
     "identifier": {
       "type": "string",
-      "description": "Identifier for the RDS instance."
+      "description": "Name for the RDS instance. If not specified, it will be look like opta-<layer_name>-<module_name>-<random_string>"
     },
     "type": {
       "description": "The name of this module",

--- a/modules/aws_postgres/aws-postgres.yaml
+++ b/modules/aws_postgres/aws-postgres.yaml
@@ -42,7 +42,7 @@ inputs:
   - name: identifier
     user_facing: true
     validator: str(required=False)
-    description: Name for the RDS instance. If not specified, it will be look like opta-<layer_name>-<module_name>-<random_string>
+    description: Name for the RDS instance. If not specified, it will default to opta-<layer_name>-<module_name>-<random_string>
     default: null
 outputs:
   - name: db_user

--- a/modules/aws_postgres/aws-postgres.yaml
+++ b/modules/aws_postgres/aws-postgres.yaml
@@ -42,7 +42,7 @@ inputs:
   - name: identifier
     user_facing: true
     validator: str(required=False)
-    description: Identifier for the RDS instance.
+    description: Name for the RDS instance. If not specified, it will be look like opta-<layer_name>-<module_name>-<random_string>
     default: null
 outputs:
   - name: db_user

--- a/modules/aws_postgres/aws-postgres.yaml
+++ b/modules/aws_postgres/aws-postgres.yaml
@@ -39,6 +39,11 @@ inputs:
     validator: int(required=False)
     description: How many days to keep the backup retention
     default: 7
+  - name: identifier
+    user_facing: true
+    validator: str(required=False)
+    description: Identifier for the RDS instance.
+    default: null
 outputs:
   - name: db_user
     export: false

--- a/modules/aws_postgres/tf_module/main.tf
+++ b/modules/aws_postgres/tf_module/main.tf
@@ -17,8 +17,12 @@ resource "random_string" "db_name_hash" {
   upper   = false
 }
 
+locals {
+  identifier = var.identifier == null ? "opta-${var.layer_name}-${var.module_name}-${random_string.db_name_hash.result}" : var.identifier
+}
+
 resource "aws_rds_cluster" "db_cluster" {
-  cluster_identifier      = "opta-${var.layer_name}-${var.module_name}-${random_string.db_name_hash.result}"
+  cluster_identifier      = local.identifier
   db_subnet_group_name    = "opta-${var.env_name}"
   database_name           = "app"
   engine                  = "aurora-postgresql"
@@ -39,7 +43,7 @@ resource "aws_rds_cluster" "db_cluster" {
 
 resource "aws_rds_cluster_instance" "db_instance" {
   count                           = var.multi_az ? 2 : 1
-  identifier                      = "opta-${var.layer_name}-${var.module_name}-${random_string.db_name_hash.result}-${count.index}"
+  identifier                      = "${local.identifier}-${count.index}"
   cluster_identifier              = aws_rds_cluster.db_cluster.id
   instance_class                  = var.instance_class
   engine                          = aws_rds_cluster.db_cluster.engine

--- a/modules/aws_postgres/tf_module/variables.tf
+++ b/modules/aws_postgres/tf_module/variables.tf
@@ -39,3 +39,8 @@ variable "multi_az" {
   type    = bool
   default = false
 }
+
+variable "identifier" {
+  type    = string
+  default = null
+}

--- a/modules/aws_redis/aws-redis.json
+++ b/modules/aws_redis/aws-redis.json
@@ -86,6 +86,11 @@
       "description": "Window during which the snapshot would be taken.",
       "default": "04:00-05:00"
     },
+    "identifier": {
+      "type": "string",
+      "description": "The identifier for the Redis instance.",
+      "default": null
+    },
     "type": {
       "description": "The name of this module",
       "enum": [

--- a/modules/aws_redis/aws-redis.json
+++ b/modules/aws_redis/aws-redis.json
@@ -88,7 +88,7 @@
     },
     "identifier": {
       "type": "string",
-      "description": "Identifier for the Redis instance."
+      "description": "Name for the Redis instance. If not specified, it will be look like opta-<layer_name>-<module_name>-<random_string>"
     },
     "type": {
       "description": "The name of this module",

--- a/modules/aws_redis/aws-redis.json
+++ b/modules/aws_redis/aws-redis.json
@@ -88,8 +88,7 @@
     },
     "identifier": {
       "type": "string",
-      "description": "The identifier for the Redis instance.",
-      "default": null
+      "description": "Identifier for the Redis instance."
     },
     "type": {
       "description": "The name of this module",

--- a/modules/aws_redis/aws-redis.json
+++ b/modules/aws_redis/aws-redis.json
@@ -88,7 +88,7 @@
     },
     "identifier": {
       "type": "string",
-      "description": "Name for the Redis instance. If not specified, it will be look like opta-<layer_name>-<module_name>-<random_string>"
+      "description": "Name for the Redis instance. If not specified, it will default to opta-<layer_name>-<module_name>-<random_string>"
     },
     "type": {
       "description": "The name of this module",

--- a/modules/aws_redis/aws-redis.yaml
+++ b/modules/aws_redis/aws-redis.yaml
@@ -37,7 +37,7 @@ inputs:
   - name: identifier
     user_facing: true
     validator: str(required=False)
-    description: Name for the Redis instance. If not specified, it will be look like opta-<layer_name>-<module_name>-<random_string>
+    description: Name for the Redis instance. If not specified, it will default to opta-<layer_name>-<module_name>-<random_string>
     default: null
 outputs:
   - name: cache_host

--- a/modules/aws_redis/aws-redis.yaml
+++ b/modules/aws_redis/aws-redis.yaml
@@ -37,7 +37,7 @@ inputs:
   - name: identifier
     user_facing: true
     validator: str(required=False)
-    description: Identifier for the Redis instance.
+    description: Name for the Redis instance. If not specified, it will be look like opta-<layer_name>-<module_name>-<random_string>
     default: null
 outputs:
   - name: cache_host

--- a/modules/aws_redis/aws-redis.yaml
+++ b/modules/aws_redis/aws-redis.yaml
@@ -34,6 +34,11 @@ inputs:
     validator: str(required=False)
     description: Window during which the snapshot would be taken.
     default: "04:00-05:00"
+  - name: identifier
+    user_facing: true
+    validator: str(required=False)
+    description: Identifier for the Redis instance.
+    default: null
 outputs:
   - name: cache_host
     export: true

--- a/modules/aws_redis/tf_module/main.tf
+++ b/modules/aws_redis/tf_module/main.tf
@@ -17,12 +17,16 @@ data "aws_kms_key" "main" {
   key_id = "alias/opta-${var.env_name}"
 }
 
+locals {
+  identifier = var.identifier == null ? "opta-${var.layer_name}-${var.module_name}-${random_string.redis_name_hash.result}" : var.identifier
+}
+
 resource "aws_elasticache_replication_group" "redis_cluster" {
   automatic_failover_enabled    = true
   auto_minor_version_upgrade    = true
   security_group_ids            = [data.aws_security_group.security_group.id]
   subnet_group_name             = "opta-${var.env_name}"
-  replication_group_id          = "opta-${var.layer_name}-${var.module_name}-${random_string.redis_name_hash.result}"
+  replication_group_id          = local.identifier
   replication_group_description = "Elasticache opta-${var.layer_name}-${var.module_name}-${random_string.redis_name_hash.result}"
   node_type                     = var.node_type
   engine_version                = var.redis_version

--- a/modules/aws_redis/tf_module/variables.tf
+++ b/modules/aws_redis/tf_module/variables.tf
@@ -34,3 +34,8 @@ variable "snapshot_retention_limit" {
   type        = number
   default     = 0
 }
+
+variable "identifier" {
+  type    = string
+  default = null
+}

--- a/modules/azure_postgres/azure-postgres.json
+++ b/modules/azure_postgres/azure-postgres.json
@@ -15,8 +15,7 @@
     },
     "identifier": {
       "type": "string",
-      "description": "Identifier for the RDS instance.",
-      "default": null
+      "description": "Identifier for the RDS instance."
     },
     "type": {
       "description": "The name of this module",

--- a/modules/azure_postgres/azure-postgres.json
+++ b/modules/azure_postgres/azure-postgres.json
@@ -13,6 +13,11 @@
       "description": "The version of the database to use.",
       "default": "11"
     },
+    "identifier": {
+      "type": "string",
+      "description": "Identifier for the RDS instance.",
+      "default": null
+    },
     "type": {
       "description": "The name of this module",
       "enum": [

--- a/modules/azure_postgres/azure-postgres.json
+++ b/modules/azure_postgres/azure-postgres.json
@@ -15,7 +15,7 @@
     },
     "identifier": {
       "type": "string",
-      "description": "Name for the RDS instance. If not specified, it will be look like opta-<layer_name>-<module_name>-<random_string>"
+      "description": "Name for the RDS instance. If not specified, it will default to opta-<layer_name>-<module_name>-<random_string>"
     },
     "type": {
       "description": "The name of this module",

--- a/modules/azure_postgres/azure-postgres.json
+++ b/modules/azure_postgres/azure-postgres.json
@@ -15,7 +15,7 @@
     },
     "identifier": {
       "type": "string",
-      "description": "Identifier for the RDS instance."
+      "description": "Name for the RDS instance. If not specified, it will be look like opta-<layer_name>-<module_name>-<random_string>"
     },
     "type": {
       "description": "The name of this module",

--- a/modules/azure_postgres/azure-postgres.yaml
+++ b/modules/azure_postgres/azure-postgres.yaml
@@ -27,7 +27,7 @@ inputs:
   - name: identifier
     user_facing: true
     validator: str(required=False)
-    description: Name for the RDS instance. If not specified, it will be look like opta-<layer_name>-<module_name>-<random_string>
+    description: Name for the RDS instance. If not specified, it will default to opta-<layer_name>-<module_name>-<random_string>
     default: null
 outputs:
   - name: db_user

--- a/modules/azure_postgres/azure-postgres.yaml
+++ b/modules/azure_postgres/azure-postgres.yaml
@@ -27,7 +27,7 @@ inputs:
   - name: identifier
     user_facing: true
     validator: str(required=False)
-    description: Identifier for the RDS instance.
+    description: Name for the RDS instance. If not specified, it will be look like opta-<layer_name>-<module_name>-<random_string>
     default: null
 outputs:
   - name: db_user

--- a/modules/azure_postgres/azure-postgres.yaml
+++ b/modules/azure_postgres/azure-postgres.yaml
@@ -24,6 +24,11 @@ inputs:
     validator: str(required=False)
     description: The version of the database to use.
     default: "11"
+  - name: identifier
+    user_facing: true
+    validator: str(required=False)
+    description: Identifier for the RDS instance.
+    default: null
 outputs:
   - name: db_user
     export: false

--- a/modules/azure_postgres/tf_module/main.tf
+++ b/modules/azure_postgres/tf_module/main.tf
@@ -13,9 +13,13 @@ resource "random_password" "root_auth" {
   }
 }
 
+locals {
+  identifier = var.identifier == null ? "opta-${var.layer_name}-${var.module_name}-${random_id.key_suffix.hex}" : var.identifier
+}
+
 
 resource "azurerm_postgresql_server" "opta" {
-  name                = "opta-${var.layer_name}-${var.module_name}-${random_id.key_suffix.hex}"
+  name                = local.identifier
   location            = data.azurerm_resource_group.main.location
   resource_group_name = data.azurerm_resource_group.main.name
 

--- a/modules/azure_postgres/tf_module/main.tf
+++ b/modules/azure_postgres/tf_module/main.tf
@@ -42,7 +42,7 @@ resource "azurerm_postgresql_server" "opta" {
   }
 
   lifecycle {
-    ignore_changes = [storage_mb]
+    ignore_changes = [storage_mb, name]
   }
 }
 

--- a/modules/azure_postgres/tf_module/variables.tf
+++ b/modules/azure_postgres/tf_module/variables.tf
@@ -32,3 +32,8 @@ variable "sku_name" {
   type    = string
   default = "GP_Gen5_2"
 }
+
+variable "identifier" {
+  type    = string
+  default = null
+}

--- a/modules/azure_redis/azure-redis.json
+++ b/modules/azure_redis/azure-redis.json
@@ -28,6 +28,11 @@
       "minimum": 0,
       "default": 2
     },
+    "identifier": {
+      "type": "string",
+      "description": "Identifier for the Redis instance.",
+      "default": null
+    },
     "type": {
       "description": "The name of this module",
       "enum": [

--- a/modules/azure_redis/azure-redis.json
+++ b/modules/azure_redis/azure-redis.json
@@ -30,7 +30,7 @@
     },
     "identifier": {
       "type": "string",
-      "description": "Name for the Redis instance. If not specified, it will be look like opta-<layer_name>-<module_name>-<random_string>"
+      "description": "Name for the Redis instance. If not specified, it will default to opta-<layer_name>-<module_name>-<random_string>"
     },
     "type": {
       "description": "The name of this module",

--- a/modules/azure_redis/azure-redis.json
+++ b/modules/azure_redis/azure-redis.json
@@ -30,8 +30,7 @@
     },
     "identifier": {
       "type": "string",
-      "description": "Identifier for the Redis instance.",
-      "default": null
+      "description": "Identifier for the Redis instance."
     },
     "type": {
       "description": "The name of this module",

--- a/modules/azure_redis/azure-redis.json
+++ b/modules/azure_redis/azure-redis.json
@@ -30,7 +30,7 @@
     },
     "identifier": {
       "type": "string",
-      "description": "Identifier for the Redis instance."
+      "description": "Name for the Redis instance. If not specified, it will be look like opta-<layer_name>-<module_name>-<random_string>"
     },
     "type": {
       "description": "The name of this module",

--- a/modules/azure_redis/azure-redis.yaml
+++ b/modules/azure_redis/azure-redis.yaml
@@ -29,6 +29,11 @@ inputs:
     validator: int(required=False)
     description: The [size](https://azure.microsoft.com/en-us/pricing/details/cache/) (see the numbers following the C or P) of the Redis cache to deploy.
     default: 2
+  - name: identifier
+    user_facing: true
+    validator: str(required=False)
+    description: Identifier for the Redis instance.
+    default: null
 outputs:
   - name: cache_host
     export: true

--- a/modules/azure_redis/azure-redis.yaml
+++ b/modules/azure_redis/azure-redis.yaml
@@ -32,7 +32,7 @@ inputs:
   - name: identifier
     user_facing: true
     validator: str(required=False)
-    description: Identifier for the Redis instance.
+    description: Name for the Redis instance. If not specified, it will be look like opta-<layer_name>-<module_name>-<random_string>
     default: null
 outputs:
   - name: cache_host

--- a/modules/azure_redis/azure-redis.yaml
+++ b/modules/azure_redis/azure-redis.yaml
@@ -32,7 +32,7 @@ inputs:
   - name: identifier
     user_facing: true
     validator: str(required=False)
-    description: Name for the Redis instance. If not specified, it will be look like opta-<layer_name>-<module_name>-<random_string>
+    description: Name for the Redis instance. If not specified, it will default to opta-<layer_name>-<module_name>-<random_string>
     default: null
 outputs:
   - name: cache_host

--- a/modules/azure_redis/tf_module/main.tf
+++ b/modules/azure_redis/tf_module/main.tf
@@ -18,6 +18,9 @@ resource "azurerm_redis_cache" "opta" {
   minimum_tls_version           = "1.2"
 
   redis_configuration {}
+  lifecycle {
+    ignore_changes = [name]
+  }
 }
 
 resource "azurerm_private_endpoint" "opta" {

--- a/modules/azure_redis/tf_module/main.tf
+++ b/modules/azure_redis/tf_module/main.tf
@@ -2,8 +2,12 @@ resource "random_id" "key_suffix" {
   byte_length = 8
 }
 
+locals {
+  identifier = var.identifier == null ? "opta-${var.layer_name}-${var.module_name}-${random_id.key_suffix.hex}" : var.identifier
+}
+
 resource "azurerm_redis_cache" "opta" {
-  name                          = "opta-${var.layer_name}-${var.module_name}-${random_id.key_suffix.hex}"
+  name                          = local.identifier
   location                      = data.azurerm_resource_group.main.location
   resource_group_name           = data.azurerm_resource_group.main.name
   capacity                      = var.capacity

--- a/modules/azure_redis/tf_module/variables.tf
+++ b/modules/azure_redis/tf_module/variables.tf
@@ -37,3 +37,8 @@ variable "module_name" {
   description = "Module name"
   type        = string
 }
+
+variable "identifier" {
+  type    = string
+  default = null
+}

--- a/modules/gcp_mysql/gcp-mysql.json
+++ b/modules/gcp_mysql/gcp-mysql.json
@@ -20,7 +20,7 @@
     },
     "identifier": {
       "type": "string",
-      "description": "Identifier for the RDS instance."
+      "description": "Name for the RDS instance. If not specified, it will be look like opta-<layer_name>-<module_name>-<random_string>"
     },
     "type": {
       "description": "The name of this module",

--- a/modules/gcp_mysql/gcp-mysql.json
+++ b/modules/gcp_mysql/gcp-mysql.json
@@ -20,8 +20,7 @@
     },
     "identifier": {
       "type": "string",
-      "description": "Identifier for the RDS instance.",
-      "default": null
+      "description": "Identifier for the RDS instance."
     },
     "type": {
       "description": "The name of this module",

--- a/modules/gcp_mysql/gcp-mysql.json
+++ b/modules/gcp_mysql/gcp-mysql.json
@@ -20,7 +20,7 @@
     },
     "identifier": {
       "type": "string",
-      "description": "Name for the RDS instance. If not specified, it will be look like opta-<layer_name>-<module_name>-<random_string>"
+      "description": "Name for the RDS instance. If not specified, it will default to opta-<layer_name>-<module_name>-<random_string>"
     },
     "type": {
       "description": "The name of this module",

--- a/modules/gcp_mysql/gcp-mysql.json
+++ b/modules/gcp_mysql/gcp-mysql.json
@@ -18,6 +18,11 @@
       "description": "The version of the database to use.",
       "default": "5_7"
     },
+    "identifier": {
+      "type": "string",
+      "description": "Identifier for the RDS instance.",
+      "default": null
+    },
     "type": {
       "description": "The name of this module",
       "enum": [

--- a/modules/gcp_mysql/gcp-mysql.yaml
+++ b/modules/gcp_mysql/gcp-mysql.yaml
@@ -32,7 +32,7 @@ inputs:
   - name: identifier
     user_facing: true
     validator: str(required=False)
-    description: Name for the RDS instance. If not specified, it will be look like opta-<layer_name>-<module_name>-<random_string>
+    description: Name for the RDS instance. If not specified, it will default to opta-<layer_name>-<module_name>-<random_string>
     default: null
 outputs:
   - name: db_name

--- a/modules/gcp_mysql/gcp-mysql.yaml
+++ b/modules/gcp_mysql/gcp-mysql.yaml
@@ -29,6 +29,11 @@ inputs:
     validator: str(required=False)
     description: The version of the database to use.
     default: "5_7"
+  - name: identifier
+    user_facing: true
+    validator: str(required=False)
+    description: Identifier for the RDS instance.
+    default: null
 outputs:
   - name: db_name
     export: false

--- a/modules/gcp_mysql/gcp-mysql.yaml
+++ b/modules/gcp_mysql/gcp-mysql.yaml
@@ -32,7 +32,7 @@ inputs:
   - name: identifier
     user_facing: true
     validator: str(required=False)
-    description: Identifier for the RDS instance.
+    description: Name for the RDS instance. If not specified, it will be look like opta-<layer_name>-<module_name>-<random_string>
     default: null
 outputs:
   - name: db_name

--- a/modules/gcp_mysql/tf_module/main.tf
+++ b/modules/gcp_mysql/tf_module/main.tf
@@ -7,11 +7,15 @@ resource "random_password" "root_auth" {
   special = false
 }
 
+locals {
+  identifier = var.identifier == null ? "opta-${var.layer_name}-${var.module_name}-${random_id.key_suffix.hex}" : var.identifier
+}
+
 # TODO: currently we are not performing disk encryption as the feature is currently in beta. You may read more about it
 # here: https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/sql_database_instance#encryption_key_name
 # We currently do not wish to tangle with the google-beta provider so we are skipping this feature for now.
 resource "google_sql_database_instance" "instance" {
-  name                = "opta-${var.layer_name}-${var.module_name}-${random_id.key_suffix.hex}"
+  name                = local.identifier
   database_version    = "MYSQL_${var.engine_version}"
   deletion_protection = var.safety
 
@@ -42,7 +46,7 @@ resource "google_sql_database_instance" "instance" {
 
 resource "google_sql_database" "main" {
   instance = google_sql_database_instance.instance.name
-  name     = "opta-${var.layer_name}-${var.module_name}-${random_id.key_suffix.hex}"
+  name     = local.identifier
 }
 
 resource "google_sql_user" "root" {

--- a/modules/gcp_mysql/tf_module/main.tf
+++ b/modules/gcp_mysql/tf_module/main.tf
@@ -40,7 +40,7 @@ resource "google_sql_database_instance" "instance" {
   }
 
   lifecycle {
-    ignore_changes = [settings[0].disk_size]
+    ignore_changes = [settings[0].disk_size, name]
   }
 }
 

--- a/modules/gcp_mysql/tf_module/variables.tf
+++ b/modules/gcp_mysql/tf_module/variables.tf
@@ -31,3 +31,8 @@ variable "safety" {
   type    = bool
   default = false
 }
+
+variable "identifier" {
+  type    = string
+  default = null
+}

--- a/modules/gcp_postgres/gcp-postgres.json
+++ b/modules/gcp_postgres/gcp-postgres.json
@@ -20,7 +20,7 @@
     },
     "identifier": {
       "type": "string",
-      "description": "Identifier for the RDS instance."
+      "description": "Name for the RDS instance. If not specified, it will be look like opta-<layer_name>-<module_name>-<random_string>"
     },
     "type": {
       "description": "The name of this module",

--- a/modules/gcp_postgres/gcp-postgres.json
+++ b/modules/gcp_postgres/gcp-postgres.json
@@ -20,8 +20,7 @@
     },
     "identifier": {
       "type": "string",
-      "description": "Identifier for the RDS instance.",
-      "default": null
+      "description": "Identifier for the RDS instance."
     },
     "type": {
       "description": "The name of this module",

--- a/modules/gcp_postgres/gcp-postgres.json
+++ b/modules/gcp_postgres/gcp-postgres.json
@@ -20,7 +20,7 @@
     },
     "identifier": {
       "type": "string",
-      "description": "Name for the RDS instance. If not specified, it will be look like opta-<layer_name>-<module_name>-<random_string>"
+      "description": "Name for the RDS instance. If not specified, it will default to opta-<layer_name>-<module_name>-<random_string>"
     },
     "type": {
       "description": "The name of this module",

--- a/modules/gcp_postgres/gcp-postgres.json
+++ b/modules/gcp_postgres/gcp-postgres.json
@@ -18,6 +18,11 @@
       "description": "The version of the database to use.",
       "default": "11"
     },
+    "identifier": {
+      "type": "string",
+      "description": "Identifier for the RDS instance.",
+      "default": null
+    },
     "type": {
       "description": "The name of this module",
       "enum": [

--- a/modules/gcp_postgres/gcp-postgres.yaml
+++ b/modules/gcp_postgres/gcp-postgres.yaml
@@ -32,7 +32,7 @@ inputs:
   - name: identifier
     user_facing: true
     validator: str(required=False)
-    description: Name for the RDS instance. If not specified, it will be look like opta-<layer_name>-<module_name>-<random_string>
+    description: Name for the RDS instance. If not specified, it will default to opta-<layer_name>-<module_name>-<random_string>
     default: null
 outputs:
   - name: db_name

--- a/modules/gcp_postgres/gcp-postgres.yaml
+++ b/modules/gcp_postgres/gcp-postgres.yaml
@@ -29,6 +29,11 @@ inputs:
     validator: str(required=False)
     description: The version of the database to use.
     default: "11"
+  - name: identifier
+    user_facing: true
+    validator: str(required=False)
+    description: Identifier for the RDS instance.
+    default: null
 outputs:
   - name: db_name
     export: false

--- a/modules/gcp_postgres/gcp-postgres.yaml
+++ b/modules/gcp_postgres/gcp-postgres.yaml
@@ -32,7 +32,7 @@ inputs:
   - name: identifier
     user_facing: true
     validator: str(required=False)
-    description: Identifier for the RDS instance.
+    description: Name for the RDS instance. If not specified, it will be look like opta-<layer_name>-<module_name>-<random_string>
     default: null
 outputs:
   - name: db_name

--- a/modules/gcp_postgres/tf_module/main.tf
+++ b/modules/gcp_postgres/tf_module/main.tf
@@ -59,7 +59,7 @@ resource "google_sql_database_instance" "instance" {
   }
 
   lifecycle {
-    ignore_changes = [settings[0].disk_size]
+    ignore_changes = [settings[0].disk_size, name]
   }
 }
 

--- a/modules/gcp_postgres/tf_module/main.tf
+++ b/modules/gcp_postgres/tf_module/main.tf
@@ -7,11 +7,15 @@ resource "random_password" "root_auth" {
   special = false
 }
 
+locals {
+  identifier = var.identifier == null ? "opta-${var.layer_name}-${var.module_name}-${random_id.key_suffix.hex}" : var.identifier
+}
+
 # TODO: currently we are not performing disk encryption as the feature is currently in beta. You may read more about it
 # here: https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/sql_database_instance#encryption_key_name
 # We currently do not wish to tangle with the google-beta provider so we are skipping this feature for now.
 resource "google_sql_database_instance" "instance" {
-  name                = "opta-${var.layer_name}-${var.module_name}-${random_id.key_suffix.hex}"
+  name                = local.identifier
   database_version    = "POSTGRES_${var.engine_version}"
   deletion_protection = var.safety
 
@@ -61,7 +65,7 @@ resource "google_sql_database_instance" "instance" {
 
 resource "google_sql_database" "main" {
   instance = google_sql_database_instance.instance.name
-  name     = "opta-${var.layer_name}-${var.module_name}-${random_id.key_suffix.hex}"
+  name     = local.identifier
 }
 
 resource "time_sleep" "wait_30_seconds" {

--- a/modules/gcp_postgres/tf_module/variables.tf
+++ b/modules/gcp_postgres/tf_module/variables.tf
@@ -31,3 +31,8 @@ variable "safety" {
   type    = bool
   default = false
 }
+
+variable "identifier" {
+  type    = string
+  default = null
+}

--- a/modules/gcp_redis/gcp-redis.json
+++ b/modules/gcp_redis/gcp-redis.json
@@ -18,6 +18,11 @@
       "description": "the redis version to use for this instance",
       "default": true
     },
+    "identifier": {
+      "type": "string",
+      "description": "Identifier for the Redis instance.",
+      "default": null
+    },
     "type": {
       "description": "The name of this module",
       "enum": [

--- a/modules/gcp_redis/gcp-redis.json
+++ b/modules/gcp_redis/gcp-redis.json
@@ -20,7 +20,7 @@
     },
     "identifier": {
       "type": "string",
-      "description": "Identifier for the Redis instance."
+      "description": "Name for the Redis instance. If not specified, it will be look like opta-<layer_name>-<module_name>"
     },
     "type": {
       "description": "The name of this module",

--- a/modules/gcp_redis/gcp-redis.json
+++ b/modules/gcp_redis/gcp-redis.json
@@ -20,8 +20,7 @@
     },
     "identifier": {
       "type": "string",
-      "description": "Identifier for the Redis instance.",
-      "default": null
+      "description": "Identifier for the Redis instance."
     },
     "type": {
       "description": "The name of this module",

--- a/modules/gcp_redis/gcp-redis.json
+++ b/modules/gcp_redis/gcp-redis.json
@@ -20,7 +20,7 @@
     },
     "identifier": {
       "type": "string",
-      "description": "Name for the Redis instance. If not specified, it will be look like opta-<layer_name>-<module_name>"
+      "description": "Name for the Redis instance. If not specified, it will default to opta-<layer_name>-<module_name>"
     },
     "type": {
       "description": "The name of this module",

--- a/modules/gcp_redis/gcp-redis.yaml
+++ b/modules/gcp_redis/gcp-redis.yaml
@@ -32,7 +32,7 @@ inputs:
   - name: identifier
     user_facing: true
     validator: str(required=False)
-    description: Name for the Redis instance. If not specified, it will be look like opta-<layer_name>-<module_name>
+    description: Name for the Redis instance. If not specified, it will default to opta-<layer_name>-<module_name>
     default: null
 outputs:
   - name: cache_host

--- a/modules/gcp_redis/gcp-redis.yaml
+++ b/modules/gcp_redis/gcp-redis.yaml
@@ -32,7 +32,7 @@ inputs:
   - name: identifier
     user_facing: true
     validator: str(required=False)
-    description: Identifier for the Redis instance.
+    description: Name for the Redis instance. If not specified, it will be look like opta-<layer_name>-<module_name>
     default: null
 outputs:
   - name: cache_host

--- a/modules/gcp_redis/gcp-redis.yaml
+++ b/modules/gcp_redis/gcp-redis.yaml
@@ -29,6 +29,11 @@ inputs:
     validator: bool(required=False)
     description: the redis version to use for this instance
     default: true
+  - name: identifier
+    user_facing: true
+    validator: str(required=False)
+    description: Identifier for the Redis instance.
+    default: null
 outputs:
   - name: cache_host
     export: true

--- a/modules/gcp_redis/tf_module/main.tf
+++ b/modules/gcp_redis/tf_module/main.tf
@@ -1,8 +1,12 @@
+locals {
+  identifier = var.identifier == null ? "opta-${var.layer_name}-${var.module_name}" : var.identifier
+}
+
 # TODO: TLS transit encryption
 resource "google_redis_instance" "main" {
   memory_size_gb     = var.memory_size_gb
-  name               = "opta-${var.layer_name}-${var.module_name}"
-  display_name       = "opta-${var.layer_name}-${var.module_name}"
+  name               = local.identifier
+  display_name       = local.identifier
   tier               = var.high_availability ? "STANDARD_HA" : "BASIC"
   authorized_network = data.google_compute_network.vpc.id
   connect_mode       = "PRIVATE_SERVICE_ACCESS"

--- a/modules/gcp_redis/tf_module/main.tf
+++ b/modules/gcp_redis/tf_module/main.tf
@@ -12,4 +12,7 @@ resource "google_redis_instance" "main" {
   connect_mode       = "PRIVATE_SERVICE_ACCESS"
   redis_version      = var.redis_version
   auth_enabled       = true
+  lifecycle {
+    ignore_changes = [name, display_name]
+  }
 }

--- a/modules/gcp_redis/tf_module/variables.tf
+++ b/modules/gcp_redis/tf_module/variables.tf
@@ -31,3 +31,8 @@ variable "memory_size_gb" {
   type    = number
   default = 2
 }
+
+variable "identifier" {
+  type    = string
+  default = null
+}


### PR DESCRIPTION
# Description
Now opta users can change the name of the databases with this new change.

> **Note:**
> **This change to some existing modules may lead to data losses, as terraform takes these changes as deleting old resources and creating new resources ones. So, for the already existing DBs, the names can't be changed.**

# Safety checklist
* [x] This change is backwards compatible and safe to apply by existing users
* [ ] This change will NOT lead to data loss
* [x] This change will NOT lead to downtime who already has an env/service setup

# Example
```yaml
environments:
  - name: aws
    path: "./aws.yml"
    variables:
      max_containers: 6
  - name: gcp
    path: "./gcp.yml"
    variables:
      max_containers: 6
input_variables:
  - name: name
name: test-naming
modules:
  - type: postgres
    name: postgres
    safety: false
    identifier: "{vars.name}"
  - name: redis
    type: redis
    identifier: "{vars.name}"
```

## How has this change been tested, beside unit tests?
Manually tested.

<img width="1394" alt="Screenshot 2022-03-22 at 5 51 04 PM" src="https://user-images.githubusercontent.com/20905988/159518379-5ef7762f-a48d-4542-9bc3-f5fe370082de.png">
<img width="1071" alt="Screenshot 2022-03-22 at 8 50 14 PM" src="https://user-images.githubusercontent.com/20905988/159518394-1e664e1a-22f9-4798-803f-6beadabbeade.png">
<img width="1326" alt="Screenshot 2022-03-22 at 8 50 36 PM" src="https://user-images.githubusercontent.com/20905988/159518403-935cacdb-a7ce-4f78-a2ad-a319303df6cc.png">


