### PR TITLE
Opta shell needs to load in the kubeconfig for it to work

### DIFF
--- a/opta/commands/shell.py
+++ b/opta/commands/shell.py
@@ -7,11 +7,7 @@ from opta.amplitude import amplitude_client
 from opta.commands.apply import local_setup
 from opta.constants import SHELLS_ALLOWED
 from opta.core.generator import gen_all
-from opta.core.kubernetes import (
-    load_opta_kube_config,
-    load_opta_kube_config_to_default,
-    set_kube_config,
-)
+from opta.core.kubernetes import load_opta_kube_config, set_kube_config
 from opta.exceptions import UserErrors
 from opta.layer import Layer
 from opta.nice_subprocess import nice_run
@@ -62,7 +58,6 @@ def shell(
     gen_all(layer)
     set_kube_config(layer)
     load_opta_kube_config()
-    load_opta_kube_config_to_default(layer)
     context_name = layer.get_cloud_client().get_kubectl_context_name()
 
     # Get a random pod in the service

--- a/opta/commands/shell.py
+++ b/opta/commands/shell.py
@@ -7,7 +7,11 @@ from opta.amplitude import amplitude_client
 from opta.commands.apply import local_setup
 from opta.constants import SHELLS_ALLOWED
 from opta.core.generator import gen_all
-from opta.core.kubernetes import load_opta_kube_config, set_kube_config
+from opta.core.kubernetes import (
+    load_opta_kube_config,
+    load_opta_kube_config_to_default,
+    set_kube_config,
+)
 from opta.exceptions import UserErrors
 from opta.layer import Layer
 from opta.nice_subprocess import nice_run
@@ -58,6 +62,7 @@ def shell(
     gen_all(layer)
     set_kube_config(layer)
     load_opta_kube_config()
+    load_opta_kube_config_to_default(layer)
 
     # Get a random pod in the service
     v1 = CoreV1Api()

--- a/opta/commands/shell.py
+++ b/opta/commands/shell.py
@@ -58,7 +58,7 @@ def shell(
     gen_all(layer)
     set_kube_config(layer)
     load_opta_kube_config()
-    context_name = layer.get_cloud_client().get_kubectl_context_name()
+    context_name = layer.get_cloud_client().get_kube_context_name()
 
     # Get a random pod in the service
     v1 = CoreV1Api()

--- a/opta/commands/shell.py
+++ b/opta/commands/shell.py
@@ -63,6 +63,7 @@ def shell(
     set_kube_config(layer)
     load_opta_kube_config()
     load_opta_kube_config_to_default(layer)
+    context_name = layer.get_cloud_client().get_kubectl_context_name()
 
     # Get a random pod in the service
     v1 = CoreV1Api()
@@ -78,6 +79,8 @@ def shell(
             layer.name,
             "-c",
             "k8s-service",
+            "--context",
+            context_name,
             pod_list[0].metadata.name,
             "-it",
             "--",

--- a/opta/core/aws.py
+++ b/opta/core/aws.py
@@ -435,7 +435,7 @@ class AWS(CloudClient):
         except client.exceptions.ResourceNotFoundException:
             return False
 
-    def get_kubectl_context_name(self) -> str:
+    def get_kube_context_name(self) -> str:
         region, account_id = self.get_cluster_env()
         # Get the environment's account details from the opta config
         cluster_name = self.layer.get_cluster_name()
@@ -465,7 +465,7 @@ class AWS(CloudClient):
         cluster = client.describe_cluster(name=cluster_name)
         cluster_cert = cluster["cluster"]["certificateAuthority"]["data"]
         cluster_ep = cluster["cluster"]["endpoint"]
-        kubectl_context_name = self.get_kubectl_context_name()
+        kube_context_name = self.get_kube_context_name()
 
         cluster_config = {
             "apiVersion": "v1",
@@ -476,23 +476,20 @@ class AWS(CloudClient):
                         "server": str(cluster_ep),
                         "certificate-authority-data": str(cluster_cert),
                     },
-                    "name": kubectl_context_name,
+                    "name": kube_context_name,
                 }
             ],
             "contexts": [
                 {
-                    "context": {
-                        "cluster": kubectl_context_name,
-                        "user": kubectl_context_name,
-                    },
-                    "name": kubectl_context_name,
+                    "context": {"cluster": kube_context_name, "user": kube_context_name,},
+                    "name": kube_context_name,
                 }
             ],
-            "current-context": kubectl_context_name,
+            "current-context": kube_context_name,
             "preferences": {},
             "users": [
                 {
-                    "name": kubectl_context_name,
+                    "name": kube_context_name,
                     "user": {
                         "exec": {
                             "apiVersion": "client.authentication.k8s.io/v1alpha1",

--- a/opta/core/aws.py
+++ b/opta/core/aws.py
@@ -481,7 +481,7 @@ class AWS(CloudClient):
             ],
             "contexts": [
                 {
-                    "context": {"cluster": kube_context_name, "user": kube_context_name,},
+                    "context": {"cluster": kube_context_name, "user": kube_context_name},
                     "name": kube_context_name,
                 }
             ],

--- a/opta/core/azure.py
+++ b/opta/core/azure.py
@@ -194,7 +194,7 @@ class Azure(CloudClient):
     def get_all_remote_configs(self) -> Dict[str, Dict[str, "StructuredConfig"]]:
         raise AzureNotImplemented("Feature Unsupported for Azure")
 
-    def get_kubectl_context_name(self) -> str:
+    def get_kube_context_name(self) -> str:
         providers = self.layer.root().gen_providers(0)
         rg_name = providers["terraform"]["backend"]["azurerm"]["resource_group_name"]
         cluster_name = self.layer.get_cluster_name()
@@ -207,7 +207,7 @@ class Azure(CloudClient):
 
         rg_name = providers["terraform"]["backend"]["azurerm"]["resource_group_name"]
         cluster_name = self.layer.get_cluster_name()
-        kubectl_context_name = self.get_kubectl_context_name()
+        kube_context_name = self.get_kube_context_name()
 
         if not self.cluster_exist():
             raise Exception(
@@ -226,7 +226,7 @@ class Azure(CloudClient):
                 "--admin",
                 "--overwrite-existing",
                 "--context",
-                kubectl_context_name.replace("-admin", ""),
+                kube_context_name.replace("-admin", ""),
             ],
             stdout=DEVNULL,
             check=True,

--- a/opta/core/azure.py
+++ b/opta/core/azure.py
@@ -194,6 +194,12 @@ class Azure(CloudClient):
     def get_all_remote_configs(self) -> Dict[str, Dict[str, "StructuredConfig"]]:
         raise AzureNotImplemented("Feature Unsupported for Azure")
 
+    def get_kubectl_context_name(self) -> str:
+        providers = self.layer.root().gen_providers(0)
+        rg_name = providers["terraform"]["backend"]["azurerm"]["resource_group_name"]
+        cluster_name = self.layer.get_cluster_name()
+        return f"{rg_name}-{cluster_name}-admin"
+
     def set_kube_config(self) -> None:
         providers = self.layer.root().gen_providers(0)
 
@@ -201,6 +207,7 @@ class Azure(CloudClient):
 
         rg_name = providers["terraform"]["backend"]["azurerm"]["resource_group_name"]
         cluster_name = self.layer.get_cluster_name()
+        kubectl_context_name = self.get_kubectl_context_name()
 
         if not self.cluster_exist():
             raise Exception(
@@ -218,6 +225,8 @@ class Azure(CloudClient):
                 cluster_name,
                 "--admin",
                 "--overwrite-existing",
+                "--context",
+                kubectl_context_name.replace("-admin", ""),
             ],
             stdout=DEVNULL,
             check=True,

--- a/opta/core/cloud_client.py
+++ b/opta/core/cloud_client.py
@@ -41,3 +41,7 @@ class CloudClient(ABC):
     @abstractmethod
     def set_kube_config(self) -> None:
         raise NotImplementedError()
+
+    @abstractmethod
+    def get_kubectl_context_name(self) -> str:
+        pass

--- a/opta/core/cloud_client.py
+++ b/opta/core/cloud_client.py
@@ -43,5 +43,5 @@ class CloudClient(ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    def get_kubectl_context_name(self) -> str:
+    def get_kube_context_name(self) -> str:
         pass

--- a/opta/core/gcp.py
+++ b/opta/core/gcp.py
@@ -271,7 +271,7 @@ class GCP(CloudClient):
             ],
             "contexts": [
                 {
-                    "context": {"cluster": kube_context_name, "user": kube_context_name,},
+                    "context": {"cluster": kube_context_name, "user": kube_context_name},
                     "name": kube_context_name,
                 }
             ],

--- a/opta/core/gcp.py
+++ b/opta/core/gcp.py
@@ -222,7 +222,7 @@ class GCP(CloudClient):
         googl_provider = self.layer.root().providers["google"]
         return googl_provider["region"], googl_provider["project"]
 
-    def get_kubectl_context_name(self) -> str:
+    def get_kube_context_name(self) -> str:
         region, project_id = self.get_cluster_env()
         # Get the environment's account details from the opta config
         cluster_name = self.layer.get_cluster_name()
@@ -255,7 +255,7 @@ class GCP(CloudClient):
         cluster_ca_certificate = cluster_data.master_auth.cluster_ca_certificate
         cluster_endpoint = f"https://{cluster_data.endpoint}"
         gcloud_path = which("gcloud")
-        kubectl_context_name = self.get_kubectl_context_name()
+        kube_context_name = self.get_kube_context_name()
 
         cluster_config = {
             "apiVersion": "v1",
@@ -266,23 +266,20 @@ class GCP(CloudClient):
                         "server": cluster_endpoint,
                         "certificate-authority-data": cluster_ca_certificate,
                     },
-                    "name": kubectl_context_name,
+                    "name": kube_context_name,
                 }
             ],
             "contexts": [
                 {
-                    "context": {
-                        "cluster": kubectl_context_name,
-                        "user": kubectl_context_name,
-                    },
-                    "name": kubectl_context_name,
+                    "context": {"cluster": kube_context_name, "user": kube_context_name,},
+                    "name": kube_context_name,
                 }
             ],
-            "current-context": kubectl_context_name,
+            "current-context": kube_context_name,
             "preferences": {},
             "users": [
                 {
-                    "name": kubectl_context_name,
+                    "name": kube_context_name,
                     "user": {
                         "auth-provider": {
                             "name": "gcp",

--- a/opta/core/gcp.py
+++ b/opta/core/gcp.py
@@ -222,6 +222,12 @@ class GCP(CloudClient):
         googl_provider = self.layer.root().providers["google"]
         return googl_provider["region"], googl_provider["project"]
 
+    def get_kubectl_context_name(self) -> str:
+        region, project_id = self.get_cluster_env()
+        # Get the environment's account details from the opta config
+        cluster_name = self.layer.get_cluster_name()
+        return f"{project_id}_{region}_{cluster_name}"
+
     def set_kube_config(self) -> None:
         ensure_installed("gcloud")
         kube_config_file_name = self.layer.get_kube_config_file_name()
@@ -249,7 +255,7 @@ class GCP(CloudClient):
         cluster_ca_certificate = cluster_data.master_auth.cluster_ca_certificate
         cluster_endpoint = f"https://{cluster_data.endpoint}"
         gcloud_path = which("gcloud")
-        kube_config_resource_name = f"{project_id}_{region}_{cluster_name}"
+        kubectl_context_name = self.get_kubectl_context_name()
 
         cluster_config = {
             "apiVersion": "v1",
@@ -260,23 +266,23 @@ class GCP(CloudClient):
                         "server": cluster_endpoint,
                         "certificate-authority-data": cluster_ca_certificate,
                     },
-                    "name": kube_config_resource_name,
+                    "name": kubectl_context_name,
                 }
             ],
             "contexts": [
                 {
                     "context": {
-                        "cluster": kube_config_resource_name,
-                        "user": kube_config_resource_name,
+                        "cluster": kubectl_context_name,
+                        "user": kubectl_context_name,
                     },
-                    "name": kube_config_resource_name,
+                    "name": kubectl_context_name,
                 }
             ],
-            "current-context": kube_config_resource_name,
+            "current-context": kubectl_context_name,
             "preferences": {},
             "users": [
                 {
-                    "name": kube_config_resource_name,
+                    "name": kubectl_context_name,
                     "user": {
                         "auth-provider": {
                             "name": "gcp",

--- a/opta/core/local.py
+++ b/opta/core/local.py
@@ -74,7 +74,7 @@ class Local(CloudClient):
             capture_output=True,
         )
 
-    def get_kubectl_context_name(self) -> str:
+    def get_kube_context_name(self) -> str:
         return "kind-opta-local-cluster"
 
     def cluster_exist(self) -> bool:

--- a/opta/core/local.py
+++ b/opta/core/local.py
@@ -74,6 +74,9 @@ class Local(CloudClient):
             capture_output=True,
         )
 
+    def get_kubectl_context_name(self) -> str:
+        return "kind-opta-local-cluster"
+
     def cluster_exist(self) -> bool:
         try:
             output: str = nice_run(

--- a/opta/layer.py
+++ b/opta/layer.py
@@ -472,6 +472,7 @@ class Layer:
                 raise e
             if module.desc.get("halt"):
                 previous_module_reference = [f"module.{module.name}"]
+        ret["output"] = ret.get("output", {})
         ret["output"]["state_storage"] = {"value": self.state_storage()}
 
         return hydrate(ret, self.metadata_hydration())

--- a/tests/commands/test_shell.py
+++ b/tests/commands/test_shell.py
@@ -18,9 +18,6 @@ def test_shell(mocker: MockFixture) -> None:
     layer_gen_all = mocker.patch("opta.commands.shell.gen_all")
     set_kube_config = mocker.patch("opta.commands.shell.set_kube_config")
     load_kube_config = mocker.patch("opta.commands.shell.load_opta_kube_config")
-    load_opta_kube_config_to_default = mocker.patch(
-        "opta.commands.shell.load_opta_kube_config_to_default"
-    )
 
     mocked_core_v1_api_class = mocker.patch("opta.commands.shell.CoreV1Api")
     mocked_core_v1_api = mocker.Mock(spec=CoreV1Api)
@@ -41,7 +38,6 @@ def test_shell(mocker: MockFixture) -> None:
     layer_gen_all.assert_called_once_with(mocked_layer)
     set_kube_config.assert_called_once_with(mocked_layer)
     load_kube_config.assert_called_once()
-    load_opta_kube_config_to_default.assert_called_once()
     mocked_core_v1_api.list_namespaced_pod.assert_called_once_with("layer_name")
 
     mocked_nice_run.assert_called_once_with(
@@ -52,6 +48,8 @@ def test_shell(mocker: MockFixture) -> None:
             "layer_name",
             "-c",
             "k8s-service",
+            "--context",
+            mocker.ANY,
             "pod_name",
             "-it",
             "--",
@@ -73,9 +71,6 @@ def test_shell_with_sh(mocker: MockFixture) -> None:
     layer_gen_all = mocker.patch("opta.commands.shell.gen_all")
     set_kube_config = mocker.patch("opta.commands.shell.set_kube_config")
     load_kube_config = mocker.patch("opta.commands.shell.load_opta_kube_config")
-    load_opta_kube_config_to_default = mocker.patch(
-        "opta.commands.shell.load_opta_kube_config_to_default"
-    )
 
     mocked_core_v1_api_class = mocker.patch("opta.commands.shell.CoreV1Api")
     mocked_core_v1_api = mocker.Mock(spec=CoreV1Api)
@@ -96,7 +91,6 @@ def test_shell_with_sh(mocker: MockFixture) -> None:
     layer_gen_all.assert_called_once_with(mocked_layer)
     set_kube_config.assert_called_once_with(mocked_layer)
     load_kube_config.assert_called_once()
-    load_opta_kube_config_to_default.assert_called_once()
     mocked_core_v1_api.list_namespaced_pod.assert_called_once_with("layer_name")
 
     mocked_nice_run.assert_called_once_with(
@@ -107,6 +101,8 @@ def test_shell_with_sh(mocker: MockFixture) -> None:
             "layer_name",
             "-c",
             "k8s-service",
+            "--context",
+            mocker.ANY,
             "pod_name",
             "-it",
             "--",

--- a/tests/commands/test_shell.py
+++ b/tests/commands/test_shell.py
@@ -73,6 +73,9 @@ def test_shell_with_sh(mocker: MockFixture) -> None:
     layer_gen_all = mocker.patch("opta.commands.shell.gen_all")
     set_kube_config = mocker.patch("opta.commands.shell.set_kube_config")
     load_kube_config = mocker.patch("opta.commands.shell.load_opta_kube_config")
+    load_opta_kube_config_to_default = mocker.patch(
+        "opta.commands.shell.load_opta_kube_config_to_default"
+    )
 
     mocked_core_v1_api_class = mocker.patch("opta.commands.shell.CoreV1Api")
     mocked_core_v1_api = mocker.Mock(spec=CoreV1Api)
@@ -93,6 +96,7 @@ def test_shell_with_sh(mocker: MockFixture) -> None:
     layer_gen_all.assert_called_once_with(mocked_layer)
     set_kube_config.assert_called_once_with(mocked_layer)
     load_kube_config.assert_called_once()
+    load_opta_kube_config_to_default.assert_called_once()
     mocked_core_v1_api.list_namespaced_pod.assert_called_once_with("layer_name")
 
     mocked_nice_run.assert_called_once_with(

--- a/tests/commands/test_shell.py
+++ b/tests/commands/test_shell.py
@@ -18,6 +18,9 @@ def test_shell(mocker: MockFixture) -> None:
     layer_gen_all = mocker.patch("opta.commands.shell.gen_all")
     set_kube_config = mocker.patch("opta.commands.shell.set_kube_config")
     load_kube_config = mocker.patch("opta.commands.shell.load_opta_kube_config")
+    load_opta_kube_config_to_default = mocker.patch(
+        "opta.commands.shell.load_opta_kube_config_to_default"
+    )
 
     mocked_core_v1_api_class = mocker.patch("opta.commands.shell.CoreV1Api")
     mocked_core_v1_api = mocker.Mock(spec=CoreV1Api)
@@ -38,6 +41,7 @@ def test_shell(mocker: MockFixture) -> None:
     layer_gen_all.assert_called_once_with(mocked_layer)
     set_kube_config.assert_called_once_with(mocked_layer)
     load_kube_config.assert_called_once()
+    load_opta_kube_config_to_default.assert_called_once()
     mocked_core_v1_api.list_namespaced_pod.assert_called_once_with("layer_name")
 
     mocked_nice_run.assert_called_once_with(

--- a/tests/core/test_azure.py
+++ b/tests/core/test_azure.py
@@ -83,6 +83,8 @@ class TestAzure:
                         "mocked_cluster_name",
                         "--admin",
                         "--overwrite-existing",
+                        "--context",
+                        "dummy_resource_group-mocked_cluster_name",
                     ],
                     stdout=DEVNULL,
                     check=True,


### PR DESCRIPTION
# Description
Fails with a weird message if there was another environment loaded up as default


# Safety checklist
* [x] This change is backwards compatible and safe to apply by existing users
* [x] This change will NOT lead to data loss
* [x] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
Manually
