### PR TITLE
NLB deletion failing because LB controller's permissions died first

### DIFF
--- a/modules/aws_k8s_base/tf_module/load_balancer_controller.tf
+++ b/modules/aws_k8s_base/tf_module/load_balancer_controller.tf
@@ -312,6 +312,7 @@ resource "helm_release" "load_balancer" {
   values = [
     yamlencode({
       clusterName : var.eks_cluster_name,
+      region : data.aws_region.current.id,
       serviceAccount : {
         annotations : {
           "eks.amazonaws.com/role-arn" : aws_iam_role.load_balancer.arn
@@ -326,6 +327,9 @@ resource "helm_release" "load_balancer" {
   cleanup_on_fail  = true
   atomic           = true
   wait_for_jobs    = false
-  version          = "1.4.0"
+  version          = "1.4.1"
+  depends_on = [
+    aws_iam_role_policy_attachment.load_balancer
+  ]
 }
 


### PR DESCRIPTION
# Description
The IAM policy was being swept under their feet. Adding this dependency ensures it is not deleted prematurely


# Safety checklist
* [x] This change is backwards compatible and safe to apply by existing users
* [x] This change will NOT lead to data loss
* [x] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
manually
