### PR TITLE
Give Opta users ability to add and update pod annotations for the K8s-service pod objects

### DIFF
--- a/modules/aws_k8s_service/aws-k8s-service.json
+++ b/modules/aws_k8s_service/aws-k8s-service.json
@@ -175,6 +175,11 @@
       "description": "These are extra annotations to add to ingress objects\n",
       "default": {}
     },
+    "pod_annotations": {
+      "type": "object",
+      "description": "These are extra annotations to add to k8s-service pod objects \n",
+      "default": {}
+    },
     "type": {
       "description": "The name of this module",
       "enum": [

--- a/modules/aws_k8s_service/aws-k8s-service.yaml
+++ b/modules/aws_k8s_service/aws-k8s-service.yaml
@@ -195,6 +195,12 @@ inputs:
     validator: list(include('cron_job'), required=False)
     description: A list of cronjobs to execute as part of this service
     default: []
+  - name: pod_annotations
+    user_facing: true
+    validator: map(required=False)
+    default: {}
+    description: |
+      These are extra annotations to add to k8s-service pod objects 
 extra_validators:
   cron_job:
     commands: list(required=True)

--- a/modules/aws_k8s_service/tf_module/main.tf
+++ b/modules/aws_k8s_service/tf_module/main.tf
@@ -54,6 +54,7 @@ resource "helm_release" "k8s-service" {
       ingressExtraAnnotations : var.ingress_extra_annotations
       tolerations : var.tolerations
       cron_jobs : var.cron_jobs
+      podAnnotations : var.pod_annotations
     })
   ]
   atomic          = true

--- a/modules/aws_k8s_service/tf_module/variables.tf
+++ b/modules/aws_k8s_service/tf_module/variables.tf
@@ -201,3 +201,9 @@ variable "tolerations" {
 variable "cron_jobs" {
   default = []
 }
+
+variable "pod_annotations" {
+  type        = map(string)
+  default     = {}
+  description = "values to add to the pod annotations for the k8s-service pods"
+}

--- a/modules/azure_k8s_service/azure-k8s-service.json
+++ b/modules/azure_k8s_service/azure-k8s-service.json
@@ -143,6 +143,11 @@
       "description": "These are extra annotations to add to ingress objects\n",
       "default": {}
     },
+    "pod_annotations": {
+      "type": "object",
+      "description": "These are extra annotations to add to k8s-service pod objects\n",
+      "default": {}
+    },
     "type": {
       "description": "The name of this module",
       "enum": [

--- a/modules/azure_k8s_service/azure-k8s-service.yaml
+++ b/modules/azure_k8s_service/azure-k8s-service.yaml
@@ -166,6 +166,12 @@ inputs: # (what users see)
     default: {}
     description: |
       These are extra annotations to add to ingress objects
+  - name: pod_annotations
+    user_facing: true
+    validator: map(required=False)
+    default: {}
+    description: |
+      These are extra annotations to add to k8s-service pod objects
 extra_validators:
   persistent_storage:
     size: int(required=True)

--- a/modules/azure_k8s_service/tf_module/main.tf
+++ b/modules/azure_k8s_service/tf_module/main.tf
@@ -51,6 +51,7 @@ resource "helm_release" "k8s-service" {
       keepPathPrefix : var.keep_path_prefix
       persistentStorage : var.persistent_storage
       ingressExtraAnnotations : var.ingress_extra_annotations
+      podAnnotations : var.pod_annotations
     })
   ]
   atomic          = true

--- a/modules/azure_k8s_service/tf_module/variables.tf
+++ b/modules/azure_k8s_service/tf_module/variables.tf
@@ -190,3 +190,9 @@ variable "ingress_extra_annotations" {
   type    = map(string)
   default = {}
 }
+
+variable "pod_annotations" {
+  type        = map(string)
+  default     = {}
+  description = "values to add to the pod annotations for the k8s-service pods"
+}

--- a/modules/gcp_k8s_service/gcp-k8s-service.json
+++ b/modules/gcp_k8s_service/gcp-k8s-service.json
@@ -160,6 +160,11 @@
       "description": "These are extra annotations to add to ingress objects\n",
       "default": {}
     },
