### PR TITLE
#894 Add waits_for_job to Opta YAML for Helm Chart module type

### DIFF
--- a/modules/helm_chart/helm-chart.json
+++ b/modules/helm_chart/helm-chart.json
@@ -76,6 +76,11 @@
       "description": "Will wait (for as long as timeout) until all resources are in a ready state before marking the release as successful.",
       "default": true
     },
+    "wait_for_jobs": {
+      "type": "boolean",
+      "description": "Will wait (for as long as timeout) until all Jobs have been completed before marking the release as successful.",
+      "default": false
+    },
     "type": {
       "description": "The name of this module",
       "enum": [

--- a/modules/helm_chart/helm-chart.yaml
+++ b/modules/helm_chart/helm-chart.yaml
@@ -87,6 +87,11 @@ inputs:
     validator: bool(required=False)
     description: Will wait (for as long as timeout) until all resources are in a ready state before marking the release as successful.
     default: true
+  - name: wait_for_jobs
+    user_facing: true
+    validator: bool(required=False)
+    description: Will wait (for as long as timeout) until all Jobs have been completed before marking the release as successful.
+    default: false
   - name: max_history
     user_facing: true
     validator: int(required=False)

--- a/modules/helm_chart/tf_module/main.tf
+++ b/modules/helm_chart/tf_module/main.tf
@@ -12,6 +12,7 @@ resource "helm_release" "remote_chart" {
   timeout           = var.timeout
   dependency_update = var.dependency_update
   wait              = var.wait
+  wait_for_jobs     = var.wait_for_jobs
   max_history       = var.max_history
   lifecycle {
     ignore_changes = [name]

--- a/modules/helm_chart/tf_module/variables.tf
+++ b/modules/helm_chart/tf_module/variables.tf
@@ -33,6 +33,11 @@ variable "wait" {
   default = true
 }
 
+variable "wait_for_jobs" {
+  type    = bool
+  default = false
+}
+
 variable "cleanup_on_fail" {
   type    = bool
   default = true


### PR DESCRIPTION
# Description

Add [waits_for_job](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release#wait_for_jobs) to Helm Chart module

# Safety checklist
* [x] This change is backwards compatible and safe to apply by existing users
* [x] This change will NOT lead to data loss
* [x] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
Tested locally
