### PR TITLE
Add the ability to pass custom pod labels to k8s service

### DIFF
--- a/modules/aws_k8s_service/aws-k8s-service.json
+++ b/modules/aws_k8s_service/aws-k8s-service.json
@@ -220,7 +220,12 @@
     },
     "pod_annotations": {
       "type": "object",
-      "description": "These are extra annotations to add to k8s-service pod objects \n",
+      "description": "These are extra annotations to add to k8s-service pod objects / replace defaults\n",
+      "default": {}
+    },
+    "pod_labels": {
+      "type": "object",
+      "description": "These are extra labels to add to k8s-service pod objects / replace defaults\n",
       "default": {}
     },
     "type": {

--- a/modules/aws_k8s_service/aws-k8s-service.yaml
+++ b/modules/aws_k8s_service/aws-k8s-service.yaml
@@ -218,7 +218,13 @@ inputs:
     validator: map(required=False)
     default: {}
     description: |
-      These are extra annotations to add to k8s-service pod objects 
+      These are extra annotations to add to k8s-service pod objects / replace defaults
+  - name: pod_labels
+    user_facing: true
+    validator: map(required=False)
+    default: {}
+    description: |
+      These are extra labels to add to k8s-service pod objects / replace defaults
   - name: timeout
     user_facing: true
     validator: int(required=False)

--- a/modules/aws_k8s_service/tf_module/main.tf
+++ b/modules/aws_k8s_service/tf_module/main.tf
@@ -56,7 +56,7 @@ resource "helm_release" "k8s-service" {
       tolerations : var.tolerations
       cron_jobs : var.cron_jobs
       podAnnotations : var.pod_annotations
-      podLabels: var.pod_labels
+      podLabels : var.pod_labels
     })
   ]
   atomic          = true

--- a/modules/aws_k8s_service/tf_module/main.tf
+++ b/modules/aws_k8s_service/tf_module/main.tf
@@ -56,6 +56,7 @@ resource "helm_release" "k8s-service" {
       tolerations : var.tolerations
       cron_jobs : var.cron_jobs
       podAnnotations : var.pod_annotations
+      podLabels: var.pod_labels
     })
   ]
   atomic          = true

--- a/modules/aws_k8s_service/tf_module/variables.tf
+++ b/modules/aws_k8s_service/tf_module/variables.tf
@@ -231,3 +231,6 @@ variable "liveness_probe_command" {
 variable "readiness_probe_command" {
   type = list(string)
 }
+variable "pod_labels" {
+  type = map(string)
+}

--- a/modules/azure_k8s_service/azure-k8s-service.json
+++ b/modules/azure_k8s_service/azure-k8s-service.json
@@ -188,7 +188,12 @@
     },
     "pod_annotations": {
       "type": "object",
-      "description": "These are extra annotations to add to k8s-service pod objects\n",
+      "description": "These are extra annotations to add to k8s-service pod objects / replace defaults\n",
+      "default": {}
+    },
+    "pod_labels": {
+      "type": "object",
+      "description": "These are extra labels to add to k8s-service pod objects / replace defaults\n",
       "default": {}
     },
     "type": {

--- a/modules/azure_k8s_service/azure-k8s-service.yaml
+++ b/modules/azure_k8s_service/azure-k8s-service.yaml
@@ -189,7 +189,13 @@ inputs: # (what users see)
     validator: map(required=False)
     default: {}
     description: |
-      These are extra annotations to add to k8s-service pod objects
+      These are extra annotations to add to k8s-service pod objects / replace defaults
+  - name: pod_labels
+    user_facing: true
+    validator: map(required=False)
+    default: {}
+    description: |
+      These are extra labels to add to k8s-service pod objects / replace defaults
   - name: timeout
     user_facing: true
     validator: int(required=False)

--- a/modules/azure_k8s_service/tf_module/main.tf
+++ b/modules/azure_k8s_service/tf_module/main.tf
@@ -53,6 +53,7 @@ resource "helm_release" "k8s-service" {
       persistentStorage : var.persistent_storage
       ingressExtraAnnotations : var.ingress_extra_annotations
       podAnnotations : var.pod_annotations
+      podLabels: var.pod_labels
     })
   ]
   atomic          = true

--- a/modules/azure_k8s_service/tf_module/main.tf
+++ b/modules/azure_k8s_service/tf_module/main.tf
@@ -53,7 +53,7 @@ resource "helm_release" "k8s-service" {
       persistentStorage : var.persistent_storage
       ingressExtraAnnotations : var.ingress_extra_annotations
       podAnnotations : var.pod_annotations
-      podLabels: var.pod_labels
+      podLabels : var.pod_labels
     })
   ]
   atomic          = true

