### PR TITLE
Treat all warnings during pytest as errors

### DIFF
--- a/opta/commands/inspect_cmd.py
+++ b/opta/commands/inspect_cmd.py
@@ -137,13 +137,17 @@ class InspectCommand:
         return values
 
     def _get_aws_region(self) -> str:
-        tf_config = json.load(open(TF_FILE_PATH))
+        tf_config = self._read_tf_config()
         return tf_config["provider"]["aws"]["region"]
 
     def _get_gcp_region(self) -> str:
-        tf_config = json.load(open(TF_FILE_PATH))
+        tf_config = self._read_tf_config()
         return tf_config["provider"]["google"]["region"]
 
     def _get_gcp_project(self) -> str:
-        tf_config = json.load(open(TF_FILE_PATH))
+        tf_config = self._read_tf_config()
         return tf_config["provider"]["google"]["project"]
+
+    def _read_tf_config(self) -> dict:
+        with open(TF_FILE_PATH) as f:
+            return json.load(f)

--- a/opta/commands/push.py
+++ b/opta/commands/push.py
@@ -140,7 +140,8 @@ def push_to_docker_local(
 #
 # If the config file has the "environments" field, then it is a child/service layer.
 def is_service_config(config: str) -> bool:
-    config_data = yaml.load(open(config))
+    with open(config) as f:
+        config_data = yaml.load(f)
     return "environments" in config_data
 
 

--- a/opta/constants.py
+++ b/opta/constants.py
@@ -22,7 +22,8 @@ one_time_run: Final = os.path.join(
 )
 
 REGISTRY: Final = make_registry_dict()
-VERSION: Final = open(version_path).read().strip()
+with open(version_path) as f:
+    VERSION: Final = f.read().strip()
 DEV_VERSION: Final = "dev"
 
 SESSION_ID: Final = int(time.time() * 1000)

--- a/opta/core/kubernetes.py
+++ b/opta/core/kubernetes.py
@@ -81,7 +81,8 @@ def purge_opta_kube_config(layer: "Layer") -> None:
     kube_config_file_name = layer.get_kube_config_file_name()
     opta_config: dict
     if exists(kube_config_file_name):
-        opta_config = yaml.load(open(kube_config_file_name))
+        with open(kube_config_file_name) as f:
+            opta_config = yaml.load(f)
         remove(kube_config_file_name)
     else:
         return
@@ -92,7 +93,9 @@ def purge_opta_kube_config(layer: "Layer") -> None:
     if not exists(default_kube_config_filename):
         return
 
-    default_kube_config = yaml.load(open(default_kube_config_filename)) or {}
+    with open(default_kube_config_filename) as f:
+        default_kube_config = yaml.load(f) or {}
+
     opta_config_user = opta_config["users"][0]
     opta_config_context = opta_config["contexts"][0]
     opta_config_cluster = opta_config["clusters"][0]
@@ -122,7 +125,10 @@ def load_opta_kube_config_to_default(layer: "Layer") -> None:
             f"Can not find opta managed kube config, {kube_config_file_name}, to load to user default"
         )
         return
-    opta_config = yaml.load(open(kube_config_file_name))
+
+    with open(kube_config_file_name) as f:
+        opta_config = yaml.load(f)
+
     default_kube_config_filename = expanduser(
         constants.DEFAULT_KUBECONFIG.split(ENV_KUBECONFIG_PATH_SEPARATOR)[0]
     )
@@ -134,7 +140,9 @@ def load_opta_kube_config_to_default(layer: "Layer") -> None:
             yaml.dump(opta_config, f)
         return
     logger.debug("Loading kube config file")
-    default_kube_config = yaml.load(open(default_kube_config_filename))
+    with open(default_kube_config_filename) as f:
+        default_kube_config = yaml.load(f)
+
     opta_config_user = opta_config["users"][0]
     opta_config_context = opta_config["contexts"][0]
     opta_config_cluster = opta_config["clusters"][0]

--- a/opta/core/local.py
+++ b/opta/core/local.py
@@ -28,7 +28,8 @@ class Local(CloudClient):
 
     def get_remote_config(self) -> Optional["StructuredConfig"]:
         try:
