### PR TITLE
cli subcommand: opta help [COMMAND]

### DIFF
--- a/opta/cli.py
+++ b/opta/cli.py
@@ -16,6 +16,7 @@ from opta.commands.destroy import destroy
 from opta.commands.events import events
 from opta.commands.force_unlock import force_unlock
 from opta.commands.generate_terraform import generate_terraform
+from opta.commands.help import help
 from opta.commands.inspect_cmd import inspect
 from opta.commands.kubectl import configure_kubectl
 from opta.commands.logs import logs
@@ -64,6 +65,7 @@ cli.add_command(force_unlock)
 cli.add_command(upgrade)
 cli.add_command(generate_terraform)
 cli.add_command(config)
+cli.add_command(help)
 
 
 if __name__ == "__main__":

--- a/opta/commands/help.py
+++ b/opta/commands/help.py
@@ -1,0 +1,23 @@
+# type: ignore
+from typing import Optional
+
+import click
+from click import Context
+from click_didyoumean import DYMGroup
+
+from opta.exceptions import UserErrors
+
+
+@click.command()
+@click.pass_context
+@click.argument("command", required=False)
+def help(context: Context, command: Optional[str]) -> None:
+    """
+    Get help for Opta.
+    """
+    command_context: DYMGroup = context.parent.command
+    if command is not None and not context.parent.command.commands.__contains__(command):
+        raise UserErrors("Invalid Command")
+    if command:
+        command_context = context.parent.commands.get(command)
+    print(command_context.get_help(context))

--- a/opta/commands/help.py
+++ b/opta/commands/help.py
@@ -14,10 +14,16 @@ from opta.exceptions import UserErrors
 def help(context: Context, command: Optional[str]) -> None:
     """
     Get help for Opta.
+
+    Example:
+
+    opta help
+
+    opta help apply
     """
     command_context: DYMGroup = context.parent.command
     if command is not None and not context.parent.command.commands.__contains__(command):
         raise UserErrors("Invalid Command")
     if command:
-        command_context = context.parent.commands.get(command)
+        command_context = context.parent.command.commands.get(command)
     print(command_context.get_help(context))

--- a/opta/commands/help.py
+++ b/opta/commands/help.py
@@ -22,8 +22,11 @@ def help(context: Context, command: Optional[str]) -> None:
     opta help apply
     """
     command_context: DYMGroup = context.parent.command
-    if command is not None and not context.parent.command.commands.__contains__(command):
-        raise UserErrors("Invalid Command")
-    if command:
-        command_context = context.parent.command.commands.get(command)
+    if command is not None:
+        try:
+            command_context = command_context.commands[command]
+        except KeyError:
+            raise UserErrors(
+                "Invalid Command. Please use correct commands mentioned in `opta help|-h|--help "
+            )
     print(command_context.get_help(context))

--- a/opta/commands/help.py
+++ b/opta/commands/help.py
@@ -1,9 +1,7 @@
-# type: ignore
 from typing import Optional
 
 import click
 from click import Context
-from click_didyoumean import DYMGroup
 
 from opta.exceptions import UserErrors
 
@@ -21,10 +19,10 @@ def help(context: Context, command: Optional[str]) -> None:
 
     opta help apply
     """
-    command_context: DYMGroup = context.parent.command
+    command_context = context.parent.command  # type: ignore
     if command is not None:
         try:
-            command_context = command_context.commands[command]
+            command_context = command_context.commands[command]  # type: ignore
         except KeyError:
             raise UserErrors(
                 "Invalid Command. Please use correct commands mentioned in `opta help|-h|--help "


### PR DESCRIPTION
# Description
Adding a new cli sub command:
`opta help [COMMAND]`

# Safety checklist
* [x] This change is backwards compatible and safe to apply by existing users
* [x] This change will NOT lead to data loss
* [x] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
Examples:

> ```bash
> > opta help
> Usage: opta help [OPTIONS] COMMAND [ARGS]...
> 
>   Welcome to opta, runx's cli! Supercharge DevOps on any cloud
> 
>   Github: https://github.com/run-x/opta
> 
>   Documentation: https://docs.opta.dev/
> 
> Options:
>   -h, --help  Show this message and exit.
> 
> Commands:
>   apply               Create or update infrastructure
>   config              Manage opta configurations
>   configure-kubectl   Configure kubectl so you can connect to the cluster
>   deploy              Deploys an image to Kubernetes
>   destroy             Destroy all opta resources from the current config
>   force-unlock        Release a stuck lock on the current workspace
>   generate-terraform  (beta) Generate Terraform language files
>   help                Get help for Opta.
>   logs                Get stream of logs for a service
>   output              Print TF outputs
>   secret              Manage secrets for a service
>   shell               Get a shell into one of the pods in a service
>   ui                  Open the interactive UI
>   upgrade             Upgrade Opta to the latest version available
> ```

> ```bash
> opta help apply
> Usage: opta help [OPTIONS]
> 
>   Create or update infrastructure
> 
>   Apply changes to match the Opta configuration files in the current
>   directory.
> 
>   Examples:
> 
>   opta apply --auto-approve
> 
>   opta apply --auto-approve --var variable1=value1
> 
>   opta apply -c my-config.yaml --image-tag=v1
> 
> Options:
>   --image-tag TEXT   If this handles a service, it's the image tag you wanna
>                      deploy
>   --auto-approve     Automatically approve terraform plan.
>   --detailed-plan    Show full terraform plan in detail, not the opta provided
>                      summary
>   -c, --config TEXT  Opta config file  [default: opta.yaml]
>   -e, --env TEXT     The env to use when loading the config file
>   -v, --var TEXT     Add input variables to your yaml at run time (e.g. --var
>                      variable1=value1)
>   --local            Use the local Kubernetes cluster for development and
>                      testing, irrespective of the environment specified inside
>                      the opta service yaml file
>   -h, --help         Show this message and exit.
> ```
