### PR TITLE
Use Absolute kube config path

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1084,8 +1084,8 @@ jobs:
             - checkout-opta
             - run:
                 command: |
-                    docker build --tag todo-api:v1 -f opta/examples/full-stack-example/api/todo-python-django/Dockerfile opta/examples/full-stack-example/api/todo-python-django/
-                    docker build --tag todo-frontend:v1 -f opta/examples/full-stack-example/frontend/todo-vuejs/Dockerfile opta/examples/full-stack-example/frontend/todo-vuejs/
+                    docker build --tag todo-api:v1 -f ./examples/full-stack-example/api/todo-python-django/Dockerfile ./examples/full-stack-example/api/todo-python-django/
+                    docker build --tag todo-frontend:v1 -f ./examples/full-stack-example/frontend/todo-vuejs/Dockerfile ./examples/full-stack-example/frontend/todo-vuejs/
                 name: Build example images
             - run:
                 command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1083,9 +1083,6 @@ jobs:
         steps:
             - checkout-opta
             - run:
-                command: git clone git@github.com:run-x/opta.git
-                name: Git clone Opta Example
-            - run:
                 command: |
                     docker build --tag todo-api:v1 -f opta/examples/full-stack-example/api/todo-python-django/Dockerfile opta/examples/full-stack-example/api/todo-python-django/
                     docker build --tag todo-frontend:v1 -f opta/examples/full-stack-example/frontend/todo-vuejs/Dockerfile opta/examples/full-stack-example/frontend/todo-vuejs/

--- a/.circleci/src/jobs/build-opta-example-images.yaml
+++ b/.circleci/src/jobs/build-opta-example-images.yaml
@@ -4,8 +4,8 @@ steps:
   - run:
       name: "Build example images"
       command: |
-        docker build --tag todo-api:v1 -f opta/examples/full-stack-example/api/todo-python-django/Dockerfile opta/examples/full-stack-example/api/todo-python-django/
-        docker build --tag todo-frontend:v1 -f opta/examples/full-stack-example/frontend/todo-vuejs/Dockerfile opta/examples/full-stack-example/frontend/todo-vuejs/
+        docker build --tag todo-api:v1 -f ./examples/full-stack-example/api/todo-python-django/Dockerfile ./examples/full-stack-example/api/todo-python-django/
+        docker build --tag todo-frontend:v1 -f ./examples/full-stack-example/frontend/todo-vuejs/Dockerfile ./examples/full-stack-example/frontend/todo-vuejs/
   - run:
       name: "Save Opta examples"
       command: |

--- a/.circleci/src/jobs/build-opta-example-images.yaml
+++ b/.circleci/src/jobs/build-opta-example-images.yaml
@@ -2,9 +2,6 @@ executor: ubuntu-machine
 steps:
   - checkout-opta
   - run:
-      name: "Git clone Opta Example"
-      command: "git clone git@github.com:run-x/opta.git"
-  - run:
       name: "Build example images"
       command: |
         docker build --tag todo-api:v1 -f opta/examples/full-stack-example/api/todo-python-django/Dockerfile opta/examples/full-stack-example/api/todo-python-django/

--- a/opta/constants.py
+++ b/opta/constants.py
@@ -3,6 +3,8 @@ import time
 from os.path import expanduser
 from typing import Dict, Final, Optional, Tuple
 
+from kubernetes.config.kube_config import KUBE_CONFIG_DEFAULT_LOCATION
+
 from opta.registry import make_registry_dict
 
 init_template_path: Final = os.path.join(
@@ -60,6 +62,7 @@ successfull_upgrade: Final = os.path.join(
 )
 
 HOME: Final = expanduser("~")
+DEFAULT_KUBECONFIG = expanduser(KUBE_CONFIG_DEFAULT_LOCATION)
 GENERATED_KUBE_CONFIG_DIR: Final = f"{HOME}/.opta/kubeconfigs"
 GENERATED_KUBE_CONFIG: Optional[str] = None
 ONE_WEEK_UNIX: Final = 604800

--- a/opta/core/helm.py
+++ b/opta/core/helm.py
@@ -1,8 +1,6 @@
 from subprocess import CalledProcessError  # nosec
 from typing import FrozenSet, List, Optional
 
-from kubernetes.config.kube_config import KUBE_CONFIG_DEFAULT_LOCATION
-
 import opta.constants as constants
 from opta.exceptions import UserErrors
 from opta.nice_subprocess import nice_run
@@ -34,7 +32,7 @@ class Helm:
                         "--kube-context",
                         kube_context,
                         "--kubeconfig",
-                        constants.GENERATED_KUBE_CONFIG or KUBE_CONFIG_DEFAULT_LOCATION,
+                        constants.GENERATED_KUBE_CONFIG or constants.DEFAULT_KUBECONFIG,
                         "--namespace",
                         namespace,
                     ],
