### PR TITLE
Not delete the output key

### DIFF
--- a/opta/module.py
+++ b/opta/module.py
@@ -138,7 +138,8 @@ class Module:
         # If there are no outputs, don't set the output key. Terraform doesn't like an
         # empty output block.
         if module_blk["output"] == {}:
-            del module_blk["output"]
+            # del module_blk["output"]
+            pass
 
         return module_blk
 


### PR DESCRIPTION
# Description
Deleting the output key because it's empty ends up throwing error when being used further.

# Safety checklist
* [x] This change is backwards compatible and safe to apply by existing users
* [x] This change will NOT lead to data loss
* [x] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
[run-create-and-destroy](https://app.circleci.com/pipelines/github/run-x/opta/2135/workflows/3520c568-d05f-494b-b439-351f673d7899)
