### PR TITLE
Fix tests failing if run with OPTA_DISABLE_REPORTING=1

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,13 +1,16 @@
 import os
 import sys
 from typing import Any, Dict, Generator
+
 from pytest import fixture
 from pytest_mock import MockFixture
+
 
 # Most commands require terraform init. Mock it here.
 @fixture(autouse=True)
 def mock_terraform_init(mocker: MockFixture) -> None:
     mocker.patch("opta.core.terraform.Terraform.init")
+
 
 @fixture
 def hide_debug_mode() -> Generator:
@@ -22,11 +25,11 @@ def hide_debug_mode() -> Generator:
     for key in unset_environs:
         original_environs[key] = os.environ.pop(key, None)
 
-    del sys._called_from_test
+    del sys._called_from_test  # type: ignore
 
     yield
 
-    sys._called_from_test = True
+    sys._called_from_test = True  # type: ignore
 
     # Restore original values
     for key, value in original_environs.items():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,36 @@
+import os
+import sys
+from typing import Any, Dict, Generator
 from pytest import fixture
 from pytest_mock import MockFixture
-
 
 # Most commands require terraform init. Mock it here.
 @fixture(autouse=True)
 def mock_terraform_init(mocker: MockFixture) -> None:
     mocker.patch("opta.core.terraform.Terraform.init")
+
+@fixture
+def hide_debug_mode() -> Generator:
+    """
+    Temporarily hides that we are running in a test by unsetting sys._called_from_test and
+    removing any env vars that might be used to disable reporting
+    """
+    # Grab original env vars
+    # Not using the imported constant to prevent errors when collecting tests
+    unset_environs = ["OPTA_DISABLE_REPORTING"]
+    original_environs: Dict[str, Any] = {}
+    for key in unset_environs:
+        original_environs[key] = os.environ.pop(key, None)
+
+    del sys._called_from_test
+
+    yield
+
+    sys._called_from_test = True
+
+    # Restore original values
+    for key, value in original_environs.items():
+        if value is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = value

--- a/tests/test_amplitude.py
+++ b/tests/test_amplitude.py
@@ -9,6 +9,7 @@ from requests import Response, codes
 from opta.amplitude import AmplitudeClient
 from opta.constants import OPTA_DISABLE_REPORTING
 
+
 @pytest.mark.usefixtures("hide_debug_mode")
 class TestAmplitudeClient:
     def test_send_event(self, mocker: MockFixture):

--- a/tests/test_amplitude.py
+++ b/tests/test_amplitude.py
@@ -1,46 +1,39 @@
 # type: ignore
 
 import os
-import sys
 
-from pytest_mock import MockFixture, mocker  # noqa
+import pytest
+from pytest_mock import MockFixture
 from requests import Response, codes
 
 from opta.amplitude import AmplitudeClient
 from opta.constants import OPTA_DISABLE_REPORTING
 
-
+@pytest.mark.usefixtures("hide_debug_mode")
 class TestAmplitudeClient:
-    def test_send_event(self, mocker: MockFixture):  # noqa
+    def test_send_event(self, mocker: MockFixture):
         mocker.patch("opta.amplitude.VERSION")
         mocked_post = mocker.patch("opta.amplitude.post")
         mocked_response = mocker.Mock(spec=Response)
         mocked_response.status_code = codes.ok
         mocked_post.return_value = mocked_response
         client = AmplitudeClient()
-        del sys._called_from_test
-        try:
-            client.send_event(client.APPLY_EVENT)
-            mocked_post.assert_called_once_with(
-                "https://api2.amplitude.com/2/httpapi",
-                params={},
-                headers={"Content-Type": "application/json", "Accept": "*/*"},
-                json=mocker.ANY,
-            )
-        finally:
-            sys._called_from_test = True
 
-    def test_dont_send_event(self, mocker: MockFixture):  # noqa
+        client.send_event(client.APPLY_EVENT)
+        mocked_post.assert_called_once_with(
+            "https://api2.amplitude.com/2/httpapi",
+            params={},
+            headers={"Content-Type": "application/json", "Accept": "*/*"},
+            json=mocker.ANY,
+        )
+
+    def test_dont_send_event(self, mocker: MockFixture):
         mocked_post = mocker.patch("opta.amplitude.post")
         mocked_response = mocker.Mock(spec=Response)
         mocked_response.status_code = codes.ok
         mocked_post.return_value = mocked_response
         client = AmplitudeClient()
