### PR TITLE
Reducing string restrictions on k8s service limits/requests

### DIFF
--- a/modules/aws_k8s_service/aws-k8s-service.yaml
+++ b/modules/aws_k8s_service/aws-k8s-service.yaml
@@ -216,10 +216,10 @@ inputs:
     default: 25
 extra_validators:
   limits:
-    memory: any(int(min=1), regex('^[1-9][0-9]{0,4}$'), required=True)
+    memory: any(int(min=1), str(), required=True)
   resources:
-    cpu: any(int(min=1), regex('^[1-9][0-9]{0,4}$'), required=True)
-    memory: any(int(min=1), regex('^[1-9][0-9]{0,4}$'), required=True)
+    cpu: any(int(min=1), str(), required=True)
+    memory: any(int(min=1), str(), required=True)
   cron_job:
     commands: list(required=True)
     schedule: str(required=True)

--- a/modules/azure_k8s_service/azure-k8s-service.yaml
+++ b/modules/azure_k8s_service/azure-k8s-service.yaml
@@ -187,10 +187,10 @@ inputs: # (what users see)
     default: 25
 extra_validators:
   limits:
-    memory: any(int(min=1), regex('^[1-9][0-9]{0,4}$'), required=True)
+    memory: any(int(min=1), str(), required=True)
   resources:
-    cpu: any(int(min=1), regex('^[1-9][0-9]{0,4}$'), required=True)
-    memory: any(int(min=1), regex('^[1-9][0-9]{0,4}$'), required=True)
+    cpu: any(int(min=1), str(), required=True)
+    memory: any(int(min=1), str(), required=True)
   persistent_storage:
     size: int(required=True)
     path: str(required=True)

--- a/modules/gcp_k8s_service/gcp-k8s-service.yaml
+++ b/modules/gcp_k8s_service/gcp-k8s-service.yaml
@@ -207,10 +207,10 @@ inputs:
     default: 25
 extra_validators:
   limits:
-    memory: any(int(min=1), regex('^[1-9][0-9]{0,4}$'), required=True)
+    memory: any(int(min=1), str(), required=True)
   resources:
-    cpu: any(int(min=1), regex('^[1-9][0-9]{0,4}$'), required=True)
-    memory: any(int(min=1), regex('^[1-9][0-9]{0,4}$'), required=True)
+    cpu: any(int(min=1), str(), required=True)
+    memory: any(int(min=1), str(), required=True)
   cron_job:
     commands: list(required=True)
     schedule: str(required=True)

--- a/modules/local_k8s_service/local-k8s-service.yaml
+++ b/modules/local_k8s_service/local-k8s-service.yaml
@@ -176,10 +176,10 @@ inputs:
     default: 25
 extra_validators:
   limits:
-    memory: any(int(min=1), regex('^[1-9][0-9]{0,4}$'), required=True)
+    memory: any(int(min=1), str(), required=True)
   resources:
-    cpu: any(int(min=1), regex('^[1-9][0-9]{0,4}$'), required=True)
-    memory: any(int(min=1), regex('^[1-9][0-9]{0,4}$'), required=True)
+    cpu: any(int(min=1), str(), required=True)
+    memory: any(int(min=1), str(), required=True)
   cron_job:
     commands: list(required=True)
     schedule: str(required=True)


### PR DESCRIPTION
# Description
So that they can actually reference variables
https://github.com/run-x/opta/issues/886


# Safety checklist
* [x] This change is backwards compatible and safe to apply by existing users
* [x] This change will NOT lead to data loss
* [x] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
YOUR_ANSWER
