### PR TITLE
Add output to opta help result

### DIFF
--- a/opta/commands/output.py
+++ b/opta/commands/output.py
@@ -16,7 +16,7 @@ from opta.utils.clickoptions import (
 )
 
 
-@click.command(hidden=True)
+@click.command()
 @config_option
 @env_option
 @input_variable_option


### PR DESCRIPTION
# Description
Add `output` subcommand to the `opta -h`

# Safety checklist
* [x] This change is backwards compatible and safe to apply by existing users
* [x] This change will NOT lead to data loss
* [x] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
<img width="791" alt="Screenshot 2022-04-11 at 10 32 04 PM" src="https://user-images.githubusercontent.com/20905988/162792616-916020d4-9cfe-4db8-b03b-c3e9ebc5aed8.png">

Slack Discussion: https://opta-group.slack.com/archives/C0240NBKUMT/p1649690540381179
