### PR TITLE
Add support for bring-your-own-vpc to aws-base

### DIFF
--- a/config/registry/schemas/common-types/aws-subnet-id.json
+++ b/config/registry/schemas/common-types/aws-subnet-id.json
@@ -1,0 +1,6 @@
+{
+    "$id": "https://app.runx.dev/common-types/aws-subnet-id",
+    "type": "string",
+    "description": "Format for an AWS Subnet ID",
+    "pattern": "^subnet-([0-9a-z]{8}|[0-9a-z]{17})$"
+}

--- a/config/registry/schemas/common-types/aws-vpc-id.json
+++ b/config/registry/schemas/common-types/aws-vpc-id.json
@@ -1,0 +1,6 @@
+{
+    "$id": "https://app.runx.dev/common-types/aws-vpc-id",
+    "type": "string",
+    "description": "Format for an AWS VPC ID",
+    "pattern": "^vpc-([0-9a-z]{8}|[0-9a-z]{17})$"
+}

--- a/modules/aws_base/aws-base.json
+++ b/modules/aws_base/aws-base.json
@@ -41,6 +41,28 @@
       "description": "This is the total cidr block for the VPC.",
       "default": "10.0.0.0/16"
     },
+    "vpc_id": {
+      "type": "string",
+      "description": "The ID of an existing VPC to import. If not provided, Opta will create a new VPC.",
+      "$ref": "/common-types/aws-vpc-id",
+      "default": null
+    },
+    "public_subnet_ids": {
+      "type": "array",
+      "description": "When importing an existing VPC, the IDs of the public subnets",
+      "items": {
+        "$ref": "/common-types/aws-subnet-id"
+      },
+      "default": []
+    },
+    "private_subnet_ids": {
+      "type": "array",
+      "description": "When importing an existing VPC, the IDs of the private subnets",
+      "items": {
+        "$ref": "/common-types/aws-subnet-id"
+      },
+      "default": []
+    },
     "type": {
       "description": "The name of this module",
       "enum": [

--- a/modules/aws_base/aws-base.json
+++ b/modules/aws_base/aws-base.json
@@ -44,24 +44,21 @@
     "vpc_id": {
       "type": "string",
       "description": "The ID of an existing VPC to import. If not provided, Opta will create a new VPC.",
-      "$ref": "/common-types/aws-vpc-id",
-      "default": null
+      "$ref": "/common-types/aws-vpc-id"
     },
     "public_subnet_ids": {
       "type": "array",
       "description": "When importing an existing VPC, the IDs of the public subnets",
       "items": {
         "$ref": "/common-types/aws-subnet-id"
-      },
-      "default": []
+      }
     },
     "private_subnet_ids": {
       "type": "array",
       "description": "When importing an existing VPC, the IDs of the private subnets",
       "items": {
         "$ref": "/common-types/aws-subnet-id"
-      },
-      "default": []
+      }
     },
     "type": {
       "description": "The name of this module",

--- a/modules/aws_base/aws-base.md
+++ b/modules/aws_base/aws-base.md
@@ -9,3 +9,14 @@ description: Sets up VPCs, a default KMS key, and the db/cache subnets for your 
 
 The defaults for this module are set to work 99% of the time, assuming no funny networking constraints (you'll know them
 if you have them), so in most cases, there is _no need to set any of the fields or know what the outputs do_.
+
+## Bring your own VPC
+To use an existing VPC with Opta, instead of having Opta create a new VPC, you must set the `vpc_id`, `public_subnet_ids`, and `private_subnet_ids` fields.
+Set `vpc_id` to the ID of the existing VPC you would like Opta to use.
+Set `public_subnet_ids` to the list of IDs of the public subnets in the VPC.
+Public subnets must have a route that connects to an internet gateway, and must be configured to assign public IP addresses.
+Set `private_subnet_ids` to the list of IDs of the private subnets in the VPC.
+Private subnets must have a route with a destination of `0.0.0.0/0` that points to a NAT gateway with a public IP address.
+
+IPv6 is not supported on VPCs that you bring.
+Those VPCs may work, but we do not verify Opta works properly with IPv6-only or dual-stack VPCs.

--- a/modules/aws_base/aws-base.md
+++ b/modules/aws_base/aws-base.md
@@ -17,6 +17,7 @@ Set `public_subnet_ids` to the list of IDs of the public subnets in the VPC.
 Public subnets must have a route that connects to an internet gateway, and must be configured to assign public IP addresses.
 Set `private_subnet_ids` to the list of IDs of the private subnets in the VPC.
 Private subnets must have a route with a destination of `0.0.0.0/0` that points to a NAT gateway with a public IP address.
+If the private subnet routes are not configured correctly, you may see an error output by Terraform that looks like "No routes matching supplied arguments found in Route Table".
 
 IPv6 is not supported on VPCs that you bring.
 Those VPCs may work, but we do not verify Opta works properly with IPv6-only or dual-stack VPCs.

--- a/modules/aws_base/aws-base.yaml
+++ b/modules/aws_base/aws-base.yaml
@@ -42,6 +42,21 @@ inputs:
         "10.0.8.0/21",
         "10.0.16.0/21"
     ]
