### PR TITLE
Use aws-eks instead of k8s-cluster

### DIFF
--- a/modules/aws_k8s_base/aws_k8s_base.py
+++ b/modules/aws_k8s_base/aws_k8s_base.py
@@ -64,7 +64,7 @@ class AwsK8sBaseProcessor(AWSK8sModuleProcessor, K8sBaseModuleProcessor):
 
         aws_eks_modules = self.layer.get_module_by_type("aws-eks", module_idx)
         if len(aws_eks_modules) == 0:
-            raise UserErrors("Must have the k8s-cluster/aws-eks module in before the k8s-base")
+            raise UserErrors("Must have the k8s-cluster/aws-eks module in before the k8s-base/aws-k8s-base")
         aws_eks_module = aws_eks_modules[0]
         self.module.data[
             "k8s_cluster_name"

--- a/modules/aws_k8s_base/aws_k8s_base.py
+++ b/modules/aws_k8s_base/aws_k8s_base.py
@@ -64,7 +64,7 @@ class AwsK8sBaseProcessor(AWSK8sModuleProcessor, K8sBaseModuleProcessor):
 
         aws_eks_modules = self.layer.get_module_by_type("aws-eks", module_idx)
         if len(aws_eks_modules) == 0:
-            raise UserErrors("Must have the k8s cluster module in before the k8s-base")
+            raise UserErrors("Must have the k8s-cluster/aws-eks module in before the k8s-base")
         aws_eks_module = aws_eks_modules[0]
         self.module.data[
             "k8s_cluster_name"

--- a/modules/aws_k8s_base/aws_k8s_base.py
+++ b/modules/aws_k8s_base/aws_k8s_base.py
@@ -62,7 +62,7 @@ class AwsK8sBaseProcessor(AWSK8sModuleProcessor, K8sBaseModuleProcessor):
             "s3_log_bucket_name"
         ] = f"${{{{module.{aws_base_module.name}.s3_log_bucket_name}}}}"
 
-        aws_eks_modules = self.layer.get_module_by_type("k8s-cluster", module_idx)
+        aws_eks_modules = self.layer.get_module_by_type("aws-eks", module_idx)
         if len(aws_eks_modules) == 0:
             raise UserErrors("Must have the k8s cluster module in before the k8s-base")
         aws_eks_module = aws_eks_modules[0]

--- a/opta/constants.py
+++ b/opta/constants.py
@@ -57,15 +57,6 @@ ESCAPE_REQUIRED = ["\\", ".", "+", "*", "?", "[", "]", "$", "^", "(", ")", "{", 
 
 SHELLS_ALLOWED = ["bash", "sh"]
 
-"""
-Note: Key in Module Dependency should have all the dependencies present in the set.
-"""
-MODULE_DEPENDENCY = {
-    "aws-k8s-base": {"aws-eks"},
-    "azure-kys-base": {"azure-aks"},
-    "gcp-k8s-base": {"gcp-gke"},
-}
-
 REDS = [1, 9, 124, 160, 196]
 
 OPTA_INSTALL_URL = "https://docs.opta.dev/install.sh"

--- a/opta/layer.py
+++ b/opta/layer.py
@@ -383,18 +383,18 @@ class Layer:
             unique_modules.add(module.type)
 
         # Checks the Dependency Graph for Unresolved Dependencies.
-        previous_modules: Set[str] = set()
-        for module in layer.modules:
-            dependency_modules = MODULE_DEPENDENCY.get(
-                module.aliased_type or module.type, set()
-            )
-            for dependency_module in dependency_modules:
-                if not previous_modules.__contains__(dependency_module):
-                    raise UserErrors(
-                        f'Module: "{module.type}" has it\'s dependency on a missing Module: "{dependency_module}". '
-                        f"Please rectify the configuration before using it."
-                    )
-            previous_modules.add(module.aliased_type or module.type)
+        # previous_modules: Set[str] = set()
+        # for module in layer.modules:
+        #     dependency_modules = MODULE_DEPENDENCY.get(
+        #         module.aliased_type or module.type, set()
+        #     )
+        #     for dependency_module in dependency_modules:
+        #         if not previous_modules.__contains__(dependency_module):
+        #             raise UserErrors(
+        #                 f'Module: "{module.type}" has it\'s dependency on a missing Module: "{dependency_module}". '
+        #                 f"Please rectify the configuration before using it."
+        #             )
+        #     previous_modules.add(module.aliased_type or module.type)
 
     @staticmethod
     def valid_name(name: str) -> bool:
@@ -435,9 +435,9 @@ class Layer:
     def get_module_by_type(
         self, module_type: str, module_idx: Optional[int] = None
     ) -> list[Module]:
-        module_idx = len(self.modules) - 1 if module_idx is None else module_idx
+        module_idx = len(self.modules) if module_idx is None else module_idx
         modules = []
-        for module in self.modules[0 : module_idx + 1]:
+        for module in self.modules[0 : module_idx]:
             if module.type == module_type or module.aliased_type == module_type:
                 modules.append(module)
         return modules

--- a/opta/layer.py
+++ b/opta/layer.py
@@ -24,7 +24,7 @@ from google.oauth2 import service_account
 
 from modules.base import ModuleProcessor
 from modules.runx.runx import RunxProcessor
-from opta.constants import GENERATED_KUBE_CONFIG_DIR, MODULE_DEPENDENCY, REGISTRY, VERSION
+from opta.constants import GENERATED_KUBE_CONFIG_DIR, REGISTRY, VERSION
 from opta.core.aws import AWS
 from opta.core.azure import Azure
 from opta.core.cloud_client import CloudClient
@@ -381,20 +381,6 @@ class Layer:
                     f"Module Type: '{module.type}' used twice in the configuration. Please check and update as required."
                 )
             unique_modules.add(module.type)
-
-        # Checks the Dependency Graph for Unresolved Dependencies.
-        # previous_modules: Set[str] = set()
-        # for module in layer.modules:
-        #     dependency_modules = MODULE_DEPENDENCY.get(
-        #         module.aliased_type or module.type, set()
-        #     )
-        #     for dependency_module in dependency_modules:
-        #         if not previous_modules.__contains__(dependency_module):
-        #             raise UserErrors(
-        #                 f'Module: "{module.type}" has it\'s dependency on a missing Module: "{dependency_module}". '
-        #                 f"Please rectify the configuration before using it."
-        #             )
-        #     previous_modules.add(module.aliased_type or module.type)
 
     @staticmethod
     def valid_name(name: str) -> bool:


### PR DESCRIPTION
# Description
Use the actual type instead of aliased type.

# Safety checklist
* [ ] This change is backwards compatible and safe to apply by existing users
* [ ] This change will NOT lead to data loss
* [ ] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
YOUR_ANSWER
