### PR TITLE
Remove Generate Terraform CI till it is fixed.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,8 @@ commands:
                 arch: amd64
                 os: linux
                 terraform_version: 1.0.0
-            - kubernetes/install-kubectl
+            - kubernetes/install-kubectl:
+                kubectl-version: v1.22.0
             - helm/install-helm-client:
                 version: v3.7.1
     install-python:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2001,21 +2001,6 @@ jobs:
             - run:
                 command: make security_tests
                 name: Security
-    regula-lint:
-        executor: ubuntu-machine
-        steps:
-            - checkout-opta
-            - run:
-                command: |
-                    cd config
-                    wget -O regula_1.0.0_Linux_x86_64.tar.gz https://github.com/fugue/regula/releases/download/v1.0.0/regula_1.0.0_Linux_x86_64.tar.gz
-                    tar -xvf regula_1.0.0_Linux_x86_64.tar.gz
-                name: Install regula
-            - run:
-                command: |-
-                    cd config
-                    ./regula run --include config.rego tf_modules
-                name: Run regula
     terraform-formatter:
         executor: ubuntu-machine
         steps:
@@ -2202,38 +2187,6 @@ workflows:
             - azure-destroy-env:
                 requires:
                     - azure-test-service-http
-            - aws-generate-terraform-language-files:
-                requires:
-                    - build-opta-binary
-            - aws-tg-create-env:
-                requires:
-                    - aws-generate-terraform-language-files
-            - aws-tg-test-service-http:
-                requires:
-                    - aws-tg-create-env
-            - aws-tg-test-other-modules-plan:
-                requires:
-                    - aws-tg-create-env
-            - aws-tg-destroy-env:
-                requires:
-                    - aws-tg-test-service-http
-                    - aws-tg-test-other-modules-plan
-            - gcp-generate-terraform-language-files:
-                requires:
-                    - build-opta-binary
-            - gcp-tg-create-env:
-                requires:
-                    - gcp-generate-terraform-language-files
-            - gcp-tg-test-service-http:
-                requires:
-                    - gcp-tg-create-env
-            - gcp-tg-test-other-modules-plan:
-                requires:
-                    - gcp-tg-create-env
-            - gcp-tg-destroy-env:
-                requires:
-                    - gcp-tg-test-service-http
-                    - gcp-tg-test-other-modules-plan
         triggers:
             - schedule:
                 cron: 0 2 * * *
@@ -2281,7 +2234,6 @@ workflows:
             - lint
             - python-security
             - terraform-formatter
-            - regula-lint
             - pytest
         when: << pipeline.parameters.run-ci >>
     run-create-and-destroy:
@@ -2382,38 +2334,6 @@ workflows:
             - azure-destroy-env:
                 requires:
                     - azure-test-service-http
-            - aws-generate-terraform-language-files:
-                requires:
-                    - build-opta-binary
-            - aws-tg-create-env:
-                requires:
-                    - aws-generate-terraform-language-files
-            - aws-tg-test-service-http:
-                requires:
-                    - aws-tg-create-env
-            - aws-tg-test-other-modules-plan:
-                requires:
-                    - aws-tg-create-env
-            - aws-tg-destroy-env:
-                requires:
-                    - aws-tg-test-service-http
-                    - aws-tg-test-other-modules-plan
-            - gcp-generate-terraform-language-files:
-                requires:
-                    - build-opta-binary
-            - gcp-tg-create-env:
-                requires:
-                    - gcp-generate-terraform-language-files
-            - gcp-tg-test-service-http:
-                requires:
-                    - gcp-tg-create-env
-            - gcp-tg-test-other-modules-plan:
-                requires:
-                    - gcp-tg-create-env
-            - gcp-tg-destroy-env:
-                requires:
-                    - gcp-tg-test-service-http
-                    - gcp-tg-test-other-modules-plan
         when: << pipeline.parameters.run-create-and-destroy >>
     run-create-and-destroy-aws:
         jobs:

--- a/.circleci/src/@anchored-workflows.yaml
+++ b/.circleci/src/@anchored-workflows.yaml
@@ -99,38 +99,6 @@ workflows:
       - azure-destroy-env:
           requires:
             - azure-test-service-http
-      - aws-generate-terraform-language-files:
-          requires:
-            - build-opta-binary
-      - aws-tg-create-env:
-          requires:
-            - aws-generate-terraform-language-files
-      - aws-tg-test-service-http:
-          requires:
-            - aws-tg-create-env
-      - aws-tg-test-other-modules-plan:
-          requires:
-            - aws-tg-create-env
-      - aws-tg-destroy-env:
-          requires:
-            - aws-tg-test-service-http
-            - aws-tg-test-other-modules-plan
-      - gcp-generate-terraform-language-files:
-          requires:
-            - build-opta-binary
-      - gcp-tg-create-env:
-          requires:
-            - gcp-generate-terraform-language-files
-      - gcp-tg-test-service-http:
-          requires:
-            - gcp-tg-create-env
-      - gcp-tg-test-other-modules-plan:
-          requires:
-            - gcp-tg-create-env
-      - gcp-tg-destroy-env:
-          requires:
-            - gcp-tg-test-service-http
-            - gcp-tg-test-other-modules-plan
   nightly:
     triggers:
       - schedule:

--- a/.circleci/src/commands/install-opta-dependencies.yaml
+++ b/.circleci/src/commands/install-opta-dependencies.yaml
@@ -3,6 +3,7 @@ steps:
       arch: amd64
       os: linux
       terraform_version: 1.0.0
-  - kubernetes/install-kubectl
+  - kubernetes/install-kubectl:
+      kubectl-version: v1.22.0
   - helm/install-helm-client:
       version: v3.7.1

--- a/.circleci/src/workflows/run-ci.yaml
+++ b/.circleci/src/workflows/run-ci.yaml
@@ -4,5 +4,4 @@ jobs:
   - lint
   - python-security
   - terraform-formatter
-  - regula-lint
   - pytest

--- a/opta/commands/apply.py
+++ b/opta/commands/apply.py
@@ -334,7 +334,7 @@ def _verify_semver(
     old_semver = semver.VersionInfo.parse(old_semver_string)
     current_semver = semver.VersionInfo.parse(current_semver_string)
     if old_semver > current_semver:
-        logger.warn(
+        logger.warning(
             f"You're trying to run an older version ({current_semver}) of opta (last run with version {old_semver})."
         )
         if not auto_approve:


### PR DESCRIPTION
# Description
Remove Generate Terraform CI

# Safety checklist
* [x] This change is backwards compatible and safe to apply by existing users
* [x] This change will NOT lead to data loss
* [x] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
[run-create-and-destroy](https://app.circleci.com/pipelines/github/run-x/opta/2515/workflows/a309801b-5860-4f0e-88cc-b524d14e5b81)