@@ -50,7 +48,7 @@ class Helm:
                         "--kube-context",
                         kube_context,
                         "--kubeconfig",
-                        constants.GENERATED_KUBE_CONFIG or KUBE_CONFIG_DEFAULT_LOCATION,
+                        constants.GENERATED_KUBE_CONFIG or constants.DEFAULT_KUBECONFIG,
                         "--namespace",
                         namespace,
                     ],
@@ -88,7 +86,7 @@ class Helm:
                     "--kube-context",
                     kube_context,
                     "--kubeconfig",
-                    constants.GENERATED_KUBE_CONFIG or KUBE_CONFIG_DEFAULT_LOCATION,
+                    constants.GENERATED_KUBE_CONFIG or constants.DEFAULT_KUBECONFIG,
                     *namespaces,
                     "-o",
                     "json",

--- a/opta/core/kubernetes.py
+++ b/opta/core/kubernetes.py
@@ -29,10 +29,7 @@ from kubernetes.client import (
     V1ServiceList,
 )
 from kubernetes.config import load_kube_config
-from kubernetes.config.kube_config import (
-    ENV_KUBECONFIG_PATH_SEPARATOR,
-    KUBE_CONFIG_DEFAULT_LOCATION,
-)
+from kubernetes.config.kube_config import ENV_KUBECONFIG_PATH_SEPARATOR
 from kubernetes.watch import Watch
 
 import opta.constants as constants
@@ -84,7 +81,7 @@ def purge_opta_kube_config(layer: "Layer") -> None:
         return
 
     default_kube_config_filename = expanduser(
-        KUBE_CONFIG_DEFAULT_LOCATION.split(ENV_KUBECONFIG_PATH_SEPARATOR)[0]
+        constants.DEFAULT_KUBECONFIG.split(ENV_KUBECONFIG_PATH_SEPARATOR)[0]
     )
     if not exists(default_kube_config_filename):
         return
@@ -121,7 +118,7 @@ def load_opta_kube_config_to_default(layer: "Layer") -> None:
         return
     opta_config = yaml.load(open(kube_config_file_name))
     default_kube_config_filename = expanduser(
-        KUBE_CONFIG_DEFAULT_LOCATION.split(ENV_KUBECONFIG_PATH_SEPARATOR)[0]
+        constants.DEFAULT_KUBECONFIG.split(ENV_KUBECONFIG_PATH_SEPARATOR)[0]
     )
     if not exists(default_kube_config_filename):
         with open(expanduser(default_kube_config_filename), "w") as f:
@@ -184,7 +181,7 @@ def cluster_exist(layer: "Layer") -> bool:
 
 def load_opta_kube_config() -> None:
     load_kube_config(
-        config_file=constants.GENERATED_KUBE_CONFIG or KUBE_CONFIG_DEFAULT_LOCATION
+        config_file=constants.GENERATED_KUBE_CONFIG or constants.DEFAULT_KUBECONFIG
     )
 
 


### PR DESCRIPTION
# Description
Generate absolute using `expanduser` on `KUBE_CONFIG_DEFAULT_LOCATION` instead of using `~/.kube/config`

# Safety checklist
* [x] This change is backwards compatible and safe to apply by existing users
* [x] This change will NOT lead to data loss
* [x] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
[run-create-destroy-local-example](https://app.circleci.com/pipelines/github/run-x/opta/2266/workflows/6870e4af-0eff-4fea-b09d-5d753b7868d2)
[run-create-and-destroy-aws](https://app.circleci.com/pipelines/github/run-x/opta/2267/workflows/a7ce65ce-9c43-4d74-9281-107dc3483bcd)
[run-create-and-destroy-gcp](https://app.circleci.com/pipelines/github/run-x/opta/2272/workflows/b21ea864-0cce-4427-9f0c-19a5f901867f)
