### PR TITLE
Add support for BYOK clusters to `opta logs`

### DIFF
--- a/opta/commands/logs.py
+++ b/opta/commands/logs.py
@@ -65,6 +65,8 @@ def logs(
         modules = layer.get_module_by_type("gcp-k8s-service")
     elif layer.cloud == "local":
         modules = layer.get_module_by_type("local-k8s-service")
+    elif layer.cloud == "helm":
+        modules = layer.get_module_by_type("local-k8s-service")
     else:
         raise Exception(f"Currently not handling logs for cloud {layer.cloud}")
     if len(modules) == 0:


### PR DESCRIPTION
# Description
- Adds support for `opta logs` to BYOK clusters.
- `opta secret` and `opta shell` already seem to work just fine without any additional changes for BYOK clusters

# Safety checklist
* [X] This change is backwards compatible and safe to apply by existing users
* [X] This change will NOT lead to data loss
* [X] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
Manually verified that I could run `opta logs`, `opta shell`, and `opta secret` with a k8s-service only opta file that doesn't contain an environment.