-        del sys._called_from_test
         os.environ[OPTA_DISABLE_REPORTING] = "1"
-        try:
-            client.send_event(client.APPLY_EVENT)
-            mocked_post.assert_not_called()
-        finally:
-            sys._called_from_test = True
-            del os.environ[OPTA_DISABLE_REPORTING]
+
+        client.send_event(client.APPLY_EVENT)
+        mocked_post.assert_not_called()

--- a/tests/test_datadog_logging.py
+++ b/tests/test_datadog_logging.py
@@ -4,7 +4,8 @@ import os
 import time
 from logging import LogRecord
 
-from pytest_mock import MockFixture, mocker  # noqa
+import pytest
+from pytest_mock import MockFixture
 from requests import Response, codes
 
 from opta.constants import OPTA_DISABLE_REPORTING
@@ -12,7 +13,7 @@ from opta.datadog_logging import CLIENT_TOKEN, DEFAULT_CACHE_SIZE, DatadogLogHan
 
 
 class TestDatadogLogHandler:
-    def test_emit(self, mocker: MockFixture):  # noqa
+    def test_emit(self, mocker: MockFixture) -> None:
         mocked_record = mocker.Mock(spec=LogRecord)
         mocked_cache_entry = mocker.Mock()
         mocked_transform_record = mocker.patch(
@@ -26,7 +27,7 @@ class TestDatadogLogHandler:
         mocked_flush.assert_not_called()
         mocked_transform_record.assert_called_once_with(mocked_record)
 
-    def test_emit_with_flush(self, mocker: MockFixture):  # noqa
+    def test_emit_with_flush(self, mocker: MockFixture) -> None:
         mocked_record = mocker.Mock(spec=LogRecord)
         mocked_cache_entry = mocker.Mock()
         mocked_transform_record = mocker.patch(
@@ -42,7 +43,8 @@ class TestDatadogLogHandler:
         mocked_flush.assert_called_once_with()
         mocked_transform_record.assert_called_once_with(mocked_record)
 
-    def test_flush(self, mocker: MockFixture):  # noqa
+    @pytest.mark.usefixtures("hide_debug_mode")
+    def test_flush(self, mocker: MockFixture) -> None:
         mocked_response = mocker.Mock(spec=Response)
         mocked_response.status_code = codes.ok
         mocked_post = mocker.patch(
@@ -70,7 +72,8 @@ class TestDatadogLogHandler:
             timeout=5,
         )
 
-    def test_dont_flush(self, mocker: MockFixture):  # noqa
+    @pytest.mark.usefixtures("hide_debug_mode")
+    def test_dont_flush(self, mocker: MockFixture) -> None:
         mocked_response = mocker.Mock(spec=Response)
         mocked_response.status_code = codes.ok
         mocked_post = mocker.patch(
@@ -85,6 +88,5 @@ class TestDatadogLogHandler:
         handler.cache = [cache_entry]
         os.environ[OPTA_DISABLE_REPORTING] = "1"
         handler.flush()
-        del os.environ[OPTA_DISABLE_REPORTING]
         assert handler.cache == []
         mocked_post.assert_not_called()


### PR DESCRIPTION
# Description
If you run Python tests (i.e. `make test`) locally while `OPTA_DISABLE_REPORTING=1` is set in your terminal, tests will fail because the datadog and amplitude tests rely on that env var not being set when the test is run, but they do not validate that assumption. This PR adds a pytest fixture that makes it easy to handle that case.

The `hide_debug_mode` fixture unsets configured env vars (currently, only `OPTA_DISABLE_REPORTING`) as well as `sys._called_from_test` during the test and restores the original values after the test. It is defined in `tests/conftest.py` to make it available to any test under `tests/`.

This PR also removes `# noqa` lines from the amplitude and datadog test files as part of cleanup.


# Safety checklist
* [X] This change is backwards compatible and safe to apply by existing users
* [X] This change will NOT lead to data loss
* [X] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
This change only affects unit tests.