### PR TITLE
Add the terraform generated test case to Nightly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -891,9 +891,11 @@ jobs:
                 command: |
                     cd $HOME/generated-tf-files-aws
                     terraform init
-                    terraform refresh
-                    terraform state rm module.base.aws_ebs_default_kms_key.default
-                    terraform plan -compact-warnings -lock=false -input=false -out=tf.plan -target=module.base -target=module.k8scluster -target=module.k8sbase -destroy
+                    terraform plan -compact-warnings -lock=false -input=false -out=tf.plan -target=module.k8sbase -destroy
+                    terraform apply -compact-warnings -auto-approve tf.plan
+                    terraform plan -compact-warnings -lock=false -input=false -out=tf.plan -target=module.k8scluster -destroy
+                    terraform apply -compact-warnings -auto-approve tf.plan
+                    terraform plan -compact-warnings -lock=false -input=false -out=tf.plan -target=module.base -destroy
                     terraform apply -compact-warnings -auto-approve tf.plan
                 name: Destroy Terraform Generated Environment
             - store_artifacts:
@@ -2528,22 +2530,6 @@ workflows:
                 requires:
                     - aws-tg-test-service-http
                     - aws-tg-test-other-modules-plan
-            - gcp-generate-terraform-language-files:
-                requires:
-                    - build-opta-binary
-            - gcp-tg-create-env:
-                requires:
-                    - gcp-generate-terraform-language-files
-            - gcp-tg-test-service-http:
-                requires:
-                    - gcp-tg-create-env
-            - gcp-tg-test-other-modules-plan:
-                requires:
-                    - gcp-tg-create-env
-            - gcp-tg-destroy-env:
-                requires:
-                    - gcp-tg-test-service-http
-                    - gcp-tg-test-other-modules-plan
         when: << pipeline.parameters.run-opta-terraform-generate-test >>
     run-release-vs-stable:
         jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1763,8 +1763,11 @@ jobs:
                 command: |
                     cd $HOME/generated-tf-files-gcp
                     terraform init
-                    terraform refresh
-                    terraform plan -compact-warnings -lock=false -input=false -out=tf.plan -target=module.base -target=module.k8scluster -target=module.k8sbase -destroy
+                    terraform plan -compact-warnings -lock=false -input=false -out=tf.plan -target=module.k8sbase -destroy
+                    terraform apply -compact-warnings -auto-approve tf.plan
+                    terraform plan -compact-warnings -lock=false -input=false -out=tf.plan -target=module.k8scluster -destroy
+                    terraform apply -compact-warnings -auto-approve tf.plan
+                    terraform plan -compact-warnings -lock=false -input=false -out=tf.plan -target=module.base -destroy
                     terraform apply -compact-warnings -auto-approve tf.plan
                 name: Destroy Terraform Generated Environment
             - store_artifacts:
@@ -2530,6 +2533,22 @@ workflows:
                 requires:
                     - aws-tg-test-service-http
                     - aws-tg-test-other-modules-plan
+            - gcp-generate-terraform-language-files:
+                requires:
+                    - build-opta-binary
+            - gcp-tg-create-env:
+                requires:
+                    - gcp-generate-terraform-language-files
+            - gcp-tg-test-service-http:
+                requires:
+                    - gcp-tg-create-env
+            - gcp-tg-test-other-modules-plan:
+                requires:
+                    - gcp-tg-create-env
+            - gcp-tg-destroy-env:
+                requires:
+                    - gcp-tg-test-service-http
+                    - gcp-tg-test-other-modules-plan
         when: << pipeline.parameters.run-opta-terraform-generate-test >>
     run-release-vs-stable:
         jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2193,6 +2193,38 @@ workflows:
             - azure-destroy-env:
                 requires:
                     - azure-test-service-http
+            - aws-generate-terraform-language-files:
+                requires:
+                    - build-opta-binary
+            - aws-tg-create-env:
+                requires:
+                    - aws-generate-terraform-language-files
+            - aws-tg-test-service-http:
+                requires:
+                    - aws-tg-create-env
+            - aws-tg-test-other-modules-plan:
+                requires:
+                    - aws-tg-create-env
+            - aws-tg-destroy-env:
+                requires:
+                    - aws-tg-test-service-http
+                    - aws-tg-test-other-modules-plan
+            - gcp-generate-terraform-language-files:
+                requires:
+                    - build-opta-binary
+            - gcp-tg-create-env:
+                requires:
+                    - gcp-generate-terraform-language-files
+            - gcp-tg-test-service-http:
+                requires:
+                    - gcp-tg-create-env
+            - gcp-tg-test-other-modules-plan:
+                requires:
+                    - gcp-tg-create-env
+            - gcp-tg-destroy-env:
+                requires:
+                    - gcp-tg-test-service-http
+                    - gcp-tg-test-other-modules-plan
         triggers:
             - schedule:
                 cron: 0 2 * * *
