### PR TITLE
Make Linkerd Certs Terraform sensitive

### DIFF
--- a/modules/aws_k8s_base/tf_module/linkerd.tf
+++ b/modules/aws_k8s_base/tf_module/linkerd.tf
@@ -61,36 +61,37 @@ resource "helm_release" "linkerd" {
   repository = "https://helm.linkerd.io/stable"
   version    = "2.10.2" // NOTE: Check https://linkerd.io/2.11/tasks/using-ingress/#nginx whenever we update linkerd
 
+  set_sensitive {
+    name  = "identityTrustAnchorsPEM"
+    value = tls_self_signed_cert.trustanchor_cert.cert_pem
+
+  }
+
+  set_sensitive {
+    name  = "identity.issuer.tls.crtPEM"
+    value = tls_locally_signed_cert.issuer_cert.cert_pem
+  }
+
+  set_sensitive {
+    name  = "identity.issuer.tls.keyPEM"
+    value = tls_private_key.issuer_key.private_key_pem
+  }
+
+  set {
+    name  = "identity.issuer.crtExpiry"
+    value = tls_locally_signed_cert.issuer_cert.validity_end_time
+  }
+
   values = var.linkerd_high_availability ? [
     file("${path.module}/values-ha.yaml"), # Adding the high-availability default values.
     yamlencode({
       podAnnotations : {
         "cluster-autoscaler.kubernetes.io/safe-to-evict" : "true"
       }
-      identityTrustAnchorsPEM : tls_self_signed_cert.trustanchor_cert.cert_pem
-      identity : {
-        issuer : {
-          crtExpiry : tls_locally_signed_cert.issuer_cert.validity_end_time
-          tls : {
-            crtPEM : tls_locally_signed_cert.issuer_cert.cert_pem
-            keyPEM : tls_private_key.issuer_key.private_key_pem
-          }
-        }
-      }
     }), yamlencode(var.linkerd_values)
     ] : [yamlencode({
       podAnnotations : {
         "cluster-autoscaler.kubernetes.io/safe-to-evict" : "true"
-      }
-      identityTrustAnchorsPEM : tls_self_signed_cert.trustanchor_cert.cert_pem
-      identity : {
-        issuer : {
-          crtExpiry : tls_locally_signed_cert.issuer_cert.validity_end_time
-          tls : {
-            crtPEM : tls_locally_signed_cert.issuer_cert.cert_pem
-            keyPEM : tls_private_key.issuer_key.private_key_pem
-          }
-        }
       }
   }), yamlencode(var.linkerd_values)]
 }

--- a/modules/azure_k8s_base/tf_module/linkerd.tf
+++ b/modules/azure_k8s_base/tf_module/linkerd.tf
@@ -61,7 +61,7 @@ resource "helm_release" "linkerd" {
   repository = "https://helm.linkerd.io/stable"
   version    = "2.10.2"
 
-  set {
+  set_sensitive {
     name  = "identityTrustAnchorsPEM"
     value = tls_self_signed_cert.trustanchor_cert.cert_pem
   }
@@ -71,12 +71,12 @@ resource "helm_release" "linkerd" {
     value = tls_locally_signed_cert.issuer_cert.validity_end_time
   }
 
-  set {
+  set_sensitive {
     name  = "identity.issuer.tls.crtPEM"
     value = tls_locally_signed_cert.issuer_cert.cert_pem
   }
 
-  set {
+  set_sensitive {
     name  = "identity.issuer.tls.keyPEM"
     value = tls_private_key.issuer_key.private_key_pem
   }

--- a/modules/gcp_k8s_base/tf_module/linkerd.tf
+++ b/modules/gcp_k8s_base/tf_module/linkerd.tf
@@ -61,36 +61,37 @@ resource "helm_release" "linkerd" {
   repository = "https://helm.linkerd.io/stable"
   version    = "2.10.2"
 
+  set_sensitive {
+    name  = "identityTrustAnchorsPEM"
+    value = tls_self_signed_cert.trustanchor_cert.cert_pem
+
+  }
+
+  set_sensitive {
+    name  = "identity.issuer.tls.crtPEM"
+    value = tls_locally_signed_cert.issuer_cert.cert_pem
+  }
+
+  set_sensitive {
+    name  = "identity.issuer.tls.keyPEM"
+    value = tls_private_key.issuer_key.private_key_pem
+  }
+
+  set {
+    name  = "identity.issuer.crtExpiry"
+    value = tls_locally_signed_cert.issuer_cert.validity_end_time
+  }
+
   values = var.linkerd_high_availability ? [
     file("${path.module}/values-ha.yaml"), # Adding the high-availability default values.
     yamlencode({
       podAnnotations : {
         "cluster-autoscaler.kubernetes.io/safe-to-evict" : "true"
       }
-      identityTrustAnchorsPEM : tls_self_signed_cert.trustanchor_cert.cert_pem
-      identity : {
-        issuer : {
-          crtExpiry : tls_locally_signed_cert.issuer_cert.validity_end_time
-          tls : {
-            crtPEM : tls_locally_signed_cert.issuer_cert.cert_pem
-            keyPEM : tls_private_key.issuer_key.private_key_pem
-          }
-        }
-      }
     }), yamlencode(var.linkerd_values)
     ] : [yamlencode({
       podAnnotations : {
         "cluster-autoscaler.kubernetes.io/safe-to-evict" : "true"
-      }
-      identityTrustAnchorsPEM : tls_self_signed_cert.trustanchor_cert.cert_pem
-      identity : {
-        issuer : {
-          crtExpiry : tls_locally_signed_cert.issuer_cert.validity_end_time
-          tls : {
-            crtPEM : tls_locally_signed_cert.issuer_cert.cert_pem
-            keyPEM : tls_private_key.issuer_key.private_key_pem
-          }
-        }
       }
   }), yamlencode(var.linkerd_values)]
 }


### PR DESCRIPTION
# Description
Mark the Certificates generated during Linkerd Setup as Terraform sensitive so that they don't show up in the plan

# Safety checklist
* [x] This change is backwards compatible and safe to apply by existing users
* [x] This change will NOT lead to data loss
* [x] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
TODO