### PR TITLE
Prompt users for upgrading instead of failing.

### DIFF
--- a/opta/commands/apply.py
+++ b/opta/commands/apply.py
@@ -14,6 +14,7 @@ from colored import attr, fg
 from opta.amplitude import amplitude_client
 from opta.cleanup_files import cleanup_files
 from opta.commands.local_flag import _clean_tf_folder, _handle_local_flag
+from opta.commands.upgrade import _upgrade
 from opta.constants import DEV_VERSION, TF_PLAN_PATH, UPGRADE_WARNINGS, VERSION
 from opta.core.aws import AWS
 from opta.core.azure import Azure
@@ -333,10 +334,16 @@ def _verify_semver(
     old_semver = semver.VersionInfo.parse(old_semver_string)
     current_semver = semver.VersionInfo.parse(current_semver_string)
     if old_semver > current_semver:
-        raise UserErrors(
-            f"You're trying to run an older version of opta (last run with version {old_semver}). "
-            "Please update to the latest version and try again!"
+        logger.warn(
+            f"You're trying to run an older version ({current_semver}) of opta (last run with version {old_semver})."
         )
+        if not auto_approve:
+            click.confirm(
+                "Do you wish to upgrade to the latest version of Opta?", abort=True,
+            )
+        _upgrade()
+        logger.info("Please rerun the command if the upgrade was successful.")
+        exit(0)
 
     present_modules = [k.aliased_type or k.type for k in layer.modules]
 

--- a/opta/commands/upgrade.py
+++ b/opta/commands/upgrade.py
@@ -36,6 +36,10 @@ def upgrade() -> None:
     """
     Upgrade Opta to the latest version available
     """
+    _upgrade()
+
+
+def _upgrade() -> None:
     try:
         upgrade_present = check_version_upgrade(is_upgrade_call=True)
         if upgrade_present:

--- a/tests/commands/test_apply.py
+++ b/tests/commands/test_apply.py
@@ -214,8 +214,10 @@ def test_verify_semver_all_good(mocker: MockFixture, mocked_layer: Any) -> None:
 
 
 def test_verify_semver_older_version(mocker: MockFixture, mocked_layer: Any) -> None:
-    with pytest.raises(UserErrors):
-        _verify_semver("0.2.0", "0.1.0", mocked_layer)
+    mock_upgrade = mocker.patch("opta.commands.apply._upgrade")
+    with pytest.raises(SystemExit):
+        _verify_semver("0.2.0", "0.1.0", mocked_layer, True)
+    mock_upgrade.assert_called_once()
 
 
 def test_verify_semver_upgrade_warning(mocker: MockFixture, mocked_layer: Any) -> None:


### PR DESCRIPTION
# Description
Prompt Users about Opta upgrade, instead of failing.

# Safety checklist
* [x] This change is backwards compatible and safe to apply by existing users
* [x] This change will NOT lead to data loss
* [x] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
Tested Manually.
