### PR TITLE
ssl-redirect and https target port if expose_self_signed_ssl turned on

### DIFF
--- a/modules/aws_k8s_base/tf_module/variables.tf
+++ b/modules/aws_k8s_base/tf_module/variables.tf
@@ -4,14 +4,14 @@ data "aws_eks_cluster" "current" {
 }
 
 locals {
-  target_ports    = var.cert_arn == "" && var.private_key == "" ? { http : "http" } : { http : "http", https : "https" }
+  target_ports    = var.cert_arn == "" && var.private_key == "" && !var.expose_self_signed_ssl ? { http : "http" } : { http : "http", https : "https" }
   container_ports = { http : 80, https : 443, healthcheck : 10254 }
   nginx_tls_ports = var.cert_arn == "" && var.private_key == "" ? "" : join(",", compact(flatten([
     ["https"],
     [for port in var.nginx_extra_tcp_ports_tls : "${port}-tcp"],
   ])))
 
-  config = merge((var.cert_arn == "" && var.private_key == "" ? { ssl-redirect : false } : {
+  config = merge((var.cert_arn == "" && var.private_key == "" && !var.expose_self_signed_ssl ? { ssl-redirect : false } : {
     ssl-redirect : true
     force-ssl-redirect : true
   }), var.nginx_config)


### PR DESCRIPTION
# Description
ssl-redirect and https target port if expose_self_signed_ssl turned on

# Safety checklist
* [x] This change is backwards compatible and safe to apply by existing users
* [x] This change will NOT lead to data loss
* [x] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
tested manually
