### PR TITLE
Adding warnings for opta destroy and how to start debugging

### DIFF
--- a/opta/cli.py
+++ b/opta/cli.py
@@ -90,6 +90,7 @@ if __name__ == "__main__":
             f"{fg('red')}Unhandled error encountered -- a crash report zipfile has been created for you. "
             "If you need more help please reach out (passing the crash report) to the contributors in our "
             f"slack channel at: https://slack.opta.dev{attr(0)}"
+            "\nHint: As a first step in debugging, try rerunning the command and seeing if it still fails."
         )
         CURRENT_CRASH_REPORTER.generate_report()
         sys.exit(1)

--- a/opta/commands/destroy.py
+++ b/opta/commands/destroy.py
@@ -7,7 +7,7 @@ import boto3
 import click
 from azure.storage.blob import ContainerClient
 from botocore.config import Config
-from colored import attr
+from colored import attr, fg
 from google.cloud import storage  # type: ignore
 from google.cloud.exceptions import NotFound
 
@@ -71,6 +71,14 @@ def destroy(
     try:
         opta_acquire_lock()
         pre_check()
+        logger.warn(
+            f"You are destroying your cloud infra state. {fg('magenta')}DO NOT, I REPEAT, DO NOT{attr(0)} do this as "
+            "an attempt to debug a weird/errored apply. What you have created is not some ephemeral object that can be "
+            "tossed arbitrarily (perhaps some day) and destroying unnecessarily just to reapply typically makes it "
+            "worse. If you're doing this cause you are really trying to destroy the environment entirely, then that's"
+            "perfectly fine-- if not then please reach out to the opta team in the slack workspace "
+            "(https://slack.opta.dev) and I promise that they'll be happy to help debug."
+        )
 
         config = check_opta_file_exists(config)
         if local:


### PR DESCRIPTION
# Description


# Safety checklist
* [x] This change is backwards compatible and safe to apply by existing users
* [x] This change will NOT lead to data loss
* [x] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
Manually