-            return json.load(open(self.config_file_path, "r"))
+            with open(self.config_file_path, "r") as f:
+                return json.load(f)
         except Exception:  # Backwards compatibility
             logger.debug(
                 "Could not successfully download and parse any pre-existing config"

--- a/opta/json_schema.py
+++ b/opta/json_schema.py
@@ -54,8 +54,9 @@ def _get_module_json(module_name: str, directory: str) -> dict:
             f"No JSON Schema file detected for module {module_name}. Please create a file named {module_name}.json in the modules' subdirectory for this module."
         )
 
-    json_schema_file = open(json_schema_file_path)
-    module_json = json.load(json_schema_file)
+    with open(json_schema_file_path) as json_schema_file:
+        module_json = json.load(json_schema_file)
+
     module_json["name"] = module_name
     return module_json
 
@@ -77,8 +78,8 @@ def _check_opta_config_schemas(write: bool = False) -> None:
                 opta_config_schemas_path, f"{cloudjs}-{config_type}.json",
             )
 
-            json_schema_file = open(json_schema_file_path)
-            json_schema = json.load(json_schema_file)
+            with open(json_schema_file_path) as json_schema_file:
+                json_schema = json.load(json_schema_file)
             new_json_schema = deepcopy(json_schema)
 
             allowed_module_ids = sorted(
@@ -112,15 +113,17 @@ def _check_opta_config_schemas(write: bool = False) -> None:
 
 def _check_module_schemas(write: bool = False) -> None:
     for cloud in ["aws", "azurerm", "google", "local"]:
-        if cloud != "common":
-            index_yaml = yaml.load(open(join(registry_path, cloud, "index.yaml")))
+        with open(join(registry_path, cloud, "index.yaml")) as f:
+            index_yaml = yaml.load(f)
 
         module_info = _get_all_module_info(
             modules_path, CLOUD_NAME_TO_JSON_SCHEMA_NAME[cloud]
         )
 
         for module_name, yaml_path, _ in module_info:
-            module_registry_dict = yaml.load(open(yaml_path))
+            with open(yaml_path) as f:
+                module_registry_dict = yaml.load(f)
+
             json_schema = _get_module_json(module_name, dirname(yaml_path))
 
             new_json_schema = deepcopy(json_schema)

--- a/opta/module.py
+++ b/opta/module.py
@@ -233,7 +233,8 @@ class Module:
 
         # Read and parse each terraform file.
         for tf_file in tf_files:
-            tf_file_config = hcl2.load(open(tf_file))
+            with open(tf_file) as f:
+                tf_file_config = hcl2.load(f)
             tf_module_config[tf_file.name] = tf_file_config
 
         return tf_module_config

--- a/opta/one_time.py
+++ b/opta/one_time.py
@@ -13,6 +13,8 @@ def one_time() -> None:
         return
 
     try:
-        open(one_time_run, "w").close()
+        with open(one_time_run, "w"):
+            # Just opening to create the file
+            pass
     except:  # noqa: E722
         sys.exit(1)

--- a/opta/registry.py
+++ b/opta/registry.py
@@ -19,15 +19,15 @@ description: This section provides the list of module types for the user to use 
 
 def make_registry_dict() -> Dict[Any, Any]:
     registry_path = _registry_path()
-    registry_dict: Dict[Any, Any] = yaml.load(
-        open(os.path.join(registry_path, "index.yaml"))
-    )
+    with open(os.path.join(registry_path, "index.yaml")) as f:
+        registry_dict: Dict[Any, Any] = yaml.load(f)
     with open(os.path.join(registry_path, "index.md"), "r") as f:
         registry_dict["text"] = f.read()
     module_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), "modules")
     for cloud in ["aws", "azurerm", "google", "local", "helm"]:
         cloud_path = os.path.join(registry_path, cloud)
-        cloud_dict = yaml.load(open(os.path.join(cloud_path, "index.yaml")))
+        with open(os.path.join(cloud_path, "index.yaml")) as f:
+            cloud_dict = yaml.load(f)
         cloud_dict["modules"] = {}
         with open(os.path.join(cloud_path, "index.md"), "r") as f:
             cloud_dict["text"] = f.read()
