### PR TITLE
Set minimum TLS version for cloudfront

### DIFF
--- a/modules/cloudfront_distribution/tf_module/main.tf
+++ b/modules/cloudfront_distribution/tf_module/main.tf
@@ -15,12 +15,12 @@ locals {
 
 resource "aws_cloudfront_distribution" "distribution" {
 
-  comment         = "Opta managed cloudfront distribution ${var.layer_name}-${var.module_name}"
-  enabled         = true
-  is_ipv6_enabled = true
-  price_class     = var.price_class
-  aliases         = var.acm_cert_arn == "" ? [] : var.domains
-
+  comment                  = "Opta managed cloudfront distribution ${var.layer_name}-${var.module_name}"
+  enabled                  = true
+  is_ipv6_enabled          = true
+  price_class              = var.price_class
+  aliases                  = var.acm_cert_arn == "" ? [] : var.domains
+  minimum_protocol_version = "TLSv1.2_2021"
   dynamic "logging_config" {
     for_each = var.s3_log_bucket_name == null ? [] : [1]
     content {

--- a/modules/cloudfront_distribution/tf_module/main.tf
+++ b/modules/cloudfront_distribution/tf_module/main.tf
@@ -13,14 +13,16 @@ locals {
   s3_distribution_count = var.s3_load_balancer_enabled == true ? 1 : 0
 }
 
+# This is optional, see Opta docs for this here: https://docs.opta.dev/reference/aws/modules/cloudfront-distribution/
+#tfsec:ignore:aws-cloudfront-enable-waf
 resource "aws_cloudfront_distribution" "distribution" {
 
-  comment                  = "Opta managed cloudfront distribution ${var.layer_name}-${var.module_name}"
-  enabled                  = true
-  is_ipv6_enabled          = true
-  price_class              = var.price_class
-  aliases                  = var.acm_cert_arn == "" ? [] : var.domains
-  minimum_protocol_version = "TLSv1.2_2021"
+  comment         = "Opta managed cloudfront distribution ${var.layer_name}-${var.module_name}"
+  enabled         = true
+  is_ipv6_enabled = true
+  price_class     = var.price_class
+  aliases         = var.acm_cert_arn == "" ? [] : var.domains
+
   dynamic "logging_config" {
     for_each = var.s3_log_bucket_name == null ? [] : [1]
     content {
@@ -37,7 +39,8 @@ resource "aws_cloudfront_distribution" "distribution" {
       restriction_type = "none"
     }
   }
-
+  # Ignored this because https://github.com/run-x/opta/pull/841#issuecomment-1102915968
+  #tfsec:ignore:aws-cloudfront-use-secure-tls-policy
   viewer_certificate {
     cloudfront_default_certificate = var.acm_cert_arn == "" ? true : false
     acm_certificate_arn            = var.acm_cert_arn


### PR DESCRIPTION
# Description

https://aquasecurity.github.io/tfsec/v1.18.0/checks/aws/cloudfront/use-secure-tls-policy/




# Safety checklist
* [ ] This change is backwards compatible and safe to apply by existing users
* [ ] This change will NOT lead to data loss
* [ ] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
YOUR_ANSWER