+  - name: vpc_id
+    user_facing: true
+    validator: regex(r'^vpc-([0-9a-z]{8}|[0-9a-z]{17})$', required=False)
+    description: The ID of an existing VPC to import. If not provided, Opta will create a new VPC.
+    default: null
+  - name: public_subnet_ids
+    user_facing: true
+    validator: list(regex(r'^subnet-([0-9a-z]{8}|[0-9a-z]{17})$'), min=1, required=False)
+    description: When importing an existing VPC, the IDs of the public subnets
+    default: null
+  - name: private_subnet_ids
+    user_facing: true
+    validator: list(regex(r'^subnet-([0-9a-z]{8}|[0-9a-z]{17})$'), min=2, required=False)
+    description: When importing an existing VPC, the IDs of the private subnets
+    default: null
 outputs:
   - name: kms_account_key_arn
     export: true

--- a/modules/aws_base/aws_base.py
+++ b/modules/aws_base/aws_base.py
@@ -1,0 +1,37 @@
+from typing import Final, List
+
+from modules.base import ModuleProcessor
+from opta.exceptions import UserErrors
+from opta.utils import logger
+
+# Params that are used for bring-your-own-VPC aka existing VPC.
+# Order below is used when printing the mutually required params
+_EXISTING_VPC_PARAMS: Final = ["vpc_id", "public_subnet_ids", "private_subnet_ids"]
+
+
+class AwsBaseProcessor(ModuleProcessor):
+    def process(self, module_idx: int) -> None:
+        # If any of the "bring your own VPC" params are set, validate all of them
+        for param in _EXISTING_VPC_PARAMS:
+            if param in self.module.data:
+                self.validate_existing_vpc_params(self.module.data)
+                break
+
+        super().process(module_idx)
+
+    def validate_existing_vpc_params(self, data: dict) -> None:
+        logger.debug("Validating existing VPC parameters")
+
+        missing = [param for param in _EXISTING_VPC_PARAMS if param not in data]
+        if missing:
+            param_str = ", ".join(missing)
+            raise UserErrors(
+                f"In the aws_base module, the parameters `{param_str}` are all required if any are set"
+            )
+
+        for unique_param in ["public_subnet_ids", "private_subnet_ids"]:
+            values: List[str] = data[unique_param]
+            if len(values) != len(set(values)):
+                raise UserErrors(
+                    f"In the aws_base module, the values in {unique_param} must all be unique"
+                )

--- a/modules/aws_base/tf_module/cache_subnet.tf
+++ b/modules/aws_base/tf_module/cache_subnet.tf
@@ -1,4 +1,4 @@
 resource "aws_elasticache_subnet_group" "main" {
   name       = "opta-${var.layer_name}"
-  subnet_ids = aws_subnet.private_subnets[*].id
+  subnet_ids = local.private_subnet_ids
 }

