### PR TITLE
Fix the Opta CI failures 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1459,6 +1459,14 @@ jobs:
                 command: docker load -i test-service-image
                 name: Load test-service image
             - run:
+                command: echo 'export KUBECONFIG="$HOME/kube_config.yaml"' >> $BASH_ENV
+                name: Update KUBECONFIG
+            - run:
+                command: |
+                    ./dist/opta/opta configure-kubectl \
+                    --config ./.circleci/ci-tests/create-and-destroy-gcp/environment.yml
+                name: Configure Kubectl
+            - run:
                 command: |
                     ./dist/opta/opta deploy \
                     --image app:latest \
@@ -1529,6 +1537,14 @@ jobs:
             - run:
                 command: docker load -i test-service-image
                 name: Load test-service image
+            - run:
+                command: echo 'export KUBECONFIG="$HOME/kube_config.yaml"' >> $BASH_ENV
+                name: Update KUBECONFIG
+            - run:
+                command: |
+                    ./dist/opta/opta configure-kubectl \
+                    --config ./.circleci/ci-tests/create-and-destroy-gcp/environment.yml
+                name: Configure Kubectl
             - run:
                 command: |
                     ./dist/opta/opta secret update \
@@ -1704,6 +1720,16 @@ jobs:
             - run:
                 command: docker load -i test-service-image
                 name: Load test-service image
+            - run:
+                command: |
+                    echo 'export KUBECONFIG="$HOME/kube_config.yaml"' >> $BASH_ENV
+                    echo $KUBECONFIG
+                name: Update KUBECONFIG
+            - run:
+                command: |
+                    ./dist/opta/opta configure-kubectl \
+                    --config ./.circleci/ci-tests/create-and-destroy-gcp/environment.yml
+                name: Configure Kubectl
             - run:
                 command: |
                     ./dist/opta/opta deploy \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -567,6 +567,11 @@ jobs:
                 name: Load test-service image
             - run:
                 command: |
+                    ./dist/opta/opta configure-kubectl \
+                    --config ./.circleci/ci-tests/create-and-destroy-aws/environment.yml
+                name: Configure Kubectl
+            - run:
+                command: |
                     ./dist/opta/opta deploy \
                     --image app:latest \
                     --env awsenv-ci \
@@ -630,6 +635,11 @@ jobs:
             - run:
                 command: docker load -i test-service-image
                 name: Load test-service image
+            - run:
+                command: |
+                    ./dist/opta/opta configure-kubectl \
+                    --config ./.circleci/ci-tests/create-and-destroy-aws/environment.yml
+                name: Configure Kubectl
             - run:
                 command: |
                     ./dist/opta/opta secret update \
@@ -730,6 +740,11 @@ jobs:
                 name: Load test-service image
             - run:
                 command: |
+                    ./dist/opta/opta configure-kubectl \
+                    --config ./.circleci/ci-tests/create-and-destroy-aws/environment.yml
+                name: Configure Kubectl
+            - run:
+                command: |
                     ./dist/opta/opta deploy \
                     --image app:latest \
                     --env awsenv-ci \
@@ -765,6 +780,11 @@ jobs:
                 name: Load test-service image
             - run:
                 command: |
+                    ./dist/opta/opta configure-kubectl \
+                    --config ./.circleci/ci-tests/create-and-destroy-aws/environment.yml
+                name: Configure Kubectl
+            - run:
+                command: |
                     ./dist/opta/opta deploy \
                     --image app:latest \
                     --env awsenv-ci \
@@ -795,6 +815,11 @@ jobs:
             - install-opta-dependencies
             - aws-cli/install
             - aws-cli/setup
+            - run:
+                command: |
+                    ./dist/opta/opta configure-kubectl \
+                    --config ./.circleci/ci-tests/create-and-destroy-aws/environment.yml
+                name: Configure Kubectl
             - run:
                 command: |
                     OPTA_DISABLE_REPORTING=true ./dist/opta/opta apply \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,9 +107,6 @@ jobs:
                     --refresh
                 name: Deploy opta environment
             - run:
-                command: echo 'export KUBECONFIG="$HOME/kube_config.yaml"' >> $BASH_ENV
-                name: Update KUBECONFIG
-            - run:
                 command: |-
                     ./dist/opta/opta configure-kubectl \
                     --config ./.circleci/ci-tests/create-and-destroy-aws/environment.yml
@@ -340,6 +337,11 @@ jobs:
                 name: Load Opta Example images
             - run:
                 command: |
+                    ./dist/opta/opta configure-kubectl \
+                    --config ./.circleci/ci-tests/create-and-destroy-aws/environment.yml
+                name: Configure Kubectl
+            - run:
+                command: |
                     ./dist/opta/opta deploy \
                     --image todo-api:v1 \
                     --config ./.circleci/ci-tests/todo-list/api-service.yml \
@@ -384,6 +386,11 @@ jobs:
             - install-opta-dependencies
             - aws-cli/install
             - aws-cli/setup
+            - run:
+                command: |
+                    ./dist/opta/opta configure-kubectl \
+                    --config ./.circleci/ci-tests/create-and-destroy-aws/environment.yml
+                name: Configure Kubectl
             - run:
                 command: |
                     yes | ./dist/opta/opta destroy \
@@ -483,9 +490,6 @@ jobs:
             - aws-cli/install
             - aws-cli/setup
             - run:
-                command: echo 'export KUBECONFIG="$HOME/kube_config.yaml"' >> $BASH_ENV
-                name: Update KUBECONFIG
-            - run:
                 command: |
                     ./dist/opta/opta configure-kubectl \
                     --config ./.circleci/ci-tests/create-and-destroy-aws/environment.yml
@@ -578,7 +582,7 @@ jobs:
                     --config ./.circleci/ci-tests/create-and-destroy-aws/service-docdb.yml \
                     --tag $CIRCLE_SHA1 \
                     --auto-approve
-                name: Deploy test-service-redis
+                name: Deploy test-service-docdb
             - run:
                 command: |-
                     yes | ./dist/opta/opta destroy \
@@ -859,6 +863,11 @@ jobs:
             - install-opta-dependencies
             - aws-cli/install
             - aws-cli/setup
+            - run:
+                command: |
+                    $HOME/.opta/opta configure-kubectl \
+                    --config ./.circleci/ci-tests/create-and-destroy-aws/environment.yml
+                name: Configure Kubectl
             - run:
                 command: |
                     yes | $HOME/.opta/opta apply \
@@ -1202,9 +1211,6 @@ jobs:
                     --refresh
                 name: Deploy opta environment
             - run:
-                command: echo 'export KUBECONFIG="$HOME/kube_config.yaml"' >> $BASH_ENV
-                name: Update KUBECONFIG
-            - run:
                 command: |-
                     ./dist/opta/opta configure-kubectl \
                     --config ./.circleci/ci-tests/create-and-destroy-gcp/environment.yml
@@ -1317,6 +1323,11 @@ jobs:
                 name: Load Opta Example images
             - run:
                 command: |
+                    ./dist/opta/opta configure-kubectl \
+                    --config ./.circleci/ci-tests/create-and-destroy-gcp/environment.yml
+                name: Configure Kubectl
+            - run:
+                command: |
                     ./dist/opta/opta deploy \
                     --image todo-api:v1 \
                     --config ./.circleci/ci-tests/todo-list/api-service.yml \
@@ -1365,6 +1376,11 @@ jobs:
             - run:
                 command: echo 'export GOOGLE_APPLICATION_CREDENTIALS="/home/circleci/gcloud-service-key.json"' >> $BASH_ENV
                 name: Setting up GCP Credentials
+            - run:
+                command: |
+                    ./dist/opta/opta configure-kubectl \
+                    --config ./.circleci/ci-tests/create-and-destroy-gcp/environment.yml
+                name: Configure Kubectl
             - run:
                 command: |
                     yes | ./dist/opta/opta destroy \
