### PR TITLE
Fix value check for CORS for AWS S3 Bucket (#786)

### DIFF
--- a/modules/aws_s3/tf_module/bucket.tf
+++ b/modules/aws_s3/tf_module/bucket.tf
@@ -60,11 +60,11 @@ resource "aws_s3_bucket_cors_configuration" "bucket" {
   count  = var.cors_rule != null ? 1 : 0
 
   cors_rule {
-    allowed_headers = try(var.cors_rule.value["allowed_headers"], [])
-    allowed_methods = try(var.cors_rule.value["allowed_methods"], [])
-    allowed_origins = try(var.cors_rule.value["allowed_origins"], [])
-    expose_headers  = try(var.cors_rule.value["expose_headers"], [])
-    max_age_seconds = try(var.cors_rule.value["max_age_seconds"], 0)
+    allowed_headers = try(var.cors_rule["allowed_headers"], [])
+    allowed_methods = try(var.cors_rule["allowed_methods"], [])
+    allowed_origins = try(var.cors_rule["allowed_origins"], [])
+    expose_headers  = try(var.cors_rule["expose_headers"], [])
+    max_age_seconds = try(var.cors_rule["max_age_seconds"], 0)
   }
 }
 


### PR DESCRIPTION
# Description
Fix the AWS Terraform Resource `aws_s3_bucket_cors_configuration` usage 

# Safety checklist
* [ ] This change is backwards compatible and safe to apply by existing users
* [ ] This change will NOT lead to data loss
* [ ] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
Tested manually
<img width="1337" alt="Screenshot 2022-03-25 at 12 18 10 AM" src="https://user-images.githubusercontent.com/20905988/159995780-74a5c1a7-5af1-4963-aeff-c43d1fa2f777.png">