--- a/modules/aws_base/tf_module/db_subnet.tf
+++ b/modules/aws_base/tf_module/db_subnet.tf
@@ -1,6 +1,6 @@
 resource "aws_db_subnet_group" "main" {
   name       = "opta-${var.layer_name}"
-  subnet_ids = aws_subnet.private_subnets[*].id
+  subnet_ids = local.private_subnet_ids
   tags = {
     "purpose" : "postgres"
     "ignore-if-seemingly-out-of-place" : "yup"

--- a/modules/aws_base/tf_module/documentdb_subnet.tf
+++ b/modules/aws_base/tf_module/documentdb_subnet.tf
@@ -1,6 +1,6 @@
 resource "aws_docdb_subnet_group" "main" {
   name       = "opta-${var.layer_name}-docdb"
-  subnet_ids = aws_subnet.private_subnets[*].id
+  subnet_ids = local.private_subnet_ids
   tags = {
     "purpose" : "docdb"
     "ignore-if-seemingly-out-of-place" : "yup"

--- a/modules/aws_base/tf_module/existing_vpc.tf
+++ b/modules/aws_base/tf_module/existing_vpc.tf
@@ -1,0 +1,37 @@
+data "aws_vpc" "vpc" {
+  count = local.create_vpc ? 0 : 1
+  id    = var.vpc_id
+  state = "available"
+}
+
+data "aws_subnet" "public_subnets" {
+  for_each = local.create_vpc ? toset([]) : toset(var.public_subnet_ids)
+  id       = each.key
+  vpc_id   = var.vpc_id
+  # state    = "available"
+}
+
+data "aws_subnet" "private_subnets" {
+  for_each = local.create_vpc ? toset([]) : toset(var.private_subnet_ids)
+  id       = each.key
+  vpc_id   = var.vpc_id
+  # state    = "available"
+}
+
+data "aws_nat_gateway" "nat_gateways" {
+  for_each = data.aws_route.private_nat_routes
+  id       = each.value.nat_gateway_id
+  # state     = "available"
+}
+
+data "aws_route_table" "private_subnet_routes" {
+  for_each  = data.aws_subnet.private_subnets
+  subnet_id = each.value.id
+  vpc_id    = var.vpc_id
+}
+
+data "aws_route" "private_nat_routes" {
+  for_each               = data.aws_route_table.private_subnet_routes
+  route_table_id         = each.value.id
+  destination_cidr_block = "0.0.0.0/0"
+}

--- a/modules/aws_base/tf_module/existing_vpc.tf
+++ b/modules/aws_base/tf_module/existing_vpc.tf
@@ -8,20 +8,20 @@ data "aws_subnet" "public_subnets" {
   for_each = local.create_vpc ? toset([]) : toset(var.public_subnet_ids)
   id       = each.key
   vpc_id   = var.vpc_id
-  # state    = "available"
+  state    = "available"
 }
 
 data "aws_subnet" "private_subnets" {
   for_each = local.create_vpc ? toset([]) : toset(var.private_subnet_ids)
   id       = each.key
   vpc_id   = var.vpc_id
-  # state    = "available"
+  state    = "available"
 }
 
 data "aws_nat_gateway" "nat_gateways" {
   for_each = data.aws_route.private_nat_routes
   id       = each.value.nat_gateway_id
-  # state     = "available"
+  state    = "available"
 }
 
 data "aws_route_table" "private_subnet_routes" {

--- a/modules/aws_base/tf_module/locals.tf
+++ b/modules/aws_base/tf_module/locals.tf
@@ -1,0 +1,8 @@
+locals {
+  create_vpc         = var.vpc_id == null
+  vpc_id             = local.create_vpc ? aws_vpc.vpc[0].id : data.aws_vpc.vpc[0].id
+  vpc_cidr_blocks    = local.create_vpc ? [aws_vpc.vpc[0].cidr_block] : data.aws_vpc.vpc[0].cidr_block_associations[*].cidr_block
+  private_subnet_ids = local.create_vpc ? aws_subnet.private_subnets[*].id : values(data.aws_subnet.private_subnets)[*].id
+  public_subnet_ids  = local.create_vpc ? aws_subnet.public_subnets[*].id : values(data.aws_subnet.public_subnets)[*].id
+  public_nat_ips     = local.create_vpc ? aws_eip.nat_eips[*].public_ip : values(data.aws_nat_gateway.nat_gateways)[*].public_ip
+}

--- a/modules/aws_base/tf_module/outputs.tf
+++ b/modules/aws_base/tf_module/outputs.tf
@@ -11,17 +11,17 @@ output "kms_account_key_id" {
 }
 
 output "vpc_id" {
-  value = aws_vpc.vpc.id
+  value = local.vpc_id
 }
 
 output "private_subnet_ids" {
-  value = aws_subnet.private_subnets.*.id
+  value = local.private_subnet_ids
 }
 
 output "public_subnets_ids" {
-  value = aws_subnet.public_subnets.*.id
+  value = local.public_subnet_ids
 }
 
 output "public_nat_ips" {
-  value = aws_eip.nat_eips.*.public_ip
+  value = local.public_nat_ips
 }

--- a/modules/aws_base/tf_module/public_subnet.tf
+++ b/modules/aws_base/tf_module/public_subnet.tf
@@ -1,8 +1,8 @@
 resource "aws_subnet" "public_subnets" {
-  count                   = length(var.public_ipv4_cidr_blocks)
+  count                   = local.create_vpc ? length(var.public_ipv4_cidr_blocks) : 0
   cidr_block              = var.public_ipv4_cidr_blocks[count.index]
   availability_zone_id    = data.aws_availability_zones.current.zone_ids[count.index]
-  vpc_id                  = aws_vpc.vpc.id
+  vpc_id                  = local.vpc_id
   map_public_ip_on_launch = true
 
   tags = {
@@ -15,7 +15,8 @@ resource "aws_subnet" "public_subnets" {
 }
 
 resource "aws_route_table" "public_route_table" {
-  vpc_id = aws_vpc.vpc.id
+  count  = local.create_vpc ? 1 : 0
+  vpc_id = local.vpc_id
   tags = {
     Name      = "opta-${var.layer_name}-public"
     terraform = "true"
@@ -23,7 +24,9 @@ resource "aws_route_table" "public_route_table" {
 }
 
 resource "aws_internet_gateway" "igw" {
-  vpc_id = aws_vpc.vpc.id
+  count = local.create_vpc ? 1 : 0
+
+  vpc_id = local.vpc_id
 
   tags = {
     Name      = "opta-${var.layer_name}-internet-gateway"
@@ -32,14 +35,14 @@ resource "aws_internet_gateway" "igw" {
 }
 
 resource "aws_route" "igw_routes" {
-  count                  = length(var.public_ipv4_cidr_blocks)
-  route_table_id         = aws_route_table.public_route_table.id
+  count                  = local.create_vpc ? length(var.public_ipv4_cidr_blocks) : 0
+  route_table_id         = aws_route_table.public_route_table[0].id
   destination_cidr_block = "0.0.0.0/0"
-  gateway_id             = aws_internet_gateway.igw.id
+  gateway_id             = aws_internet_gateway.igw[0].id
 }
 
 resource "aws_route_table_association" "public_association" {
-  count          = length(var.public_ipv4_cidr_blocks)
-  route_table_id = aws_route_table.public_route_table.id
+  count          = local.create_vpc ? length(var.public_ipv4_cidr_blocks) : 0
+  route_table_id = aws_route_table.public_route_table[0].id
   subnet_id      = aws_subnet.public_subnets[count.index].id
 }

--- a/modules/aws_base/tf_module/security_groups.tf
+++ b/modules/aws_base/tf_module/security_groups.tf
@@ -1,14 +1,14 @@
 resource "aws_security_group" "db" {
   name        = "opta-${var.layer_name}-db-sg"
   description = "For usage by databases to give access to resources in the vpc"
-  vpc_id      = aws_vpc.vpc.id
+  vpc_id      = local.vpc_id
 
   ingress {
     description = "postgres"
     from_port   = 5432
     to_port     = 5432
     protocol    = "tcp"
-    cidr_blocks = [aws_vpc.vpc.cidr_block]
+    cidr_blocks = local.vpc_cidr_blocks
   }
 
   ingress {
@@ -16,7 +16,7 @@ resource "aws_security_group" "db" {
     from_port   = 3306
     to_port     = 3306
     protocol    = "tcp"
-    cidr_blocks = [aws_vpc.vpc.cidr_block]
+    cidr_blocks = local.vpc_cidr_blocks
   }
 
   egress {
@@ -30,14 +30,14 @@ resource "aws_security_group" "db" {
 resource "aws_security_group" "elasticache" {
   name        = "opta-${var.layer_name}-elasticache-sg"
   description = "For usage by elasticache to give access to resources in the vpc"
-  vpc_id      = aws_vpc.vpc.id
+  vpc_id      = local.vpc_id
 
   ingress {
     description = "redis"
     from_port   = 6379
     to_port     = 6379
     protocol    = "tcp"
-    cidr_blocks = [aws_vpc.vpc.cidr_block]
+    cidr_blocks = local.vpc_cidr_blocks
   }
 
   egress {
@@ -51,14 +51,14 @@ resource "aws_security_group" "elasticache" {
 resource "aws_security_group" "documentdb" {
   name        = "opta-${var.layer_name}-documentdb-sg"
   description = "For usage by documentdb to give access to resources in the vpc"
-  vpc_id      = aws_vpc.vpc.id
+  vpc_id      = local.vpc_id
 
   ingress {
     description = "documentdb"
     from_port   = 27017
     to_port     = 27017
     protocol    = "tcp"
-    cidr_blocks = [aws_vpc.vpc.cidr_block]
+    cidr_blocks = local.vpc_cidr_blocks
   }
 
   egress {

--- a/modules/aws_base/tf_module/variables.tf
+++ b/modules/aws_base/tf_module/variables.tf
@@ -47,3 +47,21 @@ variable "public_ipv4_cidr_blocks" {
     "10.0.16.0/21"
   ]
 }
+
+variable "vpc_id" {
+  description = "The ID of an pre-existing VPC to use instead of creating a new VPC for opta"
+  type        = string
+  default     = null
+}
+
+variable "public_subnet_ids" {
+  description = "List of pre-existing public subnets to use instead of creating new subnets for opta. Required when var.vpc_id is set."
+  type        = list(string)
+  default     = null
+}
+
+variable "private_subnet_ids" {
+  description = "List of pre-existing private subnets to use instead of creating new subnets for opta. Required when var.vpc_id is set."
+  type        = list(string)
+  default     = null
+}

--- a/modules/aws_base/tf_module/vpc.tf
+++ b/modules/aws_base/tf_module/vpc.tf
@@ -1,4 +1,5 @@
 resource "aws_vpc" "vpc" {
+  count                = local.create_vpc ? 1 : 0
   cidr_block           = var.total_ipv4_cidr_block
   enable_dns_hostnames = true
   enable_dns_support   = true
@@ -9,29 +10,34 @@ resource "aws_vpc" "vpc" {
 }
 
 resource "aws_default_security_group" "default" {
-  vpc_id = aws_vpc.vpc.id
+  count  = local.create_vpc ? 1 : 0
+  vpc_id = local.vpc_id
 }
 
 resource "aws_flow_log" "vpc" {
-  iam_role_arn    = aws_iam_role.vpc_flow_log.arn
-  log_destination = aws_cloudwatch_log_group.vpc_flow_log.arn
+  count           = local.create_vpc ? 1 : 0
+  iam_role_arn    = aws_iam_role.vpc_flow_log[0].arn
+  log_destination = aws_cloudwatch_log_group.vpc_flow_log[0].arn
   traffic_type    = "ALL"
-  vpc_id          = aws_vpc.vpc.id
+  vpc_id          = local.vpc_id
 }
 
 resource "random_id" "vpc_flow_log_suffix" {
+  count       = local.create_vpc ? 1 : 0
   byte_length = 8
 }
 
 resource "aws_cloudwatch_log_group" "vpc_flow_log" {
-  name              = "opta-${var.env_name}-vpc-flow-${random_id.vpc_flow_log_suffix.hex}"
+  count             = local.create_vpc ? 1 : 0
+  name              = "opta-${var.env_name}-vpc-flow-${random_id.vpc_flow_log_suffix[0].hex}"
   kms_key_id        = aws_kms_key.key.arn
   retention_in_days = var.vpc_log_retention
   lifecycle { ignore_changes = [name] }
 }
 
 resource "aws_iam_role" "vpc_flow_log" {
-  name = "opta-${var.env_name}-vpc-flow"
+  count = local.create_vpc ? 1 : 0
+  name  = "opta-${var.env_name}-vpc-flow"
 
   assume_role_policy = <<EOF
 {
@@ -51,8 +57,9 @@ EOF
 }
 
 resource "aws_iam_role_policy" "vpc_flow_log" {
-  name = "opta-${var.env_name}-vpc-flow"
-  role = aws_iam_role.vpc_flow_log.id
+  count = local.create_vpc ? 1 : 0
+  name  = "opta-${var.env_name}-vpc-flow"
+  role  = aws_iam_role.vpc_flow_log[0].id
 
   policy = <<EOF
 {

--- a/modules/config.rego
+++ b/modules/config.rego
@@ -65,6 +65,12 @@ waivers[waiver] {
     "rule_id": "FG_R00101",
     "resource_id": "aws_s3_bucket.bucket"
   }
+} {
+  waiver := {
+    # TODO: Remove this waiver once we upgrade to a rego version that properly handles `count`
+    "rule_id": "FG_R00054",
+    "resource_id": "aws_vpc.vpc"
+  }
 }
 
 rules[rule] {

--- a/modules/tests/test_aws_base.py
+++ b/modules/tests/test_aws_base.py
@@ -1,0 +1,88 @@
+from typing import Any, Dict, Final, List
+
+import pytest
+from pytest_mock import MockFixture
+
+from modules.aws_base.aws_base import AwsBaseProcessor
+from opta.exceptions import UserErrors
+
+_MODULE_PATH: Final = "modules.aws_base.aws_base"
+_DEBUG_PATH: Final = _MODULE_PATH + ".logger.debug"
+
+
+class TestAwsBaseProcessor:
+    def test_validate_existing_vpc_params(
+        self,
+        mocker: MockFixture,
+        processor: AwsBaseProcessor,
+        existing_vpc_config: Dict[str, Any],
+    ) -> None:
+        mock_debug = mocker.patch(_DEBUG_PATH)
+
+        processor.validate_existing_vpc_params(existing_vpc_config)
+        mock_debug.assert_called_once()
+
+    @pytest.mark.parametrize(
+        "missing",
+        [
+            ["vpc_id"],
+            ["public_subnet_ids"],
+            ["private_subnet_ids"],
+            ["public_subnet_ids", "private_subnet_ids"],
+        ],
+    )
+    def test_validate_existing_vpc_params_missing(
+        self,
+        mocker: MockFixture,
+        processor: AwsBaseProcessor,
+        existing_vpc_config: Dict[str, Any],
+        missing: List[str],
+    ) -> None:
+        mock_debug = mocker.patch(_DEBUG_PATH)
+
+        for key in missing:
+            del existing_vpc_config[key]
+
+        with pytest.raises(UserErrors) as e:
+            processor.validate_existing_vpc_params(existing_vpc_config)
+
+        mock_debug.assert_called_once()
+
+        expected_message = f"In the aws_base module, the parameters `{', '.join(missing)}` are all required if any are set"
+        assert str(e.value) == expected_message
+
+    @pytest.mark.parametrize("duplicate", ["public_subnet_ids", "private_subnet_ids"])
+    def test_validate_existing_vpc_params_nonunique(
+        self,
+        mocker: MockFixture,
+        processor: AwsBaseProcessor,
+        existing_vpc_config: Dict[str, Any],
+        duplicate: str,
+    ) -> None:
+        mock_debug = mocker.patch(_DEBUG_PATH)
+
+        # Make all the values in the key equal to the first value
+        values: List[str] = existing_vpc_config[duplicate]
+        existing_vpc_config[duplicate] = [values[0] for _ in values]
+
+        with pytest.raises(UserErrors) as e:
+            processor.validate_existing_vpc_params(existing_vpc_config)
+
+        mock_debug.assert_called_once()
+
+        expected_message = (
+            f"In the aws_base module, the values in {duplicate} must all be unique"
+        )
+        assert str(e.value) == expected_message
+
+    @pytest.fixture
+    def processor(self) -> AwsBaseProcessor:
+        return AwsBaseProcessor(None, None)  # typing: ignore
+
+    @pytest.fixture
+    def existing_vpc_config(self) -> Dict[str, Any]:
+        return {
+            "vpc_id": "vpc-123",
+            "public_subnet_ids": ["subnet-abc", "subnet-def"],
+            "private_subnet_ids": ["subnet-uvw", "subnet-xyz"],
+        }

--- a/opta/layer.py
+++ b/opta/layer.py
@@ -47,6 +47,7 @@ from opta.utils import (
 from opta.utils.dependencies import ensure_installed, validate_installed_path_executables
 
 PROCESSOR_DICT: Dict[str, str] = {
+    "aws-base": "AwsBaseProcessor",
     "aws-k8s-service": "AwsK8sServiceProcessor",
     "aws-k8s-base": "AwsK8sBaseProcessor",
     "datadog": "DatadogProcessor",

--- a/tests/fixtures/basic_apply.py
+++ b/tests/fixtures/basic_apply.py
@@ -37,6 +37,9 @@ BASIC_APPLY = (
                 "public_ipv4_cidr_blocks": ["10.0.0.0/21", "10.0.8.0/21", "10.0.16.0/21"],
                 "total_ipv4_cidr_block": "10.0.0.0/16",
                 "vpc_log_retention": 90,
+                "vpc_id": None,
+                "public_subnet_ids": None,
+                "private_subnet_ids": None,
             }
         },
         "output": {


### PR DESCRIPTION
# Description
- Add vpc_id, public_subnet_ids, and private_subnet_ids fields to aws-base
- When set, will not create our own VPC but instead use the one provided
- Does not set up flow logs when using an existing VPC

# Safety checklist
* [X] This change is backwards compatible and safe to apply by existing users
* [X] This change will NOT lead to data loss
* [X] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
- No change in terraform plan when using this code vs `main` branch when not using BYO-VPC.
- Manually created a VPC in the AWS console and tested using that VPC, verified that VPC was used when creating an EKS cluster via opta