+    "pod_annotations": {
+      "type": "object",
+      "description": "These are extra annotations to add to k8s-service pod objects\n",
+      "default": {}
+    },
     "port": {
       "$ref": "/common-types/port-deprecated",
       "description": "Specifies what port your app was made to be listened to. Currently it must be a map of the form\n`http: [PORT_NUMBER_HERE]` or `tcp: [PORT_NUMBER_HERE]`. Use http if you just have a vanilla http server and tcp for\nwebsockets.\n"

--- a/modules/gcp_k8s_service/gcp-k8s-service.yaml
+++ b/modules/gcp_k8s_service/gcp-k8s-service.yaml
@@ -186,6 +186,12 @@ inputs:
     validator: list(include('cron_job'), required=False)
     description: A list of cronjobs to execute as part of this service
     default: []
+  - name: pod_annotations
+    user_facing: true
+    validator: map(required=False)
+    default: {}
+    description: |
+      These are extra annotations to add to k8s-service pod objects
 extra_validators:
   cron_job:
     commands: list(required=True)

--- a/modules/gcp_k8s_service/tf_module/main.tf
+++ b/modules/gcp_k8s_service/tf_module/main.tf
@@ -53,6 +53,7 @@ resource "helm_release" "k8s-service" {
       ingressExtraAnnotations : var.ingress_extra_annotations
       tolerations : var.tolerations
       cron_jobs : var.cron_jobs
+      podAnnotations : var.pod_annotations
     })
   ]
   atomic          = true

--- a/modules/gcp_k8s_service/tf_module/variables.tf
+++ b/modules/gcp_k8s_service/tf_module/variables.tf
@@ -204,3 +204,9 @@ variable "tolerations" {
 variable "cron_jobs" {
   default = []
 }
+
+variable "pod_annotations" {
+  type        = map(string)
+  default     = {}
+  description = "values to add to the pod annotations for the k8s-service pods"
+}

--- a/modules/opta-k8s-service-helm/Chart.yaml
+++ b/modules/opta-k8s-service-helm/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/modules/opta-k8s-service-helm/templates/deployment.yaml
+++ b/modules/opta-k8s-service-helm/templates/deployment.yaml
@@ -36,6 +36,9 @@ spec:
         config.linkerd.io/proxy-cpu-request: "0.05"
         config.linkerd.io/proxy-memory-limit: "20Mi"
         config.linkerd.io/proxy-memory-request: "10Mi"
+        {{- range $k, $v := $.Values.podAnnotations }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
     spec:
       serviceAccountName: {{ include "k8s-service.serviceAccountName" . }}
       containers:

--- a/modules/opta-k8s-service-helm/values.yaml
+++ b/modules/opta-k8s-service-helm/values.yaml
@@ -19,6 +19,7 @@ persistentStorage: []
 ingressExtraAnnotations: {}
 tolerations: []
 cron_jobs: []
+podAnnotations: {}
 
 serviceAccount:
   # The name of the service account to use.


### PR DESCRIPTION
# Description
This feature will let the Opta Users, existing and new, **add new and update existing pod annotations** in the Pod resources created using the opta module `k8s-service/aws-k8s-service/azure-k8s-service/gcp-k8s-service`

# Safety checklist
* [x] This change is backwards compatible and safe to apply by existing users
* [x] This change will NOT lead to data loss
* [x] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
<img width="473" alt="Screenshot 2022-04-04 at 8 34 42 PM" src="https://user-images.githubusercontent.com/20905988/161573660-1575d5dd-365b-4f61-a88a-21690aa9e431.png">
<img width="779" alt="Screenshot 2022-04-04 at 8 34 24 PM" src="https://user-images.githubusercontent.com/20905988/161573656-4ec91a98-3f1a-4be2-a9ee-cd6f99d010bd.png">
<img width="442" alt="Screenshot 2022-04-04 at 8 18 44 PM" src="https://user-images.githubusercontent.com/20905988/161573625-355b7bff-aca0-4820-ac77-d7d16320f299.png">
<img width="781" alt="Screenshot 2022-04-04 at 8 19 30 PM" src="https://user-images.githubusercontent.com/20905988/161573642-af202ce2-b65b-4ce2-846b-8abb44953400.png">
<img width="436" alt="Screenshot 2022-04-04 at 8 19 02 PM" src="https://user-images.githubusercontent.com/20905988/161573636-e2d7b60d-0ad2-49c5-9ffd-e72871dbf6e1.png">
<img width="804" alt="Screenshot 2022-04-04 at 8 19 47 PM" src="https://user-images.githubusercontent.com/20905988/161573650-5ae44c2d-34b3-4957-80b0-2ae9e4c187e5.png">
