### PR TITLE
Adding ability to make a exec command health probes

### DIFF
--- a/modules/aws_k8s_service/aws-k8s-service.md
+++ b/modules/aws_k8s_service/aws-k8s-service.md
@@ -58,6 +58,21 @@ tl;dr An (optional) liveness probe determines whether your server should be rest
 be sent to a replica or be temporarily rerouted to other replicas. Essentially smart healthchecks. For websockets Opta
 just checks the tcp connection on the given port.
 
+Opta supports 2 types of possible health checks (please be advised that while they're not required, they're highly 
+recommended):
+
+#### Option 1: Health Check HTTP Ping
+Quite straightforward, K8s does regular http get requests to your server under a specific given path. You can specify
+this by setting the `healthcheck_path` input, or alternatively the `liveness_probe_path` and/or the 
+`readiness_probe_path` if you want different behavior for the liveness and readiness checks.
+
+#### Option 2: Health Check Command
+Also simple to understand, K8s regularly execute a shell command of your choosing and considers the
+server healthy if it has and exit code of 0. Commands should be passed in as a list of the different
+parts (e.g. ["echo", "hello"]). You can specify this by setting the `healthcheck_command` input, or alternatively the 
+`liveness_probe_command` and/or the `readiness_probe_command` if you want different behavior for the liveness and 
+readiness checks.
+
 ### Autoscaling
 
 As mentioned, autoscaling is available out of the box. We currently only support autoscaling

--- a/modules/aws_k8s_service/aws-k8s-service.yaml
+++ b/modules/aws_k8s_service/aws-k8s-service.yaml
@@ -101,17 +101,32 @@ inputs:
   - name: healthcheck_path
     user_facing: true
     validator: str(required=False)
