### PR TITLE
Passing cookies in cloudfront and allowing extra headers

### DIFF
--- a/modules/cloudfront_distribution/cloudfront-distribution.json
+++ b/modules/cloudfront_distribution/cloudfront-distribution.json
@@ -22,6 +22,18 @@
       "type": "string",
       "description": "The name of the existing s3 object in your bucket which will serve as the 404 page."
     },
+    "extra_headers": {
+      "type": "array",
+      "description": "Extra headers to forward pass cloudfront",
+      "items": {
+        "oneOf": [
+          {
+            "type": "string"
+          }
+        ]
+      },
+      "default": []
+    },
     "web_acl_id": {
       "type": "string",
       "description": "The ID of the WAF ACL to add to cloudfront"

--- a/modules/cloudfront_distribution/cloudfront-distribution.yaml
+++ b/modules/cloudfront_distribution/cloudfront-distribution.yaml
@@ -94,6 +94,11 @@ inputs:
     validator: str(required=False)
     description: ID of Route53 hosted zone to add a record for. By default uses the one created by the DNS module if the module is found.
     default: ""
+  - name: extra_headers
+    user_facing: true
+    validator: list(str(), required=False)
+    description: Extra headers to forward pass cloudfront
+    default: []
   - name: web_acl_id
     user_facing: true
     validator: str(required=False)

--- a/modules/cloudfront_distribution/tf_module/main.tf
+++ b/modules/cloudfront_distribution/tf_module/main.tf
@@ -83,7 +83,10 @@ resource "aws_cloudfront_distribution" "distribution" {
 
     forwarded_values {
       query_string = true
-      headers      = ["Origin", "Access-Control-Request-Headers", "Access-Control-Request-Method", "Host"]
+      headers      = concat(["Origin", "Access-Control-Request-Headers", "Access-Control-Request-Method", "Host"], var.extra_headers)
+      cookies {
+        forward = "all"
+      }
 
       cookies {
         forward = "none"

--- a/modules/cloudfront_distribution/tf_module/variables.tf
+++ b/modules/cloudfront_distribution/tf_module/variables.tf
@@ -88,3 +88,7 @@ variable "zone_id" {
 variable "web_acl_id" {
   type = string
 }
+
+variable "extra_headers" {
+  type = list(string)
+}


### PR DESCRIPTION
# Description
For https://github.com/run-x/opta/issues/898

# Safety checklist
* [x] This change is backwards compatible and safe to apply by existing users
* [x] This change will NOT lead to data loss
* [x] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
Manually
