### PR TITLE
Fix Kubernetes auth broken for 1.24+ kubectl versions

### DIFF
--- a/opta/core/aws.py
+++ b/opta/core/aws.py
@@ -500,7 +500,7 @@ class AWS(CloudClient):
                     "name": kube_context_name,
                     "user": {
                         "exec": {
-                            "apiVersion": "client.authentication.k8s.io/v1alpha1",
+                            "apiVersion": "client.authentication.k8s.io/v1beta1",
                             "command": "aws",
                             "args": [
                                 "--region",

--- a/tests/core/test_aws.py
+++ b/tests/core/test_aws.py
@@ -79,7 +79,7 @@ class TestAWS:
             "- name: 111111111111_us-east-1_mocked_cluster_name\n"
             "  user:\n"
             "    exec:\n"
-            "      apiVersion: client.authentication.k8s.io/v1alpha1\n"
+            "      apiVersion: client.authentication.k8s.io/v1beta1\n"
             "      args: [--region, us-east-1, eks, get-token, --cluster-name, "
             "mocked_cluster_name]\n"
             "      command: aws\n"


### PR DESCRIPTION
# Description
`client.authentication.k8s.io/v1alpha1.ExecCredential` [was removed](https://github.com/kubernetes/kubernetes/pull/108616) in Kubernetes 1.24. v1 is GA, but is not supported before 1.22. In the meantime, we can use v1beta1, which should be supported for a while. See https://github.com/aws/aws-cli/issues/6920 for more info on this bug.

# Safety checklist
* [ ] This change is backwards compatible and safe to apply by existing users
* [X] This change will NOT lead to data loss
* [X] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
Verified that this works with kubectl v1.24 and awscli v2.6.4. I need someone to verify that it works on older kubectl and awscli versions.