@@ -1435,9 +1451,6 @@ jobs:
                 command: echo 'export GOOGLE_APPLICATION_CREDENTIALS="/home/circleci/gcloud-service-key.json"' >> $BASH_ENV
                 name: Setting up gcp envar
             - run:
-                command: echo 'export KUBECONFIG="$HOME/kube_config.yaml"' >> $BASH_ENV
-                name: Update KUBECONFIG
-            - run:
                 command: |
                     ./dist/opta/opta configure-kubectl \
                     --config ./.circleci/ci-tests/create-and-destroy-gcp/environment.yml
@@ -1483,9 +1496,6 @@ jobs:
             - run:
                 command: docker load -i test-service-image
                 name: Load test-service image
-            - run:
-                command: echo 'export KUBECONFIG="$HOME/kube_config.yaml"' >> $BASH_ENV
-                name: Update KUBECONFIG
             - run:
                 command: |
                     ./dist/opta/opta configure-kubectl \
@@ -1562,9 +1572,6 @@ jobs:
             - run:
                 command: docker load -i test-service-image
                 name: Load test-service image
-            - run:
-                command: echo 'export KUBECONFIG="$HOME/kube_config.yaml"' >> $BASH_ENV
-                name: Update KUBECONFIG
             - run:
                 command: |
                     ./dist/opta/opta configure-kubectl \
@@ -1675,6 +1682,11 @@ jobs:
                 name: Load test-service image
             - run:
                 command: |
+                    $HOME/.opta/opta configure-kubectl \
+                    --config ./.circleci/ci-tests/create-and-destroy-gcp/environment.yml
+                name: Configure Kubectl
+            - run:
+                command: |
                     yes | $HOME/.opta/opta secret update \
                     --env gcpenv-ci \
                     --config ./.circleci/ci-tests/create-and-destroy-gcp/service-pg.yml \
@@ -1745,11 +1757,6 @@ jobs:
             - run:
                 command: docker load -i test-service-image
                 name: Load test-service image
-            - run:
-                command: |
-                    echo 'export KUBECONFIG="$HOME/kube_config.yaml"' >> $BASH_ENV
-                    echo $KUBECONFIG
-                name: Update KUBECONFIG
             - run:
                 command: |
                     ./dist/opta/opta configure-kubectl \

--- a/.circleci/src/jobs/aws-create-env.yaml
+++ b/.circleci/src/jobs/aws-create-env.yaml
@@ -20,9 +20,6 @@ steps:
         --auto-approve \
         --refresh
   - run:
-      name: "Update KUBECONFIG"
-      command: echo 'export KUBECONFIG="$HOME/kube_config.yaml"' >> $BASH_ENV
-  - run:
       name: "Configure Kubectl"
       command: |
         ./dist/opta/opta configure-kubectl \

--- a/.circleci/src/jobs/aws-opta-example-create-svcs.yaml
+++ b/.circleci/src/jobs/aws-opta-example-create-svcs.yaml
@@ -19,6 +19,11 @@ steps:
         docker load -i todo-api
         docker load -i todo-frontend
   - run:
+      name: "Configure Kubectl"
+      command: |
+        ./dist/opta/opta configure-kubectl \
+        --config ./.circleci/ci-tests/create-and-destroy-aws/environment.yml
+  - run:
       name: "Deploy Todo-Api Service"
       command: |
         ./dist/opta/opta deploy \

--- a/.circleci/src/jobs/aws-opta-example-destroy-svcs.yaml
+++ b/.circleci/src/jobs/aws-opta-example-destroy-svcs.yaml
@@ -13,6 +13,11 @@ steps:
   - aws-cli/install
   - aws-cli/setup
   - run:
+      name: "Configure Kubectl"
+      command: |
+        ./dist/opta/opta configure-kubectl \
+        --config ./.circleci/ci-tests/create-and-destroy-aws/environment.yml
+  - run:
       name: "Destroy Monitoring Service"
       command: |
         yes | ./dist/opta/opta destroy \