@@ -2340,6 +2372,38 @@ workflows:
             - azure-destroy-env:
                 requires:
                     - azure-test-service-http
+            - aws-generate-terraform-language-files:
+                requires:
+                    - build-opta-binary
+            - aws-tg-create-env:
+                requires:
+                    - aws-generate-terraform-language-files
+            - aws-tg-test-service-http:
+                requires:
+                    - aws-tg-create-env
+            - aws-tg-test-other-modules-plan:
+                requires:
+                    - aws-tg-create-env
+            - aws-tg-destroy-env:
+                requires:
+                    - aws-tg-test-service-http
+                    - aws-tg-test-other-modules-plan
+            - gcp-generate-terraform-language-files:
+                requires:
+                    - build-opta-binary
+            - gcp-tg-create-env:
+                requires:
+                    - gcp-generate-terraform-language-files
+            - gcp-tg-test-service-http:
+                requires:
+                    - gcp-tg-create-env
+            - gcp-tg-test-other-modules-plan:
+                requires:
+                    - gcp-tg-create-env
+            - gcp-tg-destroy-env:
+                requires:
+                    - gcp-tg-test-service-http
+                    - gcp-tg-test-other-modules-plan
         when: << pipeline.parameters.run-create-and-destroy >>
     run-create-and-destroy-aws:
         jobs:

--- a/.circleci/src/@anchored-workflows.yaml
+++ b/.circleci/src/@anchored-workflows.yaml
@@ -99,6 +99,38 @@ workflows:
       - azure-destroy-env:
           requires:
             - azure-test-service-http
+      - aws-generate-terraform-language-files:
+          requires:
+            - build-opta-binary
+      - aws-tg-create-env:
+          requires:
+            - aws-generate-terraform-language-files
+      - aws-tg-test-service-http:
+          requires:
+            - aws-tg-create-env
+      - aws-tg-test-other-modules-plan:
+          requires:
+            - aws-tg-create-env
+      - aws-tg-destroy-env:
+          requires:
+            - aws-tg-test-service-http
+            - aws-tg-test-other-modules-plan
+      - gcp-generate-terraform-language-files:
+          requires:
+            - build-opta-binary
+      - gcp-tg-create-env:
+          requires:
+            - gcp-generate-terraform-language-files
+      - gcp-tg-test-service-http:
+          requires:
+            - gcp-tg-create-env
+      - gcp-tg-test-other-modules-plan:
+          requires:
+            - gcp-tg-create-env
+      - gcp-tg-destroy-env:
+          requires:
+            - gcp-tg-test-service-http
+            - gcp-tg-test-other-modules-plan
   nightly:
     triggers:
       - schedule:

--- a/.circleci/src/jobs/aws-tg-destroy-env.yaml
+++ b/.circleci/src/jobs/aws-tg-destroy-env.yaml
@@ -6,15 +6,6 @@ steps:
   - install-opta-dependencies
   - attach_workspace:
       at: ~/
-#  - run:
-#      name: "Destroy Terraform Generated Environment"
-#      command: |
-#        cd $HOME/generated-tf-files-aws
-#        terraform init
-#        terraform refresh
-#        terraform state rm module.base.aws_ebs_default_kms_key.default
-#        terraform plan -compact-warnings -lock=false -input=false -out=tf.plan -target=module.base -target=module.k8scluster -target=module.k8sbase -destroy
-#        terraform apply -compact-warnings -auto-approve tf.plan
   - run:
       name: "Destroy Terraform Generated Environment"
       command: |

--- a/.circleci/src/jobs/aws-tg-destroy-env.yaml
+++ b/.circleci/src/jobs/aws-tg-destroy-env.yaml
@@ -6,14 +6,25 @@ steps:
   - install-opta-dependencies
   - attach_workspace:
       at: ~/
+#  - run:
+#      name: "Destroy Terraform Generated Environment"
+#      command: |
+#        cd $HOME/generated-tf-files-aws
+#        terraform init
+#        terraform refresh
+#        terraform state rm module.base.aws_ebs_default_kms_key.default
+#        terraform plan -compact-warnings -lock=false -input=false -out=tf.plan -target=module.base -target=module.k8scluster -target=module.k8sbase -destroy
+#        terraform apply -compact-warnings -auto-approve tf.plan
   - run:
       name: "Destroy Terraform Generated Environment"
       command: |
         cd $HOME/generated-tf-files-aws
         terraform init