@@ -102,7 +102,8 @@ def _get_all_module_info(directory: str, cloud: str) -> list:
     all_md_files = glob.glob(directory + "/**/*.md", recursive=True)
     for a_yaml_path in all_yaml_files:
         try:
-            module_dict = yaml.load(open(a_yaml_path))
+            with open(a_yaml_path) as f:
+                module_dict = yaml.load(f)
             if not module_dict:
                 continue
         except:  # nosec # noqa
@@ -139,7 +140,8 @@ def _make_module_registry_dict(directory: str, cloud: str = "") -> Dict[Any, Any
     cloud_yamls_module_names = _get_all_module_info(directory, cloud)
     for module_name, a_yaml_path, a_md_path in cloud_yamls_module_names:
         try:
-            module_dict = yaml.load(open(a_yaml_path))
+            with open(a_yaml_path) as f:
+                module_dict = yaml.load(f)
             if not module_dict:
                 continue
         except:  # nosec # noqa

--- a/opta/utils/markdown.py
+++ b/opta/utils/markdown.py
@@ -48,9 +48,8 @@ class Markdown:
     @staticmethod
     def _write(path: str, content: str) -> None:
         """write to file"""
-        file = open(path, "w")
-        file.write(content)
-        file.close()
+        with open(path, "w") as f:
+            f.write(content)
 
 
 class Title1(Text):

--- a/opta/utils/yaml.py
+++ b/opta/utils/yaml.py
@@ -7,7 +7,7 @@ from typing import IO, Any, Iterable, Optional, Union
 import ruamel.yaml
 from ruamel.yaml import YAML as lib_YAML
 
-Loadable = Union[pathlib.Path, IO]
+Loadable = Union[str, pathlib.Path, IO]
 
 
 class YAML:

--- a/opta/utils/yaml.py
+++ b/opta/utils/yaml.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
+import pathlib
 import warnings
 from typing import IO, Any, Iterable, Optional, Union
 
 import ruamel.yaml
 from ruamel.yaml import YAML as lib_YAML
 
-Loadable = Union[str, IO]
+Loadable = Union[pathlib.Path, IO]
 
 
 class YAML:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,3 +16,9 @@ force_grid_wrap = 0
 use_parentheses = true
 line_length = 90
 skip_glob = ['**/migrations/**', '**/node_modules**']
+
+[tool.pytest.ini_options]
+# treat all warnings as errors
+filterwarnings = [
+    "error",
+]

--- a/tests/commands/test_generate_terraform.py
+++ b/tests/commands/test_generate_terraform.py
@@ -1,6 +1,4 @@
-import functools
 import os
-import sys
 import tempfile
 import uuid
 from typing import Generator, List
@@ -290,7 +288,9 @@ def test_generate_terraform_env_and_service(mocker: MockFixture) -> None:
     runner = CliRunner()
 
     # run for env
-    result = runner.invoke(cli, ["generate-terraform", "-c", env_file, "-d", tmp_dir, "--auto-approve"])
+    result = runner.invoke(
+        cli, ["generate-terraform", "-c", env_file, "-d", tmp_dir, "--auto-approve"]
+    )
     # if result.exception:
     #     print(sys.exc_info()[2])
     assert result.exit_code == 0

--- a/tests/commands/test_generate_terraform.py
+++ b/tests/commands/test_generate_terraform.py
@@ -1,4 +1,6 @@
+import functools
 import os
+import sys
 import tempfile
 import uuid
 from typing import Generator, List
@@ -22,10 +24,15 @@ def run_before_and_after_tests(mocker: MockFixture) -> Generator:
     mocked_load_kube_config = mocker.patch("opta.core.kubernetes.load_kube_config")
     mocked_set_kube_config = mocker.patch("opta.core.kubernetes.set_kube_config")
 
-    global tmp_dir
-    tmp_dir = tempfile.TemporaryDirectory(prefix="opta-gen-tf").name
+    directory = tempfile.TemporaryDirectory(prefix="opta-gen-tf")
 
-    yield  # this is where the testing happens
+    global tmp_dir
+    tmp_dir = directory.name
+
+    with directory:
+        yield  # this is where the testing happens
+
+    tmp_dir = ""
 
     # Teardown
     # no actual kubernetes/cloud needed
@@ -283,7 +290,9 @@ def test_generate_terraform_env_and_service(mocker: MockFixture) -> None:
     runner = CliRunner()
 
     # run for env
-    result = runner.invoke(cli, ["generate-terraform", "-c", env_file, "-d", tmp_dir])
+    result = runner.invoke(cli, ["generate-terraform", "-c", env_file, "-d", tmp_dir, "--auto-approve"])
+    # if result.exception:
+    #     print(sys.exc_info()[2])
     assert result.exit_code == 0
     assert "Terraform files generated successfully" in result.output
 
@@ -544,7 +553,6 @@ def _check_file_not_exist(rel_path: str) -> None:
 
 def _random_file() -> str:
     "_random_file in current directory"
-    os.mkdir(tmp_dir)
     new_file = os.path.join(tmp_dir, str(uuid.uuid4()))
     with open(new_file, "w"):
         pass

--- a/tests/core/test_generator.py
+++ b/tests/core/test_generator.py
@@ -32,7 +32,8 @@ class TestGenerator:
         mocked_state_storage = mocker.patch("opta.layer.Layer.state_storage")
         mocked_state_storage.return_value = "opta-tf-state-test-dev1-98f2"
         gen_all(layer)
-        real_output = json.load(open(test_gen_file_path))
+        with open(test_gen_file_path) as f:
+            real_output = json.load(f)
         assert gen_tf_file == real_output
 
         # Make sure generation does not work without org name.
@@ -63,7 +64,8 @@ class TestGenerator:
         layer = Layer.load_from_yaml("", None)
 
         gen_opta_resource_tags(layer)
-        tags_config = json.load(open(gen_tags_file_path))
+        with open(gen_tags_file_path) as f:
+            tags_config = json.load(f)
 
         has_vpc = False
         for resource in tags_config["resource"]:

--- a/tests/core/test_local.py
+++ b/tests/core/test_local.py
@@ -52,7 +52,8 @@ class LocalTests(unittest.TestCase):
 
     def test_upload_opta_config(self) -> None:
         self.local.upload_opta_config()
-        dict = json.load(open(self.local.config_file_path, "r"))
+        with open(self.local.config_file_path) as f:
+            dict = json.load(f)
         assert set(dict.keys()) == set(
             ["opta_version", "original_spec", "date", "defaults"]
         )

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -40,22 +40,22 @@ def test_sensitive_formatter_on_gcp_yaml() -> None:
 
 
 def test_sensitive_formatter_on_aws_tfplan() -> None:
-    tfplan_text = open(
-        os.path.join(
-            os.getcwd(), "tests", "fixtures", "sample_tf_plan_files", "aws_tfplan"
-        )
-    ).read()
+    path = os.path.join(
+        os.getcwd(), "tests", "fixtures", "sample_tf_plan_files", "aws_tfplan"
+    )
+    with open(path) as f:
+        tfplan_text = f.read()
     formatted_tfplan = SensitiveFormatter.filter(tfplan_text)
     assert "111111111111" not in formatted_tfplan
     assert json.loads(formatted_tfplan)
 
 
 def test_sensitive_formatter_on_gcp_tfplan() -> None:
-    tfplan_text = open(
-        os.path.join(
-            os.getcwd(), "tests", "fixtures", "sample_tf_plan_files", "gcp_tfplan"
-        )
-    ).read()
+    path = os.path.join(
+        os.getcwd(), "tests", "fixtures", "sample_tf_plan_files", "gcp_tfplan"
+    )
+    with open(path) as f:
+        tfplan_text = f.read()
     formatted_tfplan = SensitiveFormatter.filter(tfplan_text)
     assert "my-gcp-project" not in formatted_tfplan
     assert json.loads(formatted_tfplan)


### PR DESCRIPTION
# Description
- Configure pytest to catch all warnings and treat them as test failures.
- Fix warnings that are raised.

# Safety checklist
* [X] This change is backwards compatible and safe to apply by existing users
* [X] This change will NOT lead to data loss
* [X] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
Not tested manually
