### PR TITLE
Adding a max helm history field for k8sservice

### DIFF
--- a/modules/aws_k8s_service/aws-k8s-service.json
+++ b/modules/aws_k8s_service/aws-k8s-service.json
@@ -21,6 +21,11 @@
         "$ref": "/common-types/port"
       }
     },
+    "max_history": {
+      "type": "number",
+      "description": "The max amount of helm revisions to keep track of (0 for infinite)",
+      "default": 25
+    },
     "cron_jobs": {
       "type": "array",
       "description": "A list of cronjobs to execute as part of this service",

--- a/modules/aws_k8s_service/aws-k8s-service.yaml
+++ b/modules/aws_k8s_service/aws-k8s-service.yaml
@@ -206,6 +206,11 @@ inputs:
     validator: int(required=False)
     description: Time in seconds to wait for deployment.
     default: 300
+  - name: max_history
+    user_facing: true
+    validator: int(required=False)
+    description: The max amount of helm revisions to keep track of (0 for infinite)
+    default: 25
 extra_validators:
   cron_job:
     commands: list(required=True)

--- a/modules/aws_k8s_service/tf_module/main.tf
+++ b/modules/aws_k8s_service/tf_module/main.tf
@@ -60,5 +60,6 @@ resource "helm_release" "k8s-service" {
   atomic          = true
   cleanup_on_fail = true
   timeout         = var.timeout
+  max_history     = var.max_history
 }
 

--- a/modules/aws_k8s_service/tf_module/variables.tf
+++ b/modules/aws_k8s_service/tf_module/variables.tf
@@ -211,3 +211,7 @@ variable "timeout" {
   type    = number
   default = 300
 }
+
+variable "max_history" {
+  type = number
+}

--- a/modules/azure_k8s_service/azure-k8s-service.json
+++ b/modules/azure_k8s_service/azure-k8s-service.json
@@ -23,6 +23,11 @@
       "default": 3,
       "minimum": 0
     },
+    "max_history": {
+      "type": "number",
+      "description": "The max amount of helm revisions to keep track of (0 for infinite)",
+      "default": 25
+    },
     "timeout": {
       "type": "number",
       "description": "Time in seconds to wait for deployment.",

--- a/modules/azure_k8s_service/azure-k8s-service.yaml
+++ b/modules/azure_k8s_service/azure-k8s-service.yaml
@@ -177,6 +177,11 @@ inputs: # (what users see)
     validator: int(required=False)
     description: Time in seconds to wait for deployment.
     default: 300
+  - name: max_history
+    user_facing: true
+    validator: int(required=False)
+    description: The max amount of helm revisions to keep track of (0 for infinite)
+    default: 25
 extra_validators:
   persistent_storage:
     size: int(required=True)

--- a/modules/azure_k8s_service/tf_module/main.tf
+++ b/modules/azure_k8s_service/tf_module/main.tf
@@ -57,5 +57,6 @@ resource "helm_release" "k8s-service" {
   atomic          = true
   cleanup_on_fail = true
   timeout         = var.timeout
+  max_history     = var.max_history
 }
 

--- a/modules/azure_k8s_service/tf_module/variables.tf
+++ b/modules/azure_k8s_service/tf_module/variables.tf
@@ -200,3 +200,7 @@ variable "timeout" {
   type    = number
   default = 300
 }
+
+variable "max_history" {
+  type = number
+}

--- a/modules/gcp_k8s_service/gcp-k8s-service.json
+++ b/modules/gcp_k8s_service/gcp-k8s-service.json
@@ -21,6 +21,11 @@
       "default": 1,
       "minimum": 0
     },
+    "max_history": {
+      "type": "number",
+      "description": "The max amount of helm revisions to keep track of (0 for infinite)",
+      "default": 25
+    },
     "timeout": {
       "type": "number",
       "description": "Time in seconds to wait for deployment.",

--- a/modules/gcp_k8s_service/gcp-k8s-service.yaml
+++ b/modules/gcp_k8s_service/gcp-k8s-service.yaml
@@ -197,6 +197,11 @@ inputs:
     validator: int(required=False)
     description: Time in seconds to wait for deployment.
     default: 300
+  - name: max_history
+    user_facing: true
+    validator: int(required=False)
+    description: The max amount of helm revisions to keep track of (0 for infinite)
+    default: 25
 extra_validators:
   cron_job:
     commands: list(required=True)

--- a/modules/gcp_k8s_service/tf_module/main.tf
+++ b/modules/gcp_k8s_service/tf_module/main.tf
@@ -59,4 +59,5 @@ resource "helm_release" "k8s-service" {
   atomic          = true
   cleanup_on_fail = true
   timeout         = var.timeout
+  max_history     = var.max_history
 }

--- a/modules/gcp_k8s_service/tf_module/variables.tf
+++ b/modules/gcp_k8s_service/tf_module/variables.tf
@@ -214,3 +214,7 @@ variable "timeout" {
   type    = number
   default = 300
 }
+
+variable "max_history" {
+  type = number
+}

--- a/modules/helm_chart/helm-chart.json
+++ b/modules/helm_chart/helm-chart.json
@@ -26,6 +26,11 @@
       "description": "If set, installation process purges chart on fail. The wait flag will be set automatically if atomic is used.",
       "default": true
     },
