### PR TITLE
Fixing Cloudfront

### DIFF
--- a/modules/aws_k8s_base/tf_module/variables.tf
+++ b/modules/aws_k8s_base/tf_module/variables.tf
@@ -6,12 +6,12 @@ data "aws_eks_cluster" "current" {
 locals {
   target_ports    = var.cert_arn == "" && var.private_key == "" && !var.expose_self_signed_ssl ? { http : "http" } : { http : "http", https : "https" }
   container_ports = { http : 80, https : 443, healthcheck : 10254 }
-  nginx_tls_ports = var.cert_arn == "" && var.private_key == "" ? "" : join(",", compact(flatten([
+  nginx_tls_ports = var.cert_arn == "" && var.private_key == "" && !var.expose_self_signed_ssl ? "" : join(",", compact(flatten([
     ["https"],
     [for port in var.nginx_extra_tcp_ports_tls : "${port}-tcp"],
   ])))
 
-  config = merge((var.cert_arn == "" && var.private_key == "" && !var.expose_self_signed_ssl ? { ssl-redirect : false } : {
+  config = merge((var.cert_arn == "" && var.private_key == "" ? { ssl-redirect : false } : {
     ssl-redirect : true
     force-ssl-redirect : true
   }), var.nginx_config)

--- a/modules/cloudfront_distribution/cloudfront-distribution.json
+++ b/modules/cloudfront_distribution/cloudfront-distribution.json
@@ -22,6 +22,11 @@
       "type": "string",
       "description": "The name of the existing s3 object in your bucket which will serve as the 404 page."
     },
+    "forward_https": {
+      "type": "bool",
+      "description": "Should cloudformation forward to https port 443 instead of http port 80?",
+      "default": false
+    },
     "enable_auto_dns": {
       "type": "bool",
       "description": "Should dns records automatically be added to the hosted zone created within this opta yaml, if present (redundant if domain and zone id are added manually)?",

--- a/modules/cloudfront_distribution/cloudfront-distribution.md
+++ b/modules/cloudfront_distribution/cloudfront-distribution.md
@@ -52,8 +52,11 @@ modules:
   - type: k8s-cluster
   - type: k8s-base
     name: testbase
-    expose_self_signed_ssl: true
+    cert_arn: "${{module.dns.cert_arn}}"
   - type: cloudfront-distribution
+    # Uncomment the following line if you want added security and are using a valid, non-self-signed ssl cert on the 
+    # load balancer (SSL certs created by opta when setting dns delegated true work fine). 
+    # forward_https: true
     links:
       - testbase
 ```

--- a/modules/cloudfront_distribution/cloudfront-distribution.yaml
+++ b/modules/cloudfront_distribution/cloudfront-distribution.yaml
@@ -94,6 +94,11 @@ inputs:
     validator: str(required=False)
     description: ID of Route53 hosted zone to add a record for. By default uses the one created by the DNS module if the module is found.
     default: ""
+  - name: forward_https
+    user_facing: true
+    validator: bool(required=False)
+    description: Should cloudformation forward to https port 443 instead of http port 80?
+    default: false
 extra_validators: { }
 outputs:
   - name: cloudfront_domain

--- a/modules/cloudfront_distribution/tf_module/main.tf
+++ b/modules/cloudfront_distribution/tf_module/main.tf
@@ -21,7 +21,7 @@ resource "aws_cloudfront_distribution" "distribution" {
   enabled         = true
   is_ipv6_enabled = true
   price_class     = var.price_class
-  aliases         = var.acm_cert_arn == "" ? [] : var.domains
+  aliases         = var.acm_cert_arn == "" ? [] : concat(var.domains, formatlist("*.%s", var.domains))
 
   dynamic "logging_config" {
     for_each = var.s3_log_bucket_name == null ? [] : [1]
@@ -55,7 +55,7 @@ resource "aws_cloudfront_distribution" "distribution" {
       custom_origin_config {
         http_port              = 80
         https_port             = 443
-        origin_protocol_policy = "http-only"
+        origin_protocol_policy = var.forward_https? "https-only" : "http-only"
         origin_ssl_protocols   = ["TLSv1.2", "TLSv1.1", "TLSv1"]
       }
     }
@@ -81,7 +81,7 @@ resource "aws_cloudfront_distribution" "distribution" {
 
     forwarded_values {
       query_string = true
-      headers      = ["Origin", "Access-Control-Request-Headers", "Access-Control-Request-Method"]
+      headers      = ["Origin", "Access-Control-Request-Headers", "Access-Control-Request-Method", "Host"]
 
       cookies {
         forward = "none"

--- a/modules/cloudfront_distribution/tf_module/main.tf
+++ b/modules/cloudfront_distribution/tf_module/main.tf
@@ -55,7 +55,7 @@ resource "aws_cloudfront_distribution" "distribution" {
       custom_origin_config {
         http_port              = 80
         https_port             = 443
-        origin_protocol_policy = var.forward_https? "https-only" : "http-only"
+        origin_protocol_policy = var.forward_https ? "https-only" : "http-only"
         origin_ssl_protocols   = ["TLSv1.2", "TLSv1.1", "TLSv1"]
       }
     }

--- a/modules/cloudfront_distribution/tf_module/variables.tf
+++ b/modules/cloudfront_distribution/tf_module/variables.tf
@@ -83,6 +83,10 @@ variable "enable_auto_dns" {
   type = bool
 }
 
+variable "forward_https" {
+  type = bool
+}
+
 variable "zone_id" {
   type = string
 }


### PR DESCRIPTION
# Description
* Stop adding ssl to port 80 when using self signed certs
* Stop ssl redirect when using self signed certs
* Cloudfront ssl origin does not work if origin's ssl certs are self signed, so updating that


# Safety checklist
* [x] This change is backwards compatible and safe to apply by existing users
* [x] This change will NOT lead to data loss
* [x] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
Manually
