### PR TITLE
Add support for secrets for helm charts

### DIFF
--- a/opta/commands/secret.py
+++ b/opta/commands/secret.py
@@ -46,6 +46,9 @@ def get_secret_name_and_namespace(
     k8s_services = layer.get_module_by_type("k8s-service")
     helm_charts = layer.get_module_by_type("helm-chart")
     total_modules = k8s_services + helm_charts
+    
+    if not total_modules:
+        raise UserErrors(f"No helm/k8s-service modules were configured")
     if module_name is None and len(total_modules) > 1:
         module_name = click.prompt(
             "Multiple k8s-service/helm chart modules found. Please specify which one do you want the secret for.",

--- a/opta/commands/secret.py
+++ b/opta/commands/secret.py
@@ -54,11 +54,12 @@ def get_secret_name_and_namespace(
     if module_name is None:
         module: Module = total_modules[0]
     else:
-        module = layer.get_module(module_name)  # type: ignore
-        if module is None:
+        try:
+            module = next(module for module in total_modules if module.name == module_name)
+        except StopIteration:
             raise UserErrors(
                 f"Could not find helm/k8s-service module with name {module_name}"
-            )
+            ) from None
 
     if module.type == "k8s-service":
         return "manual-secrets", layer.name

--- a/opta/commands/secret.py
+++ b/opta/commands/secret.py
@@ -48,7 +48,7 @@ def get_secret_name_and_namespace(
     total_modules = k8s_services + helm_charts
 
     if not total_modules:
-        raise UserErrors(f"No helm/k8s-service modules were configured")
+        raise UserErrors("No helm/k8s-service modules were configured")
     if module_name is None and len(total_modules) > 1:
         module_name = click.prompt(
             "Multiple k8s-service/helm chart modules found. Please specify which one do you want the secret for.",

--- a/opta/commands/secret.py
+++ b/opta/commands/secret.py
@@ -46,7 +46,7 @@ def get_secret_name_and_namespace(
     k8s_services = layer.get_module_by_type("k8s-service")
     helm_charts = layer.get_module_by_type("helm-chart")
     total_modules = k8s_services + helm_charts
-    
+
     if not total_modules:
         raise UserErrors(f"No helm/k8s-service modules were configured")
     if module_name is None and len(total_modules) > 1:
@@ -58,7 +58,9 @@ def get_secret_name_and_namespace(
         module: Module = total_modules[0]
     else:
         try:
-            module = next(module for module in total_modules if module.name == module_name)
+            module = next(
+                module for module in total_modules if module.name == module_name
+            )
         except StopIteration:
             raise UserErrors(
                 f"Could not find helm/k8s-service module with name {module_name}"

--- a/opta/core/secrets.py
+++ b/opta/core/secrets.py
@@ -2,7 +2,7 @@ import os
 
 from dotenv import dotenv_values
 
-from opta.core.kubernetes import delete_secret_key, get_namespaced_secrets, update_secrets
+from opta.core.kubernetes import get_namespaced_secrets, update_secrets
 from opta.exceptions import UserErrors
 from opta.utils import deep_merge, logger
 
@@ -10,10 +10,12 @@ MANUAL_SECRET_NAME = "manual-secrets"  # nosec
 LINKED_SECRET_NAME = "secret"  # nosec
 
 
-def get_secrets(layer_name: str) -> dict:
+def get_secrets(namespace: str, manual_secret_name: str) -> dict:
     """:return: manual and linked secrets"""
-    manual_secrets = get_namespaced_secrets(layer_name, MANUAL_SECRET_NAME)
-    linked_secrets = get_namespaced_secrets(layer_name, LINKED_SECRET_NAME)
+    manual_secrets = get_namespaced_secrets(namespace, manual_secret_name)
+    linked_secrets = get_namespaced_secrets(
+        namespace, LINKED_SECRET_NAME
+    )  # Helm charts don't have linked secrets, but it'll just return an empty dict so no worries
     for secret_name in manual_secrets.keys():
         if secret_name in linked_secrets:
             logger.warning(
@@ -23,23 +25,9 @@ def get_secrets(layer_name: str) -> dict:
     return deep_merge(manual_secrets, linked_secrets)
 
 
-def update_manual_secrets(layer_name: str, new_values: dict) -> None:
-    """
-    append the new values to the existing data for this manual secret.
-
-    create the secret if it doesn't exist yet.
-    """
-    update_secrets(layer_name, MANUAL_SECRET_NAME, new_values)
-
-
-def delete_manual_secret(layer_name: str, secret_name: str) -> None:
-    """
-    remove an entry from the manual secret.
-    """
-    delete_secret_key(layer_name, MANUAL_SECRET_NAME, secret_name)
-
-
-def bulk_update_manual_secrets(layer_name: str, env_file: str) -> None:
+def bulk_update_manual_secrets(
+    namespace: str, manual_secret_name: str, env_file: str
+) -> None:
     """
     append the values from the env file to the existing data for this manual secret.
 
@@ -50,4 +38,4 @@ def bulk_update_manual_secrets(layer_name: str, env_file: str) -> None:
     if not os.path.exists(env_file):
         raise UserErrors(f"Could not find file {env_file}")
     new_values = dotenv_values(env_file)
-    update_manual_secrets(layer_name, new_values)
+    update_secrets(namespace, manual_secret_name, new_values)


### PR DESCRIPTION
# Description
Treat them exactly as you would for k8s-service. Even works for when a k8s-service and helm-chart are in the same yaml, or multiple helm charts in the same yaml.


# Safety checklist
* [x] This change is backwards compatible and safe to apply by existing users
* [x] This change will NOT lead to data loss
* [x] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
manually
