### PR TITLE
Update TLS ssl policy

### DIFF
--- a/examples/byok-eks/terraform/ingress-nginx.tf
+++ b/examples/byok-eks/terraform/ingress-nginx.tf
@@ -56,7 +56,7 @@ resource "helm_release" "ingress-nginx" {
             "service.beta.kubernetes.io/aws-load-balancer-name" : local.load_balancer_name
             "service.beta.kubernetes.io/aws-load-balancer-ssl-ports" : "https"
             # https://docs.aws.amazon.com/elasticloadbalancing/latest/application/create-https-listener.html#describe-ssl-policies.
-            "service.beta.kubernetes.io/aws-load-balancer-ssl-negotiation-policy" : "ELBSecurityPolicy-TLS-1-2-2017-01"
+            "service.beta.kubernetes.io/aws-load-balancer-ssl-negotiation-policy" : "ELBSecurityPolicy-TLS13-1-2-2021-06"
             "service.beta.kubernetes.io/aws-load-balancer-ssl-cert" : var.load_balancer_cert_arn
             "service.beta.kubernetes.io/aws-load-balancer-alpn-policy" : "HTTP2Preferred"
           }, var.nginx_extra_service_annotations)

--- a/modules/aws_k8s_base/tf_module/ingress_nginx.tf
+++ b/modules/aws_k8s_base/tf_module/ingress_nginx.tf
@@ -128,7 +128,7 @@ resource "helm_release" "ingress-nginx" {
             "service.beta.kubernetes.io/aws-load-balancer-access-log-s3-bucket-name" : var.s3_log_bucket_name
             "service.beta.kubernetes.io/aws-load-balancer-access-log-s3-bucket-prefix" : "opta-k8s-cluster"
             "service.beta.kubernetes.io/aws-load-balancer-ssl-ports" : local.nginx_tls_ports
-            "service.beta.kubernetes.io/aws-load-balancer-ssl-negotiation-policy" : "ELBSecurityPolicy-TLS-1-2-2017-01"
+            "service.beta.kubernetes.io/aws-load-balancer-ssl-negotiation-policy" : "ELBSecurityPolicy-TLS13-1-2-2021-06"
             "service.beta.kubernetes.io/aws-load-balancer-ssl-cert" : var.expose_self_signed_ssl ? aws_acm_certificate.self_signed[0].arn : (var.private_key != "" ? aws_acm_certificate.user_provided[0].arn : var.cert_arn)
             "service.beta.kubernetes.io/aws-load-balancer-alpn-policy" : "HTTP2Preferred"
           }


### PR DESCRIPTION
# Description
Update SSL Policy from `ELBSecurityPolicy-TLS-1-2-2017-01` to `ELBSecurityPolicy-TLS13-1-2-2021-06`

Note from AWS: 

> For TLS listeners, we recommend using the ELBSecurityPolicy-TLS13-1-2-2021-06 security policy. This is the default policy for listeners created using the AWS Management Console. This security policy includes TLS 1.3, which is optimized for security and performance, and is backward compatible with TLS 1.2.


# Safety checklist
* [ ] This change is backwards compatible and safe to apply by existing users
* [ ] This change will NOT lead to data loss
* [ ] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
