### PR TITLE
Remove Cluster Issuer from opta-base

### DIFF
--- a/modules/aws_k8s_base/tf_module/opta-base/Chart.yaml
+++ b/modules/aws_k8s_base/tf_module/opta-base/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.2
+version: 0.2.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/modules/aws_k8s_base/tf_module/opta-base/templates/selfsignedcert.yaml
+++ b/modules/aws_k8s_base/tf_module/opta-base/templates/selfsignedcert.yaml
@@ -1,6 +1,0 @@
-apiVersion: cert-manager.io/v1
-kind: ClusterIssuer
-metadata:
-  name: opta-selfsigned
-spec:
-  selfSigned: {}

--- a/modules/azure_k8s_base/tf_module/opta-base/Chart.yaml
+++ b/modules/azure_k8s_base/tf_module/opta-base/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.2.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/modules/azure_k8s_base/tf_module/opta-base/templates/selfsignedcert.yaml
+++ b/modules/azure_k8s_base/tf_module/opta-base/templates/selfsignedcert.yaml
@@ -1,6 +1,0 @@
-apiVersion: cert-manager.io/v1
-kind: ClusterIssuer
-metadata:
-  name: opta-selfsigned
-spec:
-  selfSigned: {}

--- a/modules/gcp_k8s_base/tf_module/opta-base/Chart.yaml
+++ b/modules/gcp_k8s_base/tf_module/opta-base/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.3
+version: 0.2.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/modules/gcp_k8s_base/tf_module/opta-base/templates/selfsignedcert.yaml
+++ b/modules/gcp_k8s_base/tf_module/opta-base/templates/selfsignedcert.yaml
@@ -1,6 +1,0 @@
-apiVersion: cert-manager.io/v1
-kind: ClusterIssuer
-metadata:
-  name: opta-selfsigned
-spec:
-  selfSigned: {}


### PR DESCRIPTION
# Description
Removing the Self Signed Cluster Issuer from the Opta Base

Step 2 would be to remove `cert-manager` helm from the `k8s-base` module to complete the procedure.

# Safety checklist
* [x] This change is backwards compatible and safe to apply by existing users
* [x] This change will NOT lead to data loss
* [x] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
Tested Manually on a Local cluster