--- a/.circleci/src/jobs/aws-test-k8s-manifest.yaml
+++ b/.circleci/src/jobs/aws-test-k8s-manifest.yaml
@@ -13,9 +13,6 @@ steps:
   - aws-cli/install
   - aws-cli/setup
   - run:
-      name: "Update KUBECONFIG"
-      command: echo 'export KUBECONFIG="$HOME/kube_config.yaml"' >> $BASH_ENV
-  - run:
       name: "Configure Kubectl"
       command: |
         ./dist/opta/opta configure-kubectl \

--- a/.circleci/src/jobs/aws-test-service-docdb.yaml
+++ b/.circleci/src/jobs/aws-test-service-docdb.yaml
@@ -22,7 +22,7 @@ steps:
         ./dist/opta/opta configure-kubectl \
         --config ./.circleci/ci-tests/create-and-destroy-aws/environment.yml
   - run:
-      name: "Deploy test-service-redis"
+      name: "Deploy test-service-docdb"
       command: |
         ./dist/opta/opta deploy \
         --image app:latest \

--- a/.circleci/src/jobs/aws-test-service-docdb.yaml
+++ b/.circleci/src/jobs/aws-test-service-docdb.yaml
@@ -17,6 +17,11 @@ steps:
       name: "Load test-service image"
       command: docker load -i test-service-image
   - run:
+      name: "Configure Kubectl"
+      command: |
+        ./dist/opta/opta configure-kubectl \
+        --config ./.circleci/ci-tests/create-and-destroy-aws/environment.yml
+  - run:
       name: "Deploy test-service-redis"
       command: |
         ./dist/opta/opta deploy \

--- a/.circleci/src/jobs/aws-test-service-pg.yaml
+++ b/.circleci/src/jobs/aws-test-service-pg.yaml
@@ -18,6 +18,11 @@ steps:
       name: "Load test-service image"
       command: docker load -i test-service-image
   - run:
+      name: "Configure Kubectl"
+      command: |
+        ./dist/opta/opta configure-kubectl \
+        --config ./.circleci/ci-tests/create-and-destroy-aws/environment.yml
+  - run:
       name: "Set secret"
       command: |
         ./dist/opta/opta secret update \

--- a/.circleci/src/jobs/aws-test-service-redis.yaml
+++ b/.circleci/src/jobs/aws-test-service-redis.yaml
@@ -17,6 +17,11 @@ steps:
       name: "Load test-service image"
       command: docker load -i test-service-image
   - run:
+      name: "Configure Kubectl"
+      command: |
+        ./dist/opta/opta configure-kubectl \
+        --config ./.circleci/ci-tests/create-and-destroy-aws/environment.yml
+  - run:
       name: "Deploy test-service-redis"
       command: |
         ./dist/opta/opta deploy \

--- a/.circleci/src/jobs/aws-test-service-s3.yaml
+++ b/.circleci/src/jobs/aws-test-service-s3.yaml
@@ -17,6 +17,11 @@ steps:
       name: "Load test-service image"
       command: docker load -i test-service-image
   - run:
+      name: "Configure Kubectl"
+      command: |
+        ./dist/opta/opta configure-kubectl \
+        --config ./.circleci/ci-tests/create-and-destroy-aws/environment.yml
+  - run:
       name: "Deploy test-service-s3"
       command: |
         ./dist/opta/opta deploy \

--- a/.circleci/src/jobs/aws-test-websocket-stable-version.yaml
+++ b/.circleci/src/jobs/aws-test-websocket-stable-version.yaml
@@ -14,6 +14,11 @@ steps:
   - aws-cli/install
   - aws-cli/setup
   - run:
+      name: "Configure Kubectl"
+      command: |
+        $HOME/.opta/opta configure-kubectl \
+        --config ./.circleci/ci-tests/create-and-destroy-aws/environment.yml
+  - run:
       name: "Apply Websocket Service with Stable Opta"
       command: |
         yes | $HOME/.opta/opta apply \

--- a/.circleci/src/jobs/aws-test-websocket.yaml
+++ b/.circleci/src/jobs/aws-test-websocket.yaml
@@ -14,6 +14,11 @@ steps:
   - aws-cli/install
   - aws-cli/setup
   - run:
