### PR TITLE
Adding a series of resource updates to opta

### DIFF
--- a/modules/aws_k8s_base/tf_module/autoscaler.tf
+++ b/modules/aws_k8s_base/tf_module/autoscaler.tf
@@ -56,10 +56,16 @@ resource "helm_release" "autoscaler" {
   repository = "https://kubernetes.github.io/autoscaler"
   values = [
     yamlencode({
-      extraArgs : { "skip-nodes-with-local-storage" : false }
+      extraArgs : { "skip-nodes-with-local-storage" : false, "scale-down-utilization-threshold" : "0.75" }
       autoDiscovery : {
         clusterName : var.eks_cluster_name
       },
+      resources : {
+        requests : {
+          cpu : "100m",
+          memory : "200Mi"
+        }
+      }
       rbac : {
         serviceAccount : {
           annotations : {

--- a/modules/aws_k8s_base/tf_module/ingress_nginx.tf
+++ b/modules/aws_k8s_base/tf_module/ingress_nginx.tf
@@ -61,11 +61,14 @@ resource "helm_release" "ingress-nginx" {
           "config.linkerd.io/skip-inbound-ports" : "80,443" // NOTE: should be removed when this is fixed: https://github.com/linkerd/linkerd2/issues/4219
           "viz.linkerd.io/tap-enabled" : "true"
           "cluster-autoscaler.kubernetes.io/safe-to-evict" : "true"
+          "config.linkerd.io/proxy-cpu-request" : "0.05"
+          "config.linkerd.io/proxy-memory-limit" : "20Mi"
+          "config.linkerd.io/proxy-memory-request" : "10Mi"
         }
         resources : {
           requests : {
-            cpu : "200m"
-            memory : "250Mi"
+            cpu : "100m"
+            memory : "150Mi"
           }
         }
         autoscaling : {

--- a/modules/aws_k8s_base/tf_module/values-ha.yaml
+++ b/modules/aws_k8s_base/tf_module/values-ha.yaml
@@ -4,24 +4,25 @@
 
 enablePodAntiAffinity: true
 
-global:
-  # proxy configuration
-  proxy:
-    resources:
-      cpu:
-        request: 100m
-      memory:
-        limit: 250Mi
-        request: 20Mi
+# We explicitly set the annotations in ingress-nginx and k8s service, but leaving this here for whatever else a user
+# may add.
+proxy:
+  resources:
+    cpu:
+      request: 50m
+      limit: ""
+    memory:
+      limit: 100Mi
+      request: 20Mi
 
 # controller configuration
 controllerReplicas: 3
 controllerResources: &controller_resources
   cpu: &controller_resources_cpu
     limit: ""
-    request: 100m
+    request: 50m
   memory:
-    limit: 250Mi
+    limit: ""
     request: 50Mi
 destinationResources: *controller_resources
 publicAPIResources: *controller_resources
@@ -30,29 +31,8 @@ publicAPIResources: *controller_resources
 identityResources:
   cpu: *controller_resources_cpu
   memory:
-    limit: 250Mi
+    limit: ""
     request: 10Mi
-
-# grafana configuration
-grafana:
-  resources:
-    cpu: *controller_resources_cpu
-    memory:
-      limit: 1024Mi
-      request: 50Mi
-
-# heartbeat configuration
-heartbeatResources: *controller_resources
-
-# prometheus configuration
-prometheus:
-  resources:
-    cpu:
-      limit: ""
-      request: 300m
-    memory:
-      limit: 8192Mi
-      request: 300Mi
 
 # proxy injector configuration
 proxyInjectorResources: *controller_resources
@@ -61,11 +41,6 @@ webhookFailurePolicy: Fail
 # service profile validator configuration
 spValidatorResources: *controller_resources
 
-# tap configuration
-tapResources: *controller_resources
-
-# web configuration
-webResources: *controller_resources
 # proxy injector configuration
 proxyInjector:
   # -- Namespace selector used by admission webhook. If not set defaults to all
@@ -73,12 +48,12 @@ proxyInjector:
   # config.linkerd.io/admission-webhooks=disabled
   namespaceSelector:
     matchExpressions:
-    - key: config.linkerd.io/admission-webhooks
-      operator: NotIn
-      values:
-      - disabled
-    - key: kubernetes.io/metadata.name
-      operator: NotIn
-      values:
-      - kube-system
+      - key: config.linkerd.io/admission-webhooks
+        operator: NotIn
+        values:
+          - disabled
+      - key: kubernetes.io/metadata.name
+        operator: NotIn
+        values:
+          - kube-system
     

--- a/modules/azure_k8s_base/tf_module/ingress_nginx.tf
+++ b/modules/azure_k8s_base/tf_module/ingress_nginx.tf
@@ -73,8 +73,8 @@ resource "helm_release" "ingress-nginx" {
         }
         resources : {
           requests : {
-            cpu : "200m"
-            memory : "250Mi"
+            cpu : "100m"
+            memory : "150Mi"
           }
         }
         autoscaling : {

--- a/modules/azure_k8s_base/tf_module/ingress_nginx.tf
+++ b/modules/azure_k8s_base/tf_module/ingress_nginx.tf
@@ -67,6 +67,9 @@ resource "helm_release" "ingress-nginx" {
           "config.linkerd.io/skip-inbound-ports" : "80,443" // NOTE: should be removed when this is fixed: https://github.com/linkerd/linkerd2/issues/4219
           "linkerd.io/inject" : "enabled"
           "viz.linkerd.io/tap-enabled" : "true"
+          "config.linkerd.io/proxy-cpu-request" : "0.05"
+          "config.linkerd.io/proxy-memory-limit" : "20Mi"
+          "config.linkerd.io/proxy-memory-request" : "10Mi"
         }
         resources : {
           requests : {

--- a/modules/azure_k8s_base/tf_module/values-ha.yaml
+++ b/modules/azure_k8s_base/tf_module/values-ha.yaml
@@ -4,24 +4,25 @@
 
 enablePodAntiAffinity: true
 
-global:
-  # proxy configuration
-  proxy:
-    resources:
-      cpu:
-        request: 100m
-      memory:
-        limit: 250Mi
-        request: 20Mi
+# We explicitly set the annotations in ingress-nginx and k8s service, but leaving this here for whatever else a user
+# may add.
+proxy:
+  resources:
+    cpu:
+      request: 50m
+      limit: ""
+    memory:
+      limit: 100Mi
+      request: 20Mi
 
 # controller configuration
 controllerReplicas: 3
 controllerResources: &controller_resources
   cpu: &controller_resources_cpu
     limit: ""
-    request: 100m
+    request: 50m
   memory:
-    limit: 250Mi
+    limit: ""
     request: 50Mi
 destinationResources: *controller_resources
 publicAPIResources: *controller_resources
@@ -30,29 +31,8 @@ publicAPIResources: *controller_resources
 identityResources:
   cpu: *controller_resources_cpu
   memory:
-    limit: 250Mi
+    limit: ""
     request: 10Mi
-
-# grafana configuration
-grafana:
-  resources:
-    cpu: *controller_resources_cpu
-    memory:
-      limit: 1024Mi
-      request: 50Mi
-
-# heartbeat configuration
-heartbeatResources: *controller_resources
-
-# prometheus configuration
-prometheus:
-  resources:
-    cpu:
-      limit: ""
-      request: 300m
-    memory:
-      limit: 8192Mi
-      request: 300Mi
 
 # proxy injector configuration
 proxyInjectorResources: *controller_resources
@@ -61,11 +41,6 @@ webhookFailurePolicy: Fail
 # service profile validator configuration
 spValidatorResources: *controller_resources
 
-# tap configuration
-tapResources: *controller_resources
-
-# web configuration
-webResources: *controller_resources
 # proxy injector configuration
 proxyInjector:
   # -- Namespace selector used by admission webhook. If not set defaults to all
@@ -73,12 +48,12 @@ proxyInjector:
   # config.linkerd.io/admission-webhooks=disabled
   namespaceSelector:
     matchExpressions:
-    - key: config.linkerd.io/admission-webhooks
-      operator: NotIn
-      values:
-      - disabled
-    - key: kubernetes.io/metadata.name
-      operator: NotIn
-      values:
-      - kube-system
+      - key: config.linkerd.io/admission-webhooks
+        operator: NotIn
+        values:
+          - disabled
+      - key: kubernetes.io/metadata.name
+        operator: NotIn
+        values:
+          - kube-system
     

--- a/modules/gcp_k8s_base/tf_module/ingress_nginx.tf
+++ b/modules/gcp_k8s_base/tf_module/ingress_nginx.tf
@@ -20,6 +20,9 @@ resource "helm_release" "ingress-nginx" {
           "linkerd.io/inject" : "enabled"
           "viz.linkerd.io/tap-enabled" : "true"
           "cluster-autoscaler.kubernetes.io/safe-to-evict" : "true"
+          "config.linkerd.io/proxy-cpu-request" : "0.05"
+          "config.linkerd.io/proxy-memory-limit" : "20Mi"
+          "config.linkerd.io/proxy-memory-request" : "10Mi"
         }
         resources : {
           requests : {

--- a/modules/gcp_k8s_base/tf_module/ingress_nginx.tf
+++ b/modules/gcp_k8s_base/tf_module/ingress_nginx.tf
@@ -26,8 +26,8 @@ resource "helm_release" "ingress-nginx" {
         }
         resources : {
           requests : {
-            cpu : "200m"
-            memory : "250Mi"
+            cpu : "100m"
+            memory : "150Mi"
           }
         }
         autoscaling : {

--- a/modules/gcp_k8s_base/tf_module/values-ha.yaml
+++ b/modules/gcp_k8s_base/tf_module/values-ha.yaml
@@ -4,24 +4,25 @@
 
 enablePodAntiAffinity: true
 
-global:
-  # proxy configuration
-  proxy:
-    resources:
-      cpu:
-        request: 100m
-      memory:
-        limit: 250Mi
-        request: 20Mi
+# We explicitly set the annotations in ingress-nginx and k8s service, but leaving this here for whatever else a user
+# may add.
+proxy:
+  resources:
+    cpu:
+      request: 50m
+      limit: ""
+    memory:
+      limit: 100Mi
+      request: 20Mi
 
 # controller configuration
 controllerReplicas: 3
 controllerResources: &controller_resources
   cpu: &controller_resources_cpu
     limit: ""
-    request: 100m
+    request: 50m
   memory:
-    limit: 250Mi
+    limit: ""
     request: 50Mi
 destinationResources: *controller_resources
 publicAPIResources: *controller_resources
@@ -30,29 +31,8 @@ publicAPIResources: *controller_resources
 identityResources:
   cpu: *controller_resources_cpu
   memory:
-    limit: 250Mi
+    limit: ""
     request: 10Mi
-
-# grafana configuration
-grafana:
-  resources:
-    cpu: *controller_resources_cpu
-    memory:
-      limit: 1024Mi
-      request: 50Mi
-
-# heartbeat configuration
-heartbeatResources: *controller_resources
-
-# prometheus configuration
-prometheus:
-  resources:
-    cpu:
-      limit: ""
-      request: 300m
-    memory:
-      limit: 8192Mi
-      request: 300Mi
 
 # proxy injector configuration
 proxyInjectorResources: *controller_resources
@@ -61,12 +41,6 @@ webhookFailurePolicy: Fail
 # service profile validator configuration
 spValidatorResources: *controller_resources
 
-# tap configuration
-tapResources: *controller_resources
-
-# web configuration
-webResources: *controller_resources
-
 # proxy injector configuration
 proxyInjector:
   # -- Namespace selector used by admission webhook. If not set defaults to all
@@ -74,12 +48,12 @@ proxyInjector:
   # config.linkerd.io/admission-webhooks=disabled
   namespaceSelector:
     matchExpressions:
-    - key: config.linkerd.io/admission-webhooks
-      operator: NotIn
-      values:
-      - disabled
-    - key: kubernetes.io/metadata.name
-      operator: NotIn
-      values:
-      - kube-system
+      - key: config.linkerd.io/admission-webhooks
+        operator: NotIn
+        values:
+          - disabled
+      - key: kubernetes.io/metadata.name
+        operator: NotIn
+        values:
+          - kube-system
     

--- a/modules/opta-k8s-service-helm/templates/deployment.yaml
+++ b/modules/opta-k8s-service-helm/templates/deployment.yaml
@@ -32,10 +32,9 @@ spec:
         ad.datadoghq.com/linkerd-proxy.init_configs: '[{}]'
         ad.datadoghq.com/linkerd-proxy.instances: '[{"prometheus_url": "http://%%host%%:4191/metrics"}]'
         # See https://linkerd.io/2021/05/27/linkerd-vs-istio-benchmarks/
-        config.linkerd.io/proxy-cpu-limit: "0.1"
         config.linkerd.io/proxy-cpu-request: "0.05"
-        config.linkerd.io/proxy-memory-limit: "20Mi"
-        config.linkerd.io/proxy-memory-request: "10Mi"
+        config.linkerd.io/proxy-memory-limit: "100Mi"
+        config.linkerd.io/proxy-memory-request: "20Mi"
         viz.linkerd.io/tap-enabled: "true"
         {{- range $k, $v := $.Values.podAnnotations }}
         {{ $k | quote }}: {{ $v | quote }}

--- a/modules/opta-k8s-service-helm/templates/statefulset.yaml
+++ b/modules/opta-k8s-service-helm/templates/statefulset.yaml
@@ -44,7 +44,6 @@ spec:
         ad.datadoghq.com/linkerd-proxy.init_configs: '[{}]'
         ad.datadoghq.com/linkerd-proxy.instances: '[{"prometheus_url": "http://%%host%%:4191/metrics"}]'
         # See https://linkerd.io/2021/05/27/linkerd-vs-istio-benchmarks/
-        config.linkerd.io/proxy-cpu-limit: "0.1"
         config.linkerd.io/proxy-cpu-request: "0.05"
         config.linkerd.io/proxy-memory-limit: "20Mi"
         config.linkerd.io/proxy-memory-request: "10Mi"


### PR DESCRIPTION
# Description
1. More default resources to linkerd pods in k8s service
2. Fixed obsolete linkerd HA values yaml to have proper values and set catch-all sidecar resources
3. Added missing linkerd proxy resource annotations to nginx
4. Added resource requests to autoscaler

# Safety checklist
* [x] This change is backwards compatible and safe to apply by existing users
* [x] This change will NOT lead to data loss
* [x] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
manually
