### PR TITLE
Use Http in Cloudfront testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -459,7 +459,7 @@ jobs:
                 command: |
                     sleep 20
                     export HOST=`./dist/opta/opta output --env awsenv-ci --config ./.circleci/ci-tests/create-and-destroy-aws/service-cloudfront.yml | jq -r '.cloudfront_domain'`
-                    curl --fail https://${HOST}
+                    curl --fail http://${HOST}
                 name: Test Cloudfront curl
             - run:
                 command: |-
@@ -494,7 +494,7 @@ jobs:
                 command: |
                     sleep 20
                     export HOST=`$HOME/.opta/opta output --env awsenv-ci --config ./.circleci/ci-tests/create-and-destroy-aws/service-cloudfront.yml | jq -r '.cloudfront_domain'`
-                    curl --fail https://${HOST}
+                    curl --fail http://${HOST}
                 name: Test Cloudfront curl
     aws-test-cloudfront-destroy-stable-version:
         environment:

--- a/.circleci/src/jobs/aws-test-cloudfront-apply-stable-version.yaml
+++ b/.circleci/src/jobs/aws-test-cloudfront-apply-stable-version.yaml
@@ -24,4 +24,4 @@ steps:
       command: |
         sleep 20
         export HOST=`$HOME/.opta/opta output --env awsenv-ci --config ./.circleci/ci-tests/create-and-destroy-aws/service-cloudfront.yml | jq -r '.cloudfront_domain'`
-        curl --fail https://${HOST}
+        curl --fail http://${HOST}

--- a/.circleci/src/jobs/aws-test-cloudfront.yaml
+++ b/.circleci/src/jobs/aws-test-cloudfront.yaml
@@ -24,7 +24,7 @@ steps:
       command: |
         sleep 20
         export HOST=`./dist/opta/opta output --env awsenv-ci --config ./.circleci/ci-tests/create-and-destroy-aws/service-cloudfront.yml | jq -r '.cloudfront_domain'`
-        curl --fail https://${HOST}
+        curl --fail http://${HOST}
   - run:
       name: "Destroy Cloudfront Service with Opta"
       command: |


### PR DESCRIPTION
# Description
Use an Http call instead of Https call in cloudfront.

# Safety checklist
* [x] This change is backwards compatible and safe to apply by existing users
* [x] This change will NOT lead to data loss
* [x] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
Tested Manually