+      name: "Configure Kubectl"
+      command: |
+        ./dist/opta/opta configure-kubectl \
+        --config ./.circleci/ci-tests/create-and-destroy-aws/environment.yml
+  - run:
       name: "Apply Websocket Service with Opta"
       command: |
         OPTA_DISABLE_REPORTING=true ./dist/opta/opta apply \

--- a/.circleci/src/jobs/gcp-create-env.yaml
+++ b/.circleci/src/jobs/gcp-create-env.yaml
@@ -23,9 +23,6 @@ steps:
         --auto-approve \
         --refresh
   - run:
-      name: "Update KUBECONFIG"
-      command: echo 'export KUBECONFIG="$HOME/kube_config.yaml"' >> $BASH_ENV
-  - run:
       name: "Configure Kubectl"
       command: |
         ./dist/opta/opta configure-kubectl \

--- a/.circleci/src/jobs/gcp-opta-example-create-svcs.yaml
+++ b/.circleci/src/jobs/gcp-opta-example-create-svcs.yaml
@@ -22,6 +22,11 @@ steps:
         docker load -i todo-api
         docker load -i todo-frontend
   - run:
+      name: "Configure Kubectl"
+      command: |
+        ./dist/opta/opta configure-kubectl \
+        --config ./.circleci/ci-tests/create-and-destroy-gcp/environment.yml
+  - run:
       name: "Deploy Todo-Api Service"
       command: |
         ./dist/opta/opta deploy \

--- a/.circleci/src/jobs/gcp-opta-example-destroy-svcs.yaml
+++ b/.circleci/src/jobs/gcp-opta-example-destroy-svcs.yaml
@@ -17,6 +17,11 @@ steps:
       name: "Setting up GCP Credentials"
       command: echo 'export GOOGLE_APPLICATION_CREDENTIALS="/home/circleci/gcloud-service-key.json"' >> $BASH_ENV
   - run:
+      name: "Configure Kubectl"
+      command: |
+        ./dist/opta/opta configure-kubectl \
+        --config ./.circleci/ci-tests/create-and-destroy-gcp/environment.yml
+  - run:
       name: "Destroy Monitoring Service"
       command: |
         yes | ./dist/opta/opta destroy \

--- a/.circleci/src/jobs/gcp-test-k8s-manifest.yaml
+++ b/.circleci/src/jobs/gcp-test-k8s-manifest.yaml
@@ -16,9 +16,6 @@ steps:
       name: "Setting up gcp envar"
       command: echo 'export GOOGLE_APPLICATION_CREDENTIALS="/home/circleci/gcloud-service-key.json"' >> $BASH_ENV
   - run:
-      name: "Update KUBECONFIG"
-      command: echo 'export KUBECONFIG="$HOME/kube_config.yaml"' >> $BASH_ENV
-  - run:
       name: "Configure Kubectl"
       command: |
         ./dist/opta/opta configure-kubectl \

--- a/.circleci/src/jobs/gcp-test-service-gcs.yaml
+++ b/.circleci/src/jobs/gcp-test-service-gcs.yaml
@@ -20,6 +20,14 @@ steps:
       name: "Load test-service image"
       command: docker load -i test-service-image
   - run:
+      name: "Update KUBECONFIG"
+      command: echo 'export KUBECONFIG="$HOME/kube_config.yaml"' >> $BASH_ENV
+  - run:
+      name: "Configure Kubectl"
+      command: |
+        ./dist/opta/opta configure-kubectl \
+        --config ./.circleci/ci-tests/create-and-destroy-gcp/environment.yml
+  - run:
       name: "Deploy test-service-gcs"
       command: |
         ./dist/opta/opta deploy \

--- a/.circleci/src/jobs/gcp-test-service-gcs.yaml
+++ b/.circleci/src/jobs/gcp-test-service-gcs.yaml
@@ -20,9 +20,6 @@ steps:
       name: "Load test-service image"
       command: docker load -i test-service-image
   - run:
-      name: "Update KUBECONFIG"
-      command: echo 'export KUBECONFIG="$HOME/kube_config.yaml"' >> $BASH_ENV
-  - run:
       name: "Configure Kubectl"
       command: |
         ./dist/opta/opta configure-kubectl \

--- a/.circleci/src/jobs/gcp-test-service-pg-latest-version.yaml
+++ b/.circleci/src/jobs/gcp-test-service-pg-latest-version.yaml
@@ -22,6 +22,11 @@ steps:
       name: "Load test-service image"
       command: docker load -i test-service-image
   - run:
+      name: "Configure Kubectl"
+      command: |
+        $HOME/.opta/opta configure-kubectl \
+        --config ./.circleci/ci-tests/create-and-destroy-gcp/environment.yml
+  - run:
       name: "Set secret"
       command: |
         yes | $HOME/.opta/opta secret update \

--- a/.circleci/src/jobs/gcp-test-service-pg.yaml
+++ b/.circleci/src/jobs/gcp-test-service-pg.yaml
@@ -21,6 +21,14 @@ steps:
       name: "Load test-service image"
       command: docker load -i test-service-image
   - run:
+      name: "Update KUBECONFIG"
+      command: echo 'export KUBECONFIG="$HOME/kube_config.yaml"' >> $BASH_ENV
+  - run:
+      name: "Configure Kubectl"
+      command: |
+        ./dist/opta/opta configure-kubectl \
+        --config ./.circleci/ci-tests/create-and-destroy-gcp/environment.yml
+  - run:
       name: "Set secret"
       command: |
         ./dist/opta/opta secret update \

--- a/.circleci/src/jobs/gcp-test-service-pg.yaml
+++ b/.circleci/src/jobs/gcp-test-service-pg.yaml
@@ -21,9 +21,6 @@ steps:
       name: "Load test-service image"
       command: docker load -i test-service-image
   - run:
-      name: "Update KUBECONFIG"
-      command: echo 'export KUBECONFIG="$HOME/kube_config.yaml"' >> $BASH_ENV
-  - run:
       name: "Configure Kubectl"
       command: |
         ./dist/opta/opta configure-kubectl \

--- a/.circleci/src/jobs/gcp-test-service-redis.yaml
+++ b/.circleci/src/jobs/gcp-test-service-redis.yaml
@@ -20,6 +20,16 @@ steps:
       name: "Load test-service image"
       command: docker load -i test-service-image
   - run:
+      name: "Update KUBECONFIG"
+      command: |
+        echo 'export KUBECONFIG="$HOME/kube_config.yaml"' >> $BASH_ENV
+        echo $KUBECONFIG
+  - run:
+      name: "Configure Kubectl"
+      command: |
+        ./dist/opta/opta configure-kubectl \
+        --config ./.circleci/ci-tests/create-and-destroy-gcp/environment.yml
+  - run:
       name: "Deploy test-service-redis"
       command: |
         ./dist/opta/opta deploy \

--- a/.circleci/src/jobs/gcp-test-service-redis.yaml
+++ b/.circleci/src/jobs/gcp-test-service-redis.yaml
@@ -20,11 +20,6 @@ steps:
       name: "Load test-service image"
       command: docker load -i test-service-image
   - run:
-      name: "Update KUBECONFIG"
-      command: |
-        echo 'export KUBECONFIG="$HOME/kube_config.yaml"' >> $BASH_ENV
-        echo $KUBECONFIG
-  - run:
       name: "Configure Kubectl"
       command: |
         ./dist/opta/opta configure-kubectl \


### PR DESCRIPTION
# Description
Fixing the Opta CI failures which are occurring due to Cluster authorizations.

# Safety checklist
* [x] This change is backwards compatible and safe to apply by existing users
* [x] This change will NOT lead to data loss
* [x] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
CI run: [run-create-and-destroy](https://app.circleci.com/pipelines/github/run-x/opta/2041/workflows/cf7c9005-fee7-4384-ac16-d541e022f6fb)