-    description: See the See the [liveness/readiness](https://docs.opta.dev/reference/aws/modules/aws-k8s-service/#healthcheck-probe) section. Default `null` (i.e., no user-specified healthchecks)
+    description: See the See the [healthcheck probe](https://docs.opta.dev/reference/aws/modules/aws-k8s-service/#healthcheck-probe) section. Default `null` (i.e., no user-specified healthchecks)
     default: null
+  - name: healthcheck_command
+    user_facing: true
+    validator: list(str(), required=False)
+    description: See the See the [healthcheck probe](https://docs.opta.dev/reference/aws/modules/aws-k8s-service/#healthcheck-probe) section. Default `[]` (i.e., no user-specified healthchecks)
+    default: []
+  - name: liveness_probe_command
+    user_facing: true
+    validator: list(str(), required=False)
+    description: Use if using shell command liveness checks and liveness probe != readiness probe
+    default: []
+  - name: readiness_probe_command
+    user_facing: true
+    validator: list(str(), required=False)
+    description: Use if using shell command readiness checks and liveness probe != readiness probe
+    default: []
   - name: liveness_probe_path
     user_facing: true
     validator: str(required=False)
-    description: Use if liveness probe != readiness probe
+    description: Use if using http ping liveness checks and liveness probe != readiness probe
     default: null
   - name: readiness_probe_path
     user_facing: true
     validator: str(required=False)
-    description: Use if liveness probe != readiness probe
+    description: Use if using http ping readiness checks and liveness probe != readiness probe
     default: null
   - name: initial_liveness_delay
     user_facing: true

--- a/modules/aws_k8s_service/tf_module/main.tf
+++ b/modules/aws_k8s_service/tf_module/main.tf
@@ -34,8 +34,10 @@ resource "helm_release" "k8s-service" {
       image : local.image
       version : var.tag == null ? "latest" : var.tag
       livenessProbePath : var.healthcheck_path == null || var.liveness_probe_path != null ? var.liveness_probe_path : var.healthcheck_path,
+      livenessProbeCommand : length(var.healthcheck_command) == 0 || length(var.liveness_probe_command) != 0 ? var.liveness_probe_command : var.healthcheck_command,
       initialLivenessDelay : var.initial_liveness_delay
       readinessProbePath : var.healthcheck_path == null || var.readiness_probe_path != null ? var.readiness_probe_path : var.healthcheck_path,
+      readinessProbeCommand : length(var.healthcheck_command) == 0 || length(var.readiness_probe_command) != 0 ? var.readiness_probe_command : var.healthcheck_command,
       initialReadinessDelay : var.initial_readiness_delay
       healthcheck_path : var.healthcheck_path,
       envVars : var.env_vars,

--- a/modules/aws_k8s_service/tf_module/variables.tf
+++ b/modules/aws_k8s_service/tf_module/variables.tf
@@ -219,3 +219,15 @@ variable "timeout" {
 variable "max_history" {
   type = number
 }
+
+variable "healthcheck_command" {
+  type = list(string)
+}
+
+variable "liveness_probe_command" {
+  type = list(string)
+}
+
+variable "readiness_probe_command" {
+  type = list(string)
+}

--- a/modules/azure_k8s_service/azure-k8s-service.md
+++ b/modules/azure_k8s_service/azure-k8s-service.md
@@ -57,6 +57,21 @@ tl;dr An (optional) liveness probe determines whether your server should be rest
 be sent to a replica or be temporarily rerouted to other replicas. Essentially smart healthchecks. For websockets Opta
 just checks the tcp connection on the given port.
 
+Opta supports 2 types of possible health checks (please be advised that while they're not required, they're highly
+recommended):
+
+#### Option 1: Health Check HTTP Ping
+Quite straightforward, K8s does regular http get requests to your server under a specific given path. You can specify
+this by setting the `healthcheck_path` input, or alternatively the `liveness_probe_path` and/or the
+`readiness_probe_path` if you want different behavior for the liveness and readiness checks.
+
+#### Option 2: Health Check Command
+Also simple to understand, K8s regularly execute a shell command of your choosing and considers the
+server healthy if it has and exit code of 0. Commands should be passed in as a list of the different
+parts (e.g. ["echo", "hello"]). You can specify this by setting the `healthcheck_command` input, or alternatively the
+`liveness_probe_command` and/or the `readiness_probe_command` if you want different behavior for the liveness and
+readiness checks.
+
 ### Autoscaling
 
 As mentioned, autoscaling is available out of the box. We currently only support autoscaling

--- a/modules/azure_k8s_service/azure-k8s-service.yaml
+++ b/modules/azure_k8s_service/azure-k8s-service.yaml
@@ -87,17 +87,32 @@ inputs: # (what users see)
   - name: healthcheck_path
     user_facing: true
     validator: str(required=False)
-    description: See the See the [liveness/readiness](https://docs.opta.dev/reference/azurerm/modules/azure-k8s-service/#healthcheck-probe) section. Default `null` (i.e., no user-specified healthchecks)
+    description: See the See the [healthcheck probe](https://docs.opta.dev/reference/aws/modules/aws-k8s-service/#healthcheck-probe) section. Default `null` (i.e., no user-specified healthchecks)
     default: null
+  - name: healthcheck_command
+    user_facing: true
+    validator: list(str(), required=False)
+    description: See the See the [healthcheck probe](https://docs.opta.dev/reference/aws/modules/aws-k8s-service/#healthcheck-probe) section. Default `[]` (i.e., no user-specified healthchecks)
+    default: []
+  - name: liveness_probe_command
+    user_facing: true
+    validator: list(str(), required=False)
+    description: Use if using shell command liveness checks and liveness probe != readiness probe
+    default: []
+  - name: readiness_probe_command
+    user_facing: true
+    validator: list(str(), required=False)
+    description: Use if using shell command readiness checks and liveness probe != readiness probe
+    default: []
   - name: liveness_probe_path
     user_facing: true
     validator: str(required=False)
-    description: Use if liveness probe != readiness probe
+    description: Use if using http ping liveness checks and liveness probe != readiness probe
     default: null
   - name: readiness_probe_path
     user_facing: true
     validator: str(required=False)
-    description: Use if liveness probe != readiness probe
+    description: Use if using http ping readiness checks and liveness probe != readiness probe
     default: null
   - name: initial_liveness_delay
     user_facing: true

--- a/modules/azure_k8s_service/tf_module/main.tf
+++ b/modules/azure_k8s_service/tf_module/main.tf
@@ -34,8 +34,10 @@ resource "helm_release" "k8s-service" {
       image : local.image
       version : var.tag == null ? "latest" : var.tag
       livenessProbePath : var.healthcheck_path == null || var.liveness_probe_path != null ? var.liveness_probe_path : var.healthcheck_path,
+      livenessProbeCommand : length(var.healthcheck_command) == 0 || length(var.liveness_probe_command) != 0 ? var.liveness_probe_command : var.healthcheck_command,
       initialLivenessDelay : var.initial_liveness_delay
       readinessProbePath : var.healthcheck_path == null || var.readiness_probe_path != null ? var.readiness_probe_path : var.healthcheck_path,
+      readinessProbeCommand : length(var.healthcheck_command) == 0 || length(var.readiness_probe_command) != 0 ? var.readiness_probe_command : var.healthcheck_command,
       initialReadinessDelay : var.initial_readiness_delay
       healthcheck_path : var.healthcheck_path,
       envVars : var.env_vars,

--- a/modules/azure_k8s_service/tf_module/variables.tf
+++ b/modules/azure_k8s_service/tf_module/variables.tf
@@ -208,3 +208,15 @@ variable "timeout" {
 variable "max_history" {
   type = number
 }
+
+variable "healthcheck_command" {
+  type = list(string)
+}
+
+variable "liveness_probe_command" {
+  type = list(string)
+}
+
+variable "readiness_probe_command" {
+  type = list(string)
+}

--- a/modules/base.py
+++ b/modules/base.py
@@ -255,6 +255,28 @@ class K8sServiceModuleProcessor(ModuleProcessor):
                     new_uris.append(public_uri)
             self.module.data["public_uri"] = new_uris
 
+        liveness_probe_command = self.module.data.get(
+            "healthcheck_command"
+        ) or self.module.data.get("liveness_probe_command")
+        liveness_probe_path = self.module.data.get(
+            "healthcheck_path"
+        ) or self.module.data.get("liveness_probe_path")
+        if liveness_probe_path is not None and liveness_probe_command is not None:
+            raise UserErrors(
+                "Invalid liveness probes: you can only specify a path for an http get request or a shell command to run, not both."
+            )
+
+        readiness_probe_command = self.module.data.get(
+            "healthcheck_command"
+        ) or self.module.data.get("readiness_probe_command")
+        readiness_probe_path = self.module.data.get(
+            "healthcheck_path"
+        ) or self.module.data.get("readiness_probe_path")
+        if readiness_probe_path is not None and readiness_probe_command is not None:
+            raise UserErrors(
+                "Invalid readiness probes: you can only specify a path for an http get request or a shell command to run, not both."
+            )
+
         super(K8sServiceModuleProcessor, self).process(module_idx)
 
     def get_event_properties(self) -> Dict[str, int]:

--- a/modules/gcp_k8s_service/gcp-k8s-service.md
+++ b/modules/gcp_k8s_service/gcp-k8s-service.md
@@ -58,6 +58,21 @@ tl;dr An (optional) liveness probe determines whether your server should be rest
 be sent to a replica or be temporarily rerouted to other replicas. Essentially smart healthchecks. For websockets Opta
 just checks the tcp connection on the given port.
 
+Opta supports 2 types of possible health checks (please be advised that while they're not required, they're highly
+recommended):
+
+#### Option 1: Health Check HTTP Ping
+Quite straightforward, K8s does regular http get requests to your server under a specific given path. You can specify
+this by setting the `healthcheck_path` input, or alternatively the `liveness_probe_path` and/or the
+`readiness_probe_path` if you want different behavior for the liveness and readiness checks.
+
+#### Option 2: Health Check Command
+Also simple to understand, K8s regularly execute a shell command of your choosing and considers the
+server healthy if it has and exit code of 0. Commands should be passed in as a list of the different
+parts (e.g. ["echo", "hello"]). You can specify this by setting the `healthcheck_command` input, or alternatively the
+`liveness_probe_command` and/or the `readiness_probe_command` if you want different behavior for the liveness and
+readiness checks.
+
 ### Autoscaling
 
 As mentioned, autoscaling is available out of the box. We currently only support autoscaling

--- a/modules/gcp_k8s_service/gcp-k8s-service.yaml
+++ b/modules/gcp_k8s_service/gcp-k8s-service.yaml
@@ -91,28 +91,33 @@ inputs:
   - name: healthcheck_path
     user_facing: true
     validator: str(required=False)
-    description: See the See the [liveness/readiness](https://docs.opta.dev/reference/google/modules/gcp-k8s-service/#healthcheck-probe) section. Default `null` (i.e., no user-specified healthchecks)
+    description: See the See the [healthcheck probe](https://docs.opta.dev/reference/aws/modules/aws-k8s-service/#healthcheck-probe) section. Default `null` (i.e., no user-specified healthchecks)
     default: null
+  - name: healthcheck_command
+    user_facing: true
+    validator: list(str(), required=False)
+    description: See the See the [healthcheck probe](https://docs.opta.dev/reference/aws/modules/aws-k8s-service/#healthcheck-probe) section. Default `[]` (i.e., no user-specified healthchecks)
+    default: []
+  - name: liveness_probe_command
+    user_facing: true
+    validator: list(str(), required=False)
+    description: Use if using shell command liveness checks and liveness probe != readiness probe
+    default: []
+  - name: readiness_probe_command
+    user_facing: true
+    validator: list(str(), required=False)
+    description: Use if using shell command readiness checks and liveness probe != readiness probe
+    default: []
   - name: liveness_probe_path
     user_facing: true
     validator: str(required=False)
-    description: Use if liveness probe != readiness probe
+    description: Use if using http ping liveness checks and liveness probe != readiness probe
     default: null
   - name: readiness_probe_path
     user_facing: true
     validator: str(required=False)
-    description: Use if liveness probe != readiness probe
+    description: Use if using http ping readiness checks and liveness probe != readiness probe
     default: null
-  - name: initial_liveness_delay
-    user_facing: true
-    validator: int(required=False)
-    description: Use if the initial delay needs to be changed.
-    default: 30
-  - name: initial_readiness_delay
-    user_facing: true
-    validator: int(required=False)
-    description: Use if the initial delay needs to be changed.
-    default: 30
     force_update_default_counter: 2
   - name: consistent_hash
     user_facing: true

--- a/modules/gcp_k8s_service/tf_module/main.tf
+++ b/modules/gcp_k8s_service/tf_module/main.tf
@@ -34,8 +34,10 @@ resource "helm_release" "k8s-service" {
       image : local.image
       version : var.tag == null ? "latest" : var.tag
       livenessProbePath : var.healthcheck_path == null || var.liveness_probe_path != null ? var.liveness_probe_path : var.healthcheck_path,
+      livenessProbeCommand : length(var.healthcheck_command) == 0 || length(var.liveness_probe_command) != 0 ? var.liveness_probe_command : var.healthcheck_command,
       initialLivenessDelay : var.initial_liveness_delay
       readinessProbePath : var.healthcheck_path == null || var.readiness_probe_path != null ? var.readiness_probe_path : var.healthcheck_path,
+      readinessProbeCommand : length(var.healthcheck_command) == 0 || length(var.readiness_probe_command) != 0 ? var.readiness_probe_command : var.healthcheck_command,
       initialReadinessDelay : var.initial_readiness_delay
       envVars : var.env_vars,
       linkSecrets : var.link_secrets,

--- a/modules/gcp_k8s_service/tf_module/variables.tf
+++ b/modules/gcp_k8s_service/tf_module/variables.tf
@@ -222,3 +222,15 @@ variable "timeout" {
 variable "max_history" {
   type = number
 }
+
+variable "healthcheck_command" {
+  type = list(string)
+}
+
+variable "liveness_probe_command" {
+  type = list(string)
+}
+
+variable "readiness_probe_command" {
+  type = list(string)
+}

--- a/modules/opta-k8s-service-helm/templates/deployment.yaml
+++ b/modules/opta-k8s-service-helm/templates/deployment.yaml
@@ -71,6 +71,15 @@ spec:
           - secretRef:
               name: manual-secrets
               optional: true
+          {{ if ne (len .Values.livenessProbeCommand ) 0 }}
+          livenessProbe:
+            initialDelaySeconds: {{ .Values.initialLivenessDelay }}
+            exec:
+              command:
+              {{- range $item := .Values.livenessProbeCommand }}
+                 - {{ $item }}
+              {{- end }}
+          {{- end }}
           {{- if .Values.livenessProbePath }}
           livenessProbe:
             initialDelaySeconds: {{ .Values.initialLivenessDelay }}
@@ -95,6 +104,15 @@ spec:
               port: {{ .Values.probePort.name | quote }}
               path: {{ .Values.readinessProbePath }}
             {{- end }}
+          {{- end }}
+          {{- if ne (len .Values.readinessProbeCommand ) 0 }}
+          readinessProbe:
+            initialDelaySeconds: {{ .Values.initialReadinessDelay }}
+            exec:
+              command:
+                {{- range $item := .Values.readinessProbeCommand }}
+                - {{ $item }}
+                {{- end }}
           {{- end }}
           resources:
             limits:

--- a/modules/opta-k8s-service-helm/values.yaml
+++ b/modules/opta-k8s-service-helm/values.yaml
@@ -20,7 +20,13 @@ ingressExtraAnnotations: {}
 tolerations: []
 cron_jobs: []
 podAnnotations: {}
-
+version: ""
+livenessProbePath: null
+readinessProbePath: null
+initialLivenessDelay: null
+initialReadinessDelay: null
+livenessProbeCommand: []
+readinessProbeCommand: []
 serviceAccount:
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template


### PR DESCRIPTION
# Description
At the behest of our users
https://github.com/run-x/opta/issues/876


# Safety checklist
* [x] This change is backwards compatible and safe to apply by existing users
* [x] This change will NOT lead to data loss
* [x] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
manually
