### PR TITLE
Add input variable db_name to aws-mysql and aws-postgres

### DIFF
--- a/modules/aws_mysql/aws-mysql.json
+++ b/modules/aws_mysql/aws-mysql.json
@@ -31,7 +31,7 @@
     },
     "db_name": {
       "type": "string",
-      "description": "The name of the database to create.",
+      "description": "The name of the database to create. Follow naming conventions [here](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Limits.html#RDS_Limits.Constraints)",
       "default": "app"
     },
     "type": {

--- a/modules/aws_mysql/aws-mysql.json
+++ b/modules/aws_mysql/aws-mysql.json
@@ -29,6 +29,11 @@
       "description": "Add deletion protection to stop accidental db deletions",
       "default": false
     },
+    "db_name": {
+      "type": "string",
+      "description": "The name of the database to create.",
+      "default": "app"
+    },
     "type": {
       "description": "The name of this module",
       "enum": [

--- a/modules/aws_mysql/aws-mysql.yaml
+++ b/modules/aws_mysql/aws-mysql.yaml
@@ -39,6 +39,11 @@ inputs:
     validator: bool(required=False)
     description: Add deletion protection to stop accidental db deletions
     default: false
+  - name: db_name
+    user_facing: true
+    validator: str(required=False)
+    description: The name of the database to create.
+    default: app
 outputs:
   - name: db_user
     export: false

--- a/modules/aws_mysql/aws-mysql.yaml
+++ b/modules/aws_mysql/aws-mysql.yaml
@@ -42,7 +42,7 @@ inputs:
   - name: db_name
     user_facing: true
     validator: str(required=False)
-    description: The name of the database to create.
+    description: The name of the database to create. Follow naming conventions [here](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Limits.html#RDS_Limits.Constraints)
     default: app
 outputs:
   - name: db_user

--- a/modules/aws_mysql/tf_module/main.tf
+++ b/modules/aws_mysql/tf_module/main.tf
@@ -20,7 +20,7 @@ resource "random_string" "db_name_hash" {
 resource "aws_rds_cluster" "db_cluster" {
   cluster_identifier      = "opta-${var.layer_name}-${var.module_name}-${random_string.db_name_hash.result}"
   db_subnet_group_name    = "opta-${var.env_name}"
-  database_name           = "app"
+  database_name           = var.db_name
   engine                  = "aurora-mysql"
   engine_version          = var.engine_version
   master_username         = "mysqldb"

--- a/modules/aws_mysql/tf_module/variables.tf
+++ b/modules/aws_mysql/tf_module/variables.tf
@@ -37,3 +37,8 @@ variable "multi_az" {
   type    = bool
   default = false
 }
+
+variable "db_name" {
+  type    = string
+  default = "app"
+}

--- a/modules/aws_postgres/aws-postgres.json
+++ b/modules/aws_postgres/aws-postgres.json
@@ -31,7 +31,7 @@
     },
     "db_name": {
       "type": "string",
-      "description": "The name of the database to create.",
+      "description": "The name of the database to create. Follow naming conventions [here](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Limits.html#RDS_Limits.Constraints)",
       "default": "app"
     },
     "type": {

--- a/modules/aws_postgres/aws-postgres.json
+++ b/modules/aws_postgres/aws-postgres.json
@@ -29,6 +29,11 @@
       "description": "Add deletion protection to stop accidental db deletions",
       "default": false
     },
+    "db_name": {
+      "type": "string",
+      "description": "The name of the database to create.",
+      "default": "app"
+    },
     "type": {
       "description": "The name of this module",
       "enum": [

--- a/modules/aws_postgres/aws-postgres.yaml
+++ b/modules/aws_postgres/aws-postgres.yaml
@@ -42,7 +42,7 @@ inputs:
   - name: db_name
     user_facing: true
     validator: str(required=False)
-    description: The name of the database to create.
+    description: The name of the database to create. Follow naming conventions [here](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Limits.html#RDS_Limits.Constraints)
     default: app
 outputs:
   - name: db_user

--- a/modules/aws_postgres/aws-postgres.yaml
+++ b/modules/aws_postgres/aws-postgres.yaml
@@ -39,6 +39,11 @@ inputs:
     validator: int(required=False)
     description: How many days to keep the backup retention
     default: 7
+  - name: db_name
+    user_facing: true
+    validator: str(required=False)
+    description: The name of the database to create.
+    default: app
 outputs:
   - name: db_user
     export: false

--- a/modules/aws_postgres/tf_module/main.tf
+++ b/modules/aws_postgres/tf_module/main.tf
@@ -20,7 +20,7 @@ resource "random_string" "db_name_hash" {
 resource "aws_rds_cluster" "db_cluster" {
   cluster_identifier      = "opta-${var.layer_name}-${var.module_name}-${random_string.db_name_hash.result}"
   db_subnet_group_name    = "opta-${var.env_name}"
-  database_name           = "app"
+  database_name           = var.db_name
   engine                  = "aurora-postgresql"
   engine_version          = var.engine_version
   master_username         = "postgres"

--- a/modules/aws_postgres/tf_module/variables.tf
+++ b/modules/aws_postgres/tf_module/variables.tf
@@ -39,3 +39,9 @@ variable "multi_az" {
   type    = bool
   default = false
 }
+
+
+variable "db_name" {
+  type    = string
+  default = "app"
+}


### PR DESCRIPTION
# Description
This let's users add a custom database name created with `aws-mysql` and `aws-postgres` or `mysql` and `postgres` modules respectively for AWS provider

> **Note:**
> **If the db_name is changed, the terraform resources will be destroyed and created again.**

# Safety checklist
* [x] This change is backwards compatible and safe to apply by existing users
* [ ] This change will NOT lead to data loss
* [ ] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
Tested Manually by creating a MySQL module.

## Observations:
The current existing module resources will be destroyed and new module resources would be created, if the users change the `db_name`