-        terraform refresh
-        terraform state rm module.base.aws_ebs_default_kms_key.default
-        terraform plan -compact-warnings -lock=false -input=false -out=tf.plan -target=module.base -target=module.k8scluster -target=module.k8sbase -destroy
+        terraform plan -compact-warnings -lock=false -input=false -out=tf.plan -target=module.k8sbase -destroy
+        terraform apply -compact-warnings -auto-approve tf.plan
+        terraform plan -compact-warnings -lock=false -input=false -out=tf.plan -target=module.k8scluster -destroy
+        terraform apply -compact-warnings -auto-approve tf.plan
+        terraform plan -compact-warnings -lock=false -input=false -out=tf.plan -target=module.base -destroy
         terraform apply -compact-warnings -auto-approve tf.plan
   - store_artifacts:
       path: ~/generated-tf-files-aws

--- a/.circleci/src/jobs/gcp-tg-destroy-env.yaml
+++ b/.circleci/src/jobs/gcp-tg-destroy-env.yaml
@@ -13,8 +13,11 @@ steps:
       command: |
         cd $HOME/generated-tf-files-gcp
         terraform init
-        terraform refresh
-        terraform plan -compact-warnings -lock=false -input=false -out=tf.plan -target=module.base -target=module.k8scluster -target=module.k8sbase -destroy
+        terraform plan -compact-warnings -lock=false -input=false -out=tf.plan -target=module.k8sbase -destroy
+        terraform apply -compact-warnings -auto-approve tf.plan
+        terraform plan -compact-warnings -lock=false -input=false -out=tf.plan -target=module.k8scluster -destroy
+        terraform apply -compact-warnings -auto-approve tf.plan
+        terraform plan -compact-warnings -lock=false -input=false -out=tf.plan -target=module.base -destroy
         terraform apply -compact-warnings -auto-approve tf.plan
   - store_artifacts:
       path: ~/generated-tf-files-gcp

--- a/.circleci/src/workflows/run-opta-terraform-generate-test.yaml
+++ b/.circleci/src/workflows/run-opta-terraform-generate-test.yaml
@@ -18,19 +18,19 @@ jobs:
       requires:
         - aws-tg-test-service-http
         - aws-tg-test-other-modules-plan
-#  - gcp-generate-terraform-language-files:
-#      requires:
-#        - build-opta-binary
-#  - gcp-tg-create-env:
-#      requires:
-#        - gcp-generate-terraform-language-files
-#  - gcp-tg-test-service-http:
-#      requires:
-#        - gcp-tg-create-env
-#  - gcp-tg-test-other-modules-plan:
-#      requires:
-#        - gcp-tg-create-env
-#  - gcp-tg-destroy-env:
-#      requires:
-#        - gcp-tg-test-service-http
-#        - gcp-tg-test-other-modules-plan
+  - gcp-generate-terraform-language-files:
+      requires:
+        - build-opta-binary
+  - gcp-tg-create-env:
+      requires:
+        - gcp-generate-terraform-language-files
+  - gcp-tg-test-service-http:
+      requires:
+        - gcp-tg-create-env
+  - gcp-tg-test-other-modules-plan:
+      requires:
+        - gcp-tg-create-env
+  - gcp-tg-destroy-env:
+      requires:
+        - gcp-tg-test-service-http
+        - gcp-tg-test-other-modules-plan

--- a/.circleci/src/workflows/run-opta-terraform-generate-test.yaml
+++ b/.circleci/src/workflows/run-opta-terraform-generate-test.yaml
@@ -18,19 +18,19 @@ jobs:
       requires:
         - aws-tg-test-service-http
         - aws-tg-test-other-modules-plan
-  - gcp-generate-terraform-language-files:
-      requires:
-        - build-opta-binary
-  - gcp-tg-create-env:
-      requires:
-        - gcp-generate-terraform-language-files
-  - gcp-tg-test-service-http:
-      requires:
-        - gcp-tg-create-env
-  - gcp-tg-test-other-modules-plan:
-      requires:
-        - gcp-tg-create-env
-  - gcp-tg-destroy-env:
-      requires:
-        - gcp-tg-test-service-http
-        - gcp-tg-test-other-modules-plan
+#  - gcp-generate-terraform-language-files:
+#      requires:
+#        - build-opta-binary
+#  - gcp-tg-create-env:
+#      requires:
+#        - gcp-generate-terraform-language-files
+#  - gcp-tg-test-service-http:
+#      requires:
+#        - gcp-tg-create-env
+#  - gcp-tg-test-other-modules-plan:
+#      requires:
+#        - gcp-tg-create-env
+#  - gcp-tg-destroy-env:
+#      requires:
+#        - gcp-tg-test-service-http
+#        - gcp-tg-test-other-modules-plan


### PR DESCRIPTION
# Description
Add the Terraform generated test cases back to nightly.

# Safety checklist
* [x] This change is backwards compatible and safe to apply by existing users
* [x] This change will NOT lead to data loss
* [x] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
[run-opta-terraform-generate-test](https://app.circleci.com/pipelines/github/run-x/opta/2538/workflows/bd9b3c24-d1ac-443c-a776-bbc77fbbcf9c)