--- a/modules/azure_k8s_service/tf_module/variables.tf
+++ b/modules/azure_k8s_service/tf_module/variables.tf
@@ -220,3 +220,6 @@ variable "liveness_probe_command" {
 variable "readiness_probe_command" {
   type = list(string)
 }
+variable "pod_labels" {
+  type = map(string)
+}

--- a/modules/gcp_k8s_service/gcp-k8s-service.json
+++ b/modules/gcp_k8s_service/gcp-k8s-service.json
@@ -205,7 +205,12 @@
     },
     "pod_annotations": {
       "type": "object",
-      "description": "These are extra annotations to add to k8s-service pod objects\n",
+      "description": "These are extra annotations to add to k8s-service pod objects / replace defaults\n",
+      "default": {}
+    },
+    "pod_labels": {
+      "type": "object",
+      "description": "These are extra labels to add to k8s-service pod objects / replace defaults\n",
       "default": {}
     },
     "port": {

--- a/modules/gcp_k8s_service/gcp-k8s-service.yaml
+++ b/modules/gcp_k8s_service/gcp-k8s-service.yaml
@@ -199,7 +199,13 @@ inputs:
     validator: map(required=False)
     default: {}
     description: |
-      These are extra annotations to add to k8s-service pod objects
+      These are extra annotations to add to k8s-service pod objects / replace defaults
+  - name: pod_labels
+    user_facing: true
+    validator: map(required=False)
+    default: {}
+    description: |
+      These are extra labels to add to k8s-service pod objects / replace defaults
   - name: timeout
     user_facing: true
     validator: int(required=False)

--- a/modules/gcp_k8s_service/tf_module/main.tf
+++ b/modules/gcp_k8s_service/tf_module/main.tf
@@ -55,6 +55,7 @@ resource "helm_release" "k8s-service" {
       tolerations : var.tolerations
       cron_jobs : var.cron_jobs
       podAnnotations : var.pod_annotations
+      podLabels: var.pod_labels
     })
   ]
   atomic          = true

--- a/modules/gcp_k8s_service/tf_module/main.tf
+++ b/modules/gcp_k8s_service/tf_module/main.tf
@@ -55,7 +55,7 @@ resource "helm_release" "k8s-service" {
       tolerations : var.tolerations
       cron_jobs : var.cron_jobs
       podAnnotations : var.pod_annotations
-      podLabels: var.pod_labels
+      podLabels : var.pod_labels
     })
   ]
   atomic          = true

--- a/modules/gcp_k8s_service/tf_module/variables.tf
+++ b/modules/gcp_k8s_service/tf_module/variables.tf
@@ -234,3 +234,6 @@ variable "liveness_probe_command" {
 variable "readiness_probe_command" {
   type = list(string)
 }
+variable "pod_labels" {
+  type = map(string)
+}

--- a/modules/opta-k8s-service-helm/templates/crons.yaml
+++ b/modules/opta-k8s-service-helm/templates/crons.yaml
@@ -24,9 +24,15 @@ spec:
             tags.datadoghq.com/version: {{ $.Values.version | quote }}
             {{- include "k8s-service.labels" $ | nindent 12 }}
             cronjob: "true"
+            {{- range $k, $v := $.Values.podLabels }}
+            {{ $k | quote }}: {{ $v | quote }}
+            {{- end }}
           annotations:
             # Disable linkerd because https://github.com/linkerd/linkerd2/issues/1869
             linkerd.io/inject: disabled
+            {{- range $k, $v := $.Values.podAnnotations }}
+            {{ $k | quote }}: {{ $v | quote }}
+            {{- end }}
         spec:
           restartPolicy: "Never"
           {{- if ne ( len $.Values.tolerations ) 0 }}

--- a/modules/opta-k8s-service-helm/templates/deployment.yaml
+++ b/modules/opta-k8s-service-helm/templates/deployment.yaml
@@ -21,6 +21,9 @@ spec:
         {{- include "k8s-service.optaLabels" . | nindent 8 }}
         tags.datadoghq.com/service: {{ include "k8s-service.serviceName" . }}-{{ include "k8s-service.namespaceName" . }}
         tags.datadoghq.com/version: {{ .Values.version | quote }}
+        {{- range $k, $v := $.Values.podLabels }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
         # Outbound ports that should skip the proxy: datadog agent UDP (8126), postgres (5432), MySQL (3306)

--- a/modules/opta-k8s-service-helm/templates/statefulset.yaml
+++ b/modules/opta-k8s-service-helm/templates/statefulset.yaml
@@ -33,6 +33,9 @@ spec:
         {{- include "k8s-service.optaLabels" . | nindent 8 }}
         tags.datadoghq.com/service: {{ include "k8s-service.serviceName" . }}-{{ include "k8s-service.namespaceName" . }}
         tags.datadoghq.com/version: {{ .Values.version | quote }}
+        {{- range $k, $v := $.Values.podLabels }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
         # Outbound ports that should skip the proxy: datadog agent UDP (8126), postgres (5432), MySQL (3306)
@@ -47,6 +50,9 @@ spec:
         config.linkerd.io/proxy-cpu-request: "0.05"
         config.linkerd.io/proxy-memory-limit: "20Mi"
         config.linkerd.io/proxy-memory-request: "10Mi"
+        {{- range $k, $v := $.Values.podAnnotations }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
     spec:
       serviceAccountName: {{ include "k8s-service.serviceAccountName" . }}
       containers:

--- a/modules/opta-k8s-service-helm/values.yaml
+++ b/modules/opta-k8s-service-helm/values.yaml
@@ -27,6 +27,8 @@ initialLivenessDelay: null
 initialReadinessDelay: null
 livenessProbeCommand: []
 readinessProbeCommand: []
+podLabels: {}
+
 serviceAccount:
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template


### PR DESCRIPTION
# Description
Like what we did for pod annotations

# Safety checklist
* [x] This change is backwards compatible and safe to apply by existing users
* [x] This change will NOT lead to data loss
* [x] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
manually
