### PR TITLE
Remove version upgrade from opta output

### DIFF
--- a/opta/cli.py
+++ b/opta/cli.py
@@ -27,10 +27,10 @@ from opta.commands.ui import ui
 from opta.commands.upgrade import upgrade
 from opta.commands.validate import validate
 from opta.commands.version import version
+from opta.core.upgrade import check_version_upgrade
 from opta.crash_reporter import CURRENT_CRASH_REPORTER
 from opta.exceptions import UserErrors
 from opta.one_time import one_time
-from opta.upgrade import check_version_upgrade
 from opta.utils import dd_handler, dd_listener, logger
 
 

--- a/opta/commands/output.py
+++ b/opta/commands/output.py
@@ -6,6 +6,7 @@ from opta.amplitude import amplitude_client
 from opta.commands.apply import local_setup
 from opta.core.generator import gen_all
 from opta.core.terraform import get_terraform_outputs
+from opta.core.upgrade import disable_version_upgrade
 from opta.layer import Layer
 from opta.utils import check_opta_file_exists, json
 from opta.utils.clickoptions import (
@@ -25,7 +26,7 @@ def output(
     config: str, env: Optional[str], local: Optional[bool], var: Dict[str, str],
 ) -> None:
     """Print TF outputs"""
-
+    disable_version_upgrade()
     config = check_opta_file_exists(config)
     if local:
         config = local_setup(config, var, None)

--- a/opta/commands/upgrade.py
+++ b/opta/commands/upgrade.py
@@ -5,8 +5,8 @@ import requests
 from colored import attr, fg
 
 from opta.constants import OPTA_INSTALL_URL
+from opta.core.upgrade import check_version_upgrade
 from opta.nice_subprocess import nice_run
-from opta.upgrade import check_version_upgrade
 from opta.utils import logger
 from opta.utils.globals import OptaUpgrade
 

--- a/opta/core/upgrade.py
+++ b/opta/core/upgrade.py
@@ -17,7 +17,7 @@ UPGRADE_INSTRUCTIONS_URL = "https://docs.opta.dev/installation/"
 
 
 def _should_check_for_version_upgrade() -> bool:
-    return (VERSION != DEV_VERSION) and (
+    return (VERSION not in [DEV_VERSION, "", None]) and (
         random.random() < UPGRADE_CHECK_PROBABILITY  # nosec
     )
 

--- a/opta/core/upgrade.py
+++ b/opta/core/upgrade.py
@@ -1,3 +1,4 @@
+import os
 import random
 
 import requests
@@ -8,7 +9,9 @@ from opta.utils import logger
 from opta.utils.globals import OptaUpgrade
 
 LATEST_VERSION_FILE_URL = "https://dev-runx-opta-binaries.s3.amazonaws.com/latest"
-UPGRADE_CHECK_PROBABILITY = 0.2
+UPGRADE_CHECK_PROBABILITY: float = float(
+    os.environ.get("OPTA_UPGRADE_CHECK_PROBABILITY", "0.2")
+)
 # TODO: Change this to the actual upgrade URL.
 UPGRADE_INSTRUCTIONS_URL = "https://docs.opta.dev/installation/"
 
@@ -24,6 +27,11 @@ def _get_latest_version() -> str:
     resp = requests.get(LATEST_VERSION_FILE_URL)
     resp.raise_for_status()
     return resp.text.strip().strip("v")
+
+
+def disable_version_upgrade() -> None:
+    global UPGRADE_CHECK_PROBABILITY
+    UPGRADE_CHECK_PROBABILITY = 0
 
 
 def check_version_upgrade(is_upgrade_call: bool = False) -> bool:

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -47,9 +47,9 @@ class TestGetLatestVersion:
 class TestCheckVersionUpgrade:
     def test_does_not_check_if_should_check_false(self, mocker: MockFixture) -> None:
         mocked_should_check = mocker.patch(
-            "opta.upgrade._should_check_for_version_upgrade", return_value=False
+            "opta.core.upgrade._should_check_for_version_upgrade", return_value=False
         )
-        mocked_get_latest_version = mocker.patch("opta.upgrade._get_latest_version")
+        mocked_get_latest_version = mocker.patch("opta.core.upgrade._get_latest_version")
         check_version_upgrade()
         mocked_should_check.assert_called_once()
         mocked_get_latest_version.assert_not_called()
@@ -57,10 +57,14 @@ class TestCheckVersionUpgrade:
     def test_logs_update_instructions_if_newer_version_available(
         self, mocker: MockFixture
     ) -> None:
-        mocker.patch("opta.upgrade._should_check_for_version_upgrade", return_value=True)
-        mocker.patch("opta.upgrade._get_latest_version", return_value=TEST_LATEST_VERSION)
-        mocker.patch("opta.upgrade.VERSION", TEST_OLD_VERSION)
-        mocked_logger_warning = mocker.patch("opta.upgrade.logger.warning")
+        mocker.patch(
+            "opta.core.upgrade._should_check_for_version_upgrade", return_value=True
+        )
+        mocker.patch(
+            "opta.core.upgrade._get_latest_version", return_value=TEST_LATEST_VERSION
+        )
+        mocker.patch("opta.core.upgrade.VERSION", TEST_OLD_VERSION)
+        mocked_logger_warning = mocker.patch("opta.core.upgrade.logger.warning")
         check_version_upgrade()
         mocked_logger_warning.assert_called_once()
         warning_message: str = mocked_logger_warning.call_args.args[0]
@@ -68,9 +72,11 @@ class TestCheckVersionUpgrade:
         assert warning_message.find(TEST_LATEST_VERSION) > -1
 
     def test_handles_get_latest_version_exceptions(self, mocker: MockFixture) -> None:
-        mocker.patch("opta.upgrade._should_check_for_version_upgrade", return_value=True)
+        mocker.patch(
+            "opta.core.upgrade._should_check_for_version_upgrade", return_value=True
+        )
         mocked_get_latest_version = mocker.patch(
-            "opta.upgrade._get_latest_version",
+            "opta.core.upgrade._get_latest_version",
             side_effect=requests.exceptions.ConnectTimeout,
         )
         check_version_upgrade()

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -3,7 +3,7 @@ import requests
 import requests_mock
 from pytest_mock import MockFixture
 
-from opta.upgrade import (
+from opta.core.upgrade import (
     LATEST_VERSION_FILE_URL,
     _get_latest_version,
     check_version_upgrade,


### PR DESCRIPTION
# Description
Because it's expecting a json be printed in stdout


# Safety checklist
* [x] This change is backwards compatible and safe to apply by existing users
* [x] This change will NOT lead to data loss
* [x] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
n/a