+    "max_history": {
+      "type": "number",
+      "description": "The max amount of helm revisions to keep track of (0 for infinite)",
+      "default": 25
+    },
     "cleanup_on_fail": {
       "type": "boolean",
       "description": "Allow deletion of new resources created in this upgrade when upgrade fails",

--- a/modules/helm_chart/helm-chart.yaml
+++ b/modules/helm_chart/helm-chart.yaml
@@ -82,6 +82,11 @@ inputs:
     validator: bool(required=False)
     description: Will wait (for as long as timeout) until all resources are in a ready state before marking the release as successful.
     default: true
+  - name: max_history
+    user_facing: true
+    validator: int(required=False)
+    description: The max amount of helm revisions to keep track of (0 for infinite)
+    default: 25
 outputs: { }
 output_providers: { }
 output_data: { }

--- a/modules/helm_chart/tf_module/main.tf
+++ b/modules/helm_chart/tf_module/main.tf
@@ -12,6 +12,7 @@ resource "helm_release" "remote_chart" {
   timeout           = var.timeout
   dependency_update = var.dependency_update
   wait              = var.wait
+  max_history = var.max_history
 }
 
 
@@ -26,4 +27,5 @@ resource "helm_release" "local_chart" {
   values            = var.values_files == [] ? [yamlencode(var.values)] : concat(local.values_from_files, [yamlencode(var.values)])
   timeout           = var.timeout
   dependency_update = var.dependency_update
+  max_history = var.max_history
 }

--- a/modules/helm_chart/tf_module/main.tf
+++ b/modules/helm_chart/tf_module/main.tf
@@ -12,7 +12,7 @@ resource "helm_release" "remote_chart" {
   timeout           = var.timeout
   dependency_update = var.dependency_update
   wait              = var.wait
-  max_history = var.max_history
+  max_history       = var.max_history
 }
 
 
@@ -27,5 +27,5 @@ resource "helm_release" "local_chart" {
   values            = var.values_files == [] ? [yamlencode(var.values)] : concat(local.values_from_files, [yamlencode(var.values)])
   timeout           = var.timeout
   dependency_update = var.dependency_update
-  max_history = var.max_history
+  max_history       = var.max_history
 }

--- a/modules/helm_chart/tf_module/variables.tf
+++ b/modules/helm_chart/tf_module/variables.tf
@@ -82,3 +82,6 @@ variable "dependency_update" {
   default = true
 }
 
+variable "max_history" {
+  type = number
+}

--- a/modules/local_k8s_service/local-k8s-service.json
+++ b/modules/local_k8s_service/local-k8s-service.json
@@ -24,6 +24,11 @@
       },
       "default": []
     },
+    "max_history": {
+      "type": "number",
+      "description": "The max amount of helm revisions to keep track of (0 for infinite)",
+      "default": 25
+    },
     "tolerations": {
       "type": "list",
       "description": "Taint tolerations to add to the pods.",

--- a/modules/local_k8s_service/local-k8s-service.yaml
+++ b/modules/local_k8s_service/local-k8s-service.yaml
@@ -166,6 +166,11 @@ inputs:
     validator: list(include('cron_job'), required=False)
     description: A list of cronjobs to execute as part of this service
     default: []
+  - name: max_history
+    user_facing: true
+    validator: int(required=False)
+    description: The max amount of helm revisions to keep track of (0 for infinite)
+    default: 25
 extra_validators:
   cron_job:
     commands: list(required=True)

--- a/modules/local_k8s_service/tf_module/main.tf
+++ b/modules/local_k8s_service/tf_module/main.tf
@@ -58,5 +58,6 @@ resource "helm_release" "k8s-service" {
   ]
   atomic          = true
   cleanup_on_fail = true
+  max_history     = var.max_history
 }
 

--- a/modules/local_k8s_service/tf_module/variables.tf
+++ b/modules/local_k8s_service/tf_module/variables.tf
@@ -191,3 +191,7 @@ variable "tolerations" {
 variable "cron_jobs" {
   default = []
 }
+
+variable "max_history" {
+  type = number
+}


### PR DESCRIPTION
# Description
Cause a problem Will was facing is that he made hundreds of deployments and so the history was obscenely large


# Safety checklist
* [x] This change is backwards compatible and safe to apply by existing users
* [x] This change will NOT lead to data loss
* [x] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
YOUR_ANSWER
