### PR TITLE
How to configure EKS for Opta

### DIFF
--- a/examples/byo-eks/README.md
+++ b/examples/byo-eks/README.md
@@ -1,0 +1,111 @@
+# Bring Your Own Cluster
+
+This is an example of using [Opta](https://github.com/run-x/opta) with an existing EKS cluster.
+
+# What does this do?
+
+If you already have an EKS cluster, and would like to try out Opta, follow these instructions to configure your cluster to work with Opta.
+
+If you don't have an EKS cluster, Opta can also create it, check [Getting Started](https://docs.opta.dev/getting-started/) instead.
+
+# What is included?
+
+By running terraform on an existing EKS cluster, your cluster will be configured to have the target [Network Architecture](https://docs.opta.dev/features/networking/network_overview/).
+
+The following components will be installed:
+
+- [Ingress Nginx](https://github.com/kubernetes/ingress-nginx) to expose services to the public
+- [Linkerd](https://linkerd.io/) as the service mesh.
+- [AWS Load Balancer Controller](https://kubernetes-sigs.github.io/aws-load-balancer-controller/) to manage the ELB for the Kubernetes cluster.
+
+Here is the break down of the terraform files:
+
+    .
+    └── terraform
+        ├──aws-lb-iam-policy.json            # The IAM policy for the load balancer
+        └──aws-load-balancer-controller.tf   # Create IAM role and install the AWS Load Balancer Controller
+        └──data.tf                           # Data fetched from providers
+        └──ingress-nginx.tf                  # Install the Nginx Ingres Controller
+        └──linkerd.tf                        # Install Linkerd
+        └──outputs.tf                        # Terraform outputs
+        └──providers.tf                      # Terraform providers
+        └──variables.tf                      # Terraform variables
+
+# Requirements
+
+To configure the cluster (this guide), you need to use an AWS user with permissions to create AWS policies and roles, and admin permission on the target EKS cluster.
+
+# Configure the cluster for Opta
+
+This step configures the networking stack (nginx/linkerd/load balancer) on an existing EKS cluster.
+
+- Init terraform
+```shell
+cd ./terraform
+terraform init
+```
+
+- [Optional] Configure a Terraform backend. By default, Terraform stores the state as a local file on disk. If you want to use a different backend such as S3, add this file locally.
+```terraform
+# ./terraform/backend.tf
+terraform {
+  backend "s3" {
+    bucket = "mybucket"
+    key    = "path/to/my/key"
+    region = "us-east-1"
+  }
+}
+```
+Check this [page](https://www.terraform.io/language/settings/backends) for more information or other backends.
+
+- Run terraformm plan
+```
+terraform plan -var kubeconfig=~/.kube/config -var cluster_name=my-cluster -var oidc_provider_url=https://oidc.eks.... -out=tf.plan
+
+Plan: XX to add, 0 to change, 0 to destroy.
+```
+
+For the target EKS cluster:
+- For `cluster_name`, run `aws eks list-clusters` to see the availables clusters.
+- For `oidc_provider_url`, see `OpenID Connect provider URL` in the EKS cluster page in the AWS console. For more information, check the [official documentation](https://docs.aws.amazon.com/eks/latest/userguide/enable-iam-roles-for-service-accounts.html)
+- For `kubeconfig`, check the [official documentation](https://docs.aws.amazon.com/eks/latest/userguide/create-kubeconfig.html) if you don't have one yet.
+
+
+At this time, nothing was changed yet, you can review what will be created by terraform.
+
+- Run terraformm apply
+```
+terraform apply tf.plan
+
+Apply complete! Resources: XX added, 0 changed, 0 destroyed.
+
+Outputs:
+
+load_balancer_raw_dns = "xxx"
+
+```
+
+Note the load balancer DNS, this is the public endpoint to access your Kubernetes cluster.
+
+# Additional cluster configuration
+
+These steps are not automated with the terraform step, but you can configure them using these guides.
+- Configure DNS
+    - Follow this guide: [Routing traffic to an ELB load balancer](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/routing-to-elb-load-balancer.html)
+    - Using the TODO..
+- Configure a public certificate:
+    - Follow this guide: [Requesting a public certificate](https://docs.aws.amazon.com/acm/latest/userguide/gs-acm-request-public.html)
+    - Using the certificate ARN, run the terraform commands with `-var load_balancer_cert_arn=...` 
+
+# Deploy Kubernetes services with Opta
+
+Coming soon.
+
+# Uninstallation
+
+- Run terraformm destroy to remove the configuration added for Opta
+
+```
+terraform destroy -var kubeconfig=~/.kube/config -var cluster_name=my-cluster -var oidc_provider_url=https://oidc.eks....
+```
+

--- a/examples/byo-eks/terraform/aws-lb-iam-policy.json
+++ b/examples/byo-eks/terraform/aws-lb-iam-policy.json
@@ -1,0 +1,228 @@
+{
+    "Statement": [
+        {
+            "Action": "iam:CreateServiceLinkedRole",
+            "Condition": {
+                "StringEquals": {
+                    "iam:AWSServiceName": "elasticloadbalancing.amazonaws.com"
+                }
+            },
+            "Effect": "Allow",
+            "Resource": "*",
+            "Sid": "0"
+        },
+        {
+            "Action": [
+                "elasticloadbalancing:DescribeTargetHealth",
+                "elasticloadbalancing:DescribeTargetGroups",
+                "elasticloadbalancing:DescribeTargetGroupAttributes",
+                "elasticloadbalancing:DescribeTags",
+                "elasticloadbalancing:DescribeSSLPolicies",
+                "elasticloadbalancing:DescribeRules",
+                "elasticloadbalancing:DescribeLoadBalancers",
+                "elasticloadbalancing:DescribeLoadBalancerAttributes",
+                "elasticloadbalancing:DescribeListeners",
+                "elasticloadbalancing:DescribeListenerCertificates",
+                "ec2:GetCoipPoolUsage",
+                "ec2:DescribeVpcs",
+                "ec2:DescribeVpcPeeringConnections",
+                "ec2:DescribeTags",
+                "ec2:DescribeSubnets",
+                "ec2:DescribeSecurityGroups",
+                "ec2:DescribeNetworkInterfaces",
+                "ec2:DescribeInternetGateways",
+                "ec2:DescribeInstances",
+                "ec2:DescribeCoipPools",
+                "ec2:DescribeAvailabilityZones",
+                "ec2:DescribeAddresses",
+                "ec2:DescribeAccountAttributes"
+            ],
+            "Effect": "Allow",
+            "Resource": "*",
+            "Sid": "1"
+        },
+        {
+            "Action": [
+                "wafv2:GetWebACLForResource",
+                "wafv2:GetWebACL",
+                "wafv2:DisassociateWebACL",
+                "wafv2:AssociateWebACL",
+                "waf-regional:GetWebACLForResource",
+                "waf-regional:GetWebACL",
+                "waf-regional:DisassociateWebACL",
+                "waf-regional:AssociateWebACL",
+                "shield:GetSubscriptionState",
+                "shield:DescribeProtection",
+                "shield:DeleteProtection",
+                "shield:CreateProtection",
+                "iam:ListServerCertificates",
+                "iam:GetServerCertificate",
+                "cognito-idp:DescribeUserPoolClient",
+                "acm:ListCertificates",
+                "acm:DescribeCertificate"
+            ],
+            "Effect": "Allow",
+            "Resource": "*",
+            "Sid": "2"
+        },
+        {
+            "Action": [
+                "ec2:RevokeSecurityGroupIngress",
+                "ec2:AuthorizeSecurityGroupIngress"
+            ],
+            "Effect": "Allow",
+            "Resource": "*",
+            "Sid": "3"
+        },
+        {
+            "Action": "ec2:CreateSecurityGroup",
+            "Effect": "Allow",
+            "Resource": "*",
+            "Sid": "4"
+        },
+        {
+            "Action": "ec2:CreateTags",
+            "Condition": {
+                "Null": {
+                    "aws:RequestTag/elbv2.k8s.aws/cluster": "false"
+                },
+                "StringEquals": {
+                    "ec2:CreateAction": "CreateSecurityGroup"
+                }
+            },
+            "Effect": "Allow",
+            "Resource": "arn:aws:ec2:*:*:security-group/*",
+            "Sid": "5"
+        },
+        {
+            "Action": [
+                "ec2:DeleteTags",
+                "ec2:CreateTags"
+            ],
+            "Condition": {
+                "Null": {
+                    "aws:RequestTag/elbv2.k8s.aws/cluster": "true",
+                    "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
+                }
+            },
+            "Effect": "Allow",
+            "Resource": "arn:aws:ec2:*:*:security-group/*",
+            "Sid": "6"
+        },
+        {
+            "Action": [
+                "ec2:RevokeSecurityGroupIngress",
+                "ec2:DeleteSecurityGroup",
+                "ec2:AuthorizeSecurityGroupIngress"
+            ],
+            "Condition": {
+                "Null": {
+                    "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
+                }
+            },
+            "Effect": "Allow",
+            "Resource": "*",
+            "Sid": "7"
+        },
+        {
+            "Action": [
+                "elasticloadbalancing:CreateTargetGroup",
+                "elasticloadbalancing:CreateLoadBalancer"
+            ],
+            "Condition": {
+                "Null": {
+                    "aws:RequestTag/elbv2.k8s.aws/cluster": "false"
+                }
+            },
+            "Effect": "Allow",
+            "Resource": "*",
+            "Sid": "8"
+        },
+        {
+            "Action": [
+                "elasticloadbalancing:DeleteRule",
+                "elasticloadbalancing:DeleteListener",
+                "elasticloadbalancing:CreateRule",
+                "elasticloadbalancing:CreateListener"
+            ],
+            "Effect": "Allow",
+            "Resource": "*",
+            "Sid": "9"
+        },
+        {
+            "Action": [
+                "elasticloadbalancing:RemoveTags",
+                "elasticloadbalancing:AddTags"
+            ],
+            "Condition": {
+                "Null": {
+                    "aws:RequestTag/elbv2.k8s.aws/cluster": "true",
+                    "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
+                }
+            },
+            "Effect": "Allow",
+            "Resource": [
+                "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*",
+                "arn:aws:elasticloadbalancing:*:*:loadbalancer/net/*/*",
+                "arn:aws:elasticloadbalancing:*:*:loadbalancer/app/*/*"
+            ],
+            "Sid": "10"
+        },
+        {
+            "Action": [
+                "elasticloadbalancing:RemoveTags",
+                "elasticloadbalancing:AddTags"
+            ],
+            "Effect": "Allow",
+            "Resource": [
+                "arn:aws:elasticloadbalancing:*:*:listener/net/*/*/*",
+                "arn:aws:elasticloadbalancing:*:*:listener/app/*/*/*",
+                "arn:aws:elasticloadbalancing:*:*:listener-rule/net/*/*/*",
+                "arn:aws:elasticloadbalancing:*:*:listener-rule/app/*/*/*"
+            ],
+            "Sid": "11"
+        },
+        {
+            "Action": [
+                "elasticloadbalancing:SetSubnets",
+                "elasticloadbalancing:SetSecurityGroups",
+                "elasticloadbalancing:SetIpAddressType",
+                "elasticloadbalancing:ModifyTargetGroupAttributes",
+                "elasticloadbalancing:ModifyTargetGroup",
+                "elasticloadbalancing:ModifyLoadBalancerAttributes",
+                "elasticloadbalancing:DeleteTargetGroup",
+                "elasticloadbalancing:DeleteLoadBalancer"
+            ],
+            "Condition": {
+                "Null": {
+                    "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
+                }
+            },
+            "Effect": "Allow",
+            "Resource": "*",
+            "Sid": "12"
+        },
+        {
+            "Action": [
+                "elasticloadbalancing:RegisterTargets",
+                "elasticloadbalancing:DeregisterTargets"
+            ],
+            "Effect": "Allow",
+            "Resource": "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*",
+            "Sid": "13"
+        },
+        {
+            "Action": [
+                "elasticloadbalancing:SetWebAcl",
+                "elasticloadbalancing:RemoveListenerCertificates",
+                "elasticloadbalancing:ModifyRule",
+                "elasticloadbalancing:ModifyListener",
+                "elasticloadbalancing:AddListenerCertificates"
+            ],
+            "Effect": "Allow",
+            "Resource": "*",
+            "Sid": "14"
+        }
+    ],
+    "Version": "2012-10-17"
+}

--- a/examples/byo-eks/terraform/aws-load-balancer-controller.tf
+++ b/examples/byo-eks/terraform/aws-load-balancer-controller.tf
@@ -1,0 +1,59 @@
+
+resource "aws_iam_policy" "load_balancer" {
+  name        = "load-balancer-controller"
+  description = "Policy for the AWS Load Balancer Controller"
+  policy      = file("aws-lb-iam-policy.json")
+}
+
+data "aws_iam_policy_document" "trust_k8s_openid_alb" {
+  statement {
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+    effect  = "Allow"
+
+    condition {
+      test     = "StringEquals"
+      variable = "${replace(var.oidc_provider_url, "https://", "")}:sub"
+      values   = ["system:serviceaccount:kube-system:aws-load-balancer-controller"]
+    }
+
+    principals {
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:oidc-provider/${replace(var.oidc_provider_url, "https://", "")}"]
+
+      type = "Federated"
+    }
+  }
+}
+
+resource "aws_iam_role" "load_balancer" {
+  assume_role_policy = data.aws_iam_policy_document.trust_k8s_openid_alb.json
+  name               = "load-balancer-controller"
+}
+
+resource "aws_iam_role_policy_attachment" "load_balancer" {
+  policy_arn = aws_iam_policy.load_balancer.arn
+  role       = aws_iam_role.load_balancer.name
+}
+
+
+resource "helm_release" "load_balancer" {
+  chart      = "aws-load-balancer-controller"
+  name       = "aws-load-balancer-controller"
+  repository = "https://aws.github.io/eks-charts"
+  values = [
+    yamlencode({
+      clusterName : var.cluster_name,
+      serviceAccount : {
+        annotations : {
+          "eks.amazonaws.com/role-arn" : aws_iam_role.load_balancer.arn
+        }
+        name : "aws-load-balancer-controller"
+      },
+      region : data.aws_region.current.name
+    })
+  ]
+  namespace       = "kube-system"
+  cleanup_on_fail = true
+  atomic          = true
+  wait_for_jobs   = false
+  version         = "1.4.0"
+}

--- a/examples/byo-eks/terraform/data.tf
+++ b/examples/byo-eks/terraform/data.tf
@@ -1,0 +1,3 @@
+data "aws_region" "current" {}
+
+data "aws_caller_identity" "current" {}

--- a/examples/byo-eks/terraform/ingress-nginx.tf
+++ b/examples/byo-eks/terraform/ingress-nginx.tf
@@ -1,0 +1,77 @@
+
+locals {
+  load_balancer_name = "${var.cluster_name}-ingress"
+}
+
+// deploy the ingress nginx
+resource "helm_release" "ingress-nginx" {
+  chart            = "ingress-nginx"
+  name             = "ingress-nginx"
+  repository       = "https://kubernetes.github.io/ingress-nginx"
+  version          = var.nginx_chart_version
+  namespace        = "ingress-nginx"
+  create_namespace = true
+  atomic           = true
+  cleanup_on_fail  = true
+  values = [
+    yamlencode({
+      controller : {
+        config : merge({
+          ssl-redirect : true
+          force-ssl-redirect : true
+        }, var.nginx_config)
+        podAnnotations : merge({
+          "cluster-autoscaler.kubernetes.io/safe-to-evict" : "true",
+          "linkerd.io/inject" : "enabled"
+        }, var.nginx_extra_pod_annotations)
+        resources : {
+          requests : {
+            cpu : "200m"
+            memory : "250Mi"
+          }
+        }
+        autoscaling : {
+          enabled : var.nginx_high_availability ? true : false
+          minReplicas : var.nginx_high_availability ? 3 : 1
+        }
+        containerPort : { http : 80, https : 443, healthcheck : 10254 }
+        ingressClassResource : {
+          default : true
+        }
+
+        service : {
+          loadBalancerSourceRanges : ["0.0.0.0/0"]
+          externalTrafficPolicy : "Local"
+          enableHttps : true
+          targetPorts : { http : "http", https : "https" }
+          annotations : merge({
+            // the aws-load-balancer annotations will trigger the creation of the AWS NLB
+            # see https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.2/guide/service/annotations/#lb-type
+            "service.beta.kubernetes.io/aws-load-balancer-scheme" : "internet-facing"
+            "service.beta.kubernetes.io/aws-load-balancer-type" : "external"
+            "service.beta.kubernetes.io/aws-load-balancer-nlb-target-type" : "instance"
+            "service.beta.kubernetes.io/aws-load-balancer-healthcheck-protocol" : "HTTP"
+            "service.beta.kubernetes.io/aws-load-balancer-healthcheck-path" : "/healthz"
+            "service.beta.kubernetes.io/aws-load-balancer-backend-protocol" : "ssl"
+            "service.beta.kubernetes.io/aws-load-balancer-name" : local.load_balancer_name
+            "service.beta.kubernetes.io/aws-load-balancer-ssl-ports" : "https"
+            # https://docs.aws.amazon.com/elasticloadbalancing/latest/application/create-https-listener.html#describe-ssl-policies.
+            "service.beta.kubernetes.io/aws-load-balancer-ssl-negotiation-policy" : "ELBSecurityPolicy-TLS-1-2-2017-01"
+            "service.beta.kubernetes.io/aws-load-balancer-ssl-cert" : var.load_balancer_cert_arn
+            "service.beta.kubernetes.io/aws-load-balancer-alpn-policy" : "HTTP2Preferred"
+          }, var.nginx_extra_service_annotations)
+        }
+      },
+    })
+  ]
+  depends_on = [
+    module.linkerd2,
+    helm_release.load_balancer,
+  ]
+}
+
+data "aws_lb" "ingress-nginx" {
+  name       = local.load_balancer_name
+  depends_on = [helm_release.ingress-nginx]
+}
+

--- a/examples/byo-eks/terraform/linkerd.tf
+++ b/examples/byo-eks/terraform/linkerd.tf
@@ -1,0 +1,6 @@
+
+# install linkerd2 in high availability (HA) mode
+module "linkerd2" {
+  source  = "run-x/linkerd2/helm"
+  version = "0.1.2"
+}

--- a/examples/byo-eks/terraform/outputs.tf
+++ b/examples/byo-eks/terraform/outputs.tf
@@ -1,0 +1,8 @@
+
+output "account_id" {
+  value = data.aws_caller_identity.current.account_id
+}
+
+output "load_balancer_raw_dns" {
+  value = data.aws_lb.ingress-nginx.dns_name
+}

--- a/examples/byo-eks/terraform/providers.tf
+++ b/examples/byo-eks/terraform/providers.tf
@@ -1,0 +1,24 @@
+
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "3.70.0"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = "2.4.1"
+    }
+  }
+}
+
+provider "helm" {
+  kubernetes {
+    config_path = var.kubeconfig
+  }
+}
+
+provider "aws" {
+  region              = "us-east-1"
+  allowed_account_ids = ["248233625043"]
+}

--- a/examples/byo-eks/terraform/variables.tf
+++ b/examples/byo-eks/terraform/variables.tf
@@ -1,0 +1,52 @@
+
+variable "cluster_name" {
+  type        = string
+  description = "EKS cluster name - where to deploy this stack"
+}
+
+variable "oidc_provider_url" {
+  description = "To allow using IAM roles for service accounts, see [documentation](https://docs.aws.amazon.com/eks/latest/userguide/enable-iam-roles-for-service-accounts.html)"
+  type        = string
+}
+
+variable "kubeconfig" {
+  description = "kubeconfig file path, to use another authentication, edit the helm provider configuration"
+  type        = string
+  default     = "~/.kube/config"
+}
+
+variable "nginx_chart_version" {
+  description = "ingress-nginx version, see [releases](https://github.com/kubernetes/ingress-nginx/releases)"
+  type        = string
+  default     = "4.0.19"
+}
+
+variable "nginx_config" {
+  description = "Additional configuration for ingress-nginx. [Available options](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#configuration-options)"
+  type        = map(string)
+  default     = {}
+}
+
+variable "nginx_high_availability" {
+  description = "Install ingress-nginx controller in high availability (HA) mode: enable auto-scaling and set minimum replicas to 3"
+  type        = bool
+  default     = false
+}
+
+variable "nginx_extra_pod_annotations" {
+  description = "Extra podAnnotations for nginx chart values"
+  type        = map(string)
+  default     = {}
+}
+
+variable "nginx_extra_service_annotations" {
+  description = "Extra service.annotations for nginx chart values"
+  type        = map(string)
+  default     = {}
+}
+
+variable "load_balancer_cert_arn" {
+  description = "specifies the ARN of one or more certificates managed by the AWS Certificate Manager. If you don't set a certificate, TLS termination will be done in the nginx-controller"
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
# Description
This guide describes how a user can configure their EKS cluster to use Opta.
This is mostly what we have in the opta k8s-base module terraform, but these files have been simplified to remove some configuration specific to Opta.

**No change to opta code base at this time**, a few changes will be needed with a provided kubeconfig file, it will be done in a separate PR.

# Safety checklist
* [X] This change is backwards compatible and safe to apply by existing users
* [X] This change will NOT lead to data loss
* [X] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
terraform plan/apply/destroy on an EKS cluster - That cluster was created with Opta but without `k8s-base`.
