### PR TITLE
Adding args and commands variable to k8s service and its cron jobs

### DIFF
--- a/modules/aws_k8s_service/aws-k8s-service.json
+++ b/modules/aws_k8s_service/aws-k8s-service.json
@@ -14,6 +14,16 @@
       },
       "default": []
     },
+    "commands": {
+      "type": "list",
+      "description": "The commands override to execute in your container (corresponds to EntryPoint in docker)",
+      "default": []
+    },
+    "args": {
+      "type": "list",
+      "description": "The args override to pass to your container (corresponds to Cmd in docker)",
+      "default": []
+    },
     "ports": {
       "type": "array",
       "description": "Specifies which port(s) your app exposes.",

--- a/modules/aws_k8s_service/aws-k8s-service.md
+++ b/modules/aws_k8s_service/aws-k8s-service.md
@@ -195,10 +195,11 @@ For example, here is a service which has a cron job that runs every minute and s
     port:
       http: 80
     cron_jobs:
-      - commands:
+      - args: # Args is an optional field
+          - "-c"
+          - 'echo "Hello world!"'
+        commands:
         - /bin/sh
-        - -c
-        - 'echo "Hello world!"'
         schedule: "* * * * *"
 ```
 

--- a/modules/aws_k8s_service/aws-k8s-service.yaml
+++ b/modules/aws_k8s_service/aws-k8s-service.yaml
@@ -235,6 +235,16 @@ inputs:
     validator: int(required=False)
     description: The max amount of helm revisions to keep track of (0 for infinite)
     default: 25
+  - name: commands
+    user_facing: true
+    validator: list(required=False)
+    description: The commands override to execute in your container (corresponds to EntryPoint in docker)
+    default: []
+  - name: args
+    user_facing: true
+    validator: list(required=False)
+    description: The args override to pass to your container (corresponds to Cmd in docker)
+    default: []
 extra_validators:
   limits:
     memory: any(int(min=1), str(), required=True)
@@ -243,6 +253,7 @@ extra_validators:
     memory: any(int(min=1), str(), required=True)
   cron_job:
     commands: list(required=True)
+    args: list(required=False)
     schedule: str(required=True)
   toleration:
     key: str(required=True)

--- a/modules/aws_k8s_service/tf_module/main.tf
+++ b/modules/aws_k8s_service/tf_module/main.tf
@@ -57,6 +57,8 @@ resource "helm_release" "k8s-service" {
       cron_jobs : var.cron_jobs
       podAnnotations : var.pod_annotations
       podLabels : var.pod_labels
+      commands: var.commands
+      args: var.args
     })
   ]
   atomic          = true

--- a/modules/aws_k8s_service/tf_module/main.tf
+++ b/modules/aws_k8s_service/tf_module/main.tf
@@ -57,8 +57,8 @@ resource "helm_release" "k8s-service" {
       cron_jobs : var.cron_jobs
       podAnnotations : var.pod_annotations
       podLabels : var.pod_labels
-      commands: var.commands
-      args: var.args
+      commands : var.commands
+      args : var.args
     })
   ]
   atomic          = true

--- a/modules/aws_k8s_service/tf_module/variables.tf
+++ b/modules/aws_k8s_service/tf_module/variables.tf
@@ -234,3 +234,11 @@ variable "readiness_probe_command" {
 variable "pod_labels" {
   type = map(string)
 }
+
+variable "commands" {
+  type = list(string)
+}
+
+variable "args" {
+  type = list(string)
+}

--- a/modules/azure_k8s_service/azure-k8s-service.json
+++ b/modules/azure_k8s_service/azure-k8s-service.json
@@ -11,6 +11,24 @@
       "description": "Set to AUTO to create a private repo for your own images. Otherwises attempts to pull image from public dockerhub",
       "default": "AUTO"
     },
+    "commands": {
+      "type": "list",
+      "description": "The commands override to execute in your container (corresponds to EntryPoint in docker)",
+      "default": []
+    },
+    "args": {
+      "type": "list",
+      "description": "The args override to pass to your container (corresponds to Cmd in docker)",
+      "default": []
+    },
+    "cron_jobs": {
+      "type": "array",
+      "description": "A list of cronjobs to execute as part of this service",
+      "items": {
+        "$ref": "/common-types/cron-job"
+      },
+      "default": []
+    },
     "min_containers": {
       "type": "integer",
       "description": "The minimum number of replicas your app can autoscale to.",

--- a/modules/azure_k8s_service/azure-k8s-service.yaml
+++ b/modules/azure_k8s_service/azure-k8s-service.yaml
@@ -206,9 +206,28 @@ inputs: # (what users see)
     validator: int(required=False)
     description: The max amount of helm revisions to keep track of (0 for infinite)
     default: 25
+  - name: cron_jobs
+    user_facing: true
+    validator: list(include('cron_job'), required=False)
+    description: A list of cronjobs to execute as part of this service
+    default: []
+  - name: commands
+    user_facing: true
+    validator: list(required=False)
+    description: The commands override to execute in your container (corresponds to EntryPoint in docker)
+    default: []
+  - name: args
+    user_facing: true
+    validator: list(required=False)
+    description: The args override to pass to your container (corresponds to Cmd in docker)
+    default: []
 extra_validators:
   limits:
     memory: any(int(min=1), str(), required=True)
+  cron_job:
+    commands: list(required=True)
+    args: list(required=False)
+    schedule: str(required=True)
   resources:
     cpu: any(int(min=1), str(), required=True)
     memory: any(int(min=1), str(), required=True)

--- a/modules/azure_k8s_service/tf_module/main.tf
+++ b/modules/azure_k8s_service/tf_module/main.tf
@@ -54,6 +54,9 @@ resource "helm_release" "k8s-service" {
       ingressExtraAnnotations : var.ingress_extra_annotations
       podAnnotations : var.pod_annotations
       podLabels : var.pod_labels
+      cron_jobs : var.cron_jobs
+      commands: var.commands
+      args: var.args
     })
   ]
   atomic          = true

--- a/modules/azure_k8s_service/tf_module/main.tf
+++ b/modules/azure_k8s_service/tf_module/main.tf
@@ -55,8 +55,8 @@ resource "helm_release" "k8s-service" {
       podAnnotations : var.pod_annotations
       podLabels : var.pod_labels
       cron_jobs : var.cron_jobs
-      commands: var.commands
-      args: var.args
+      commands : var.commands
+      args : var.args
     })
   ]
   atomic          = true

--- a/modules/azure_k8s_service/tf_module/variables.tf
+++ b/modules/azure_k8s_service/tf_module/variables.tf
@@ -223,3 +223,15 @@ variable "readiness_probe_command" {
 variable "pod_labels" {
   type = map(string)
 }
+
+variable "commands" {
+  type = list(string)
+}
+
+variable "args" {
+  type = list(string)
+}
+
+variable "cron_jobs" {
+  default = []
+}

--- a/modules/base.py
+++ b/modules/base.py
@@ -243,6 +243,10 @@ class K8sServiceModuleProcessor(ModuleProcessor):
         if isinstance(self.module.data.get("public_uri"), str):
             self.module.data["public_uri"] = [self.module.data["public_uri"]]
 
+        cron_jobs = self.module.data.get("cron_jobs", [])
+        for cron_job in cron_jobs:
+            cron_job["args"] = cron_job.get("args", [])
+
         if "public_uri" in self.module.data:
             new_uris: List[str] = []
             public_uri: str

--- a/modules/gcp_k8s_service/gcp-k8s-service.json
+++ b/modules/gcp_k8s_service/gcp-k8s-service.json
@@ -15,6 +15,16 @@
       "description": "Set to AUTO to create a private repo for your own images. Otherwises attempts to pull image from public dockerhub",
       "default": "AUTO"
     },
+    "commands": {
+      "type": "list",
+      "description": "The commands override to execute in your container (corresponds to EntryPoint in docker)",
+      "default": []
+    },
+    "args": {
+      "type": "list",
+      "description": "The args override to pass to your container (corresponds to Cmd in docker)",
+      "default": []
+    },
     "min_containers": {
       "type": "integer",
       "description": "The minimum number of replicas your app can autoscale to.",

--- a/modules/gcp_k8s_service/gcp-k8s-service.md
+++ b/modules/gcp_k8s_service/gcp-k8s-service.md
@@ -195,10 +195,11 @@ For example, here is a service which has a cron job that runs every minute and s
     port:
       http: 80
     cron_jobs:
-      - commands:
+      - args: # Args is an optional field
+          - "-c"
+          - 'echo "Hello world!"'
+        commands:
         - /bin/sh
-        - -c
-        - 'echo "Hello world!"'
         schedule: "* * * * *"
 ```
 

--- a/modules/gcp_k8s_service/gcp-k8s-service.yaml
+++ b/modules/gcp_k8s_service/gcp-k8s-service.yaml
@@ -216,6 +216,16 @@ inputs:
     validator: int(required=False)
     description: The max amount of helm revisions to keep track of (0 for infinite)
     default: 25
+  - name: commands
+    user_facing: true
+    validator: list(required=False)
+    description: The commands override to execute in your container (corresponds to EntryPoint in docker)
+    default: []
+  - name: args
+    user_facing: true
+    validator: list(required=False)
+    description: The args override to pass to your container (corresponds to Cmd in docker)
+    default: []
 extra_validators:
   limits:
     memory: any(int(min=1), str(), required=True)
@@ -224,6 +234,7 @@ extra_validators:
     memory: any(int(min=1), str(), required=True)
   cron_job:
     commands: list(required=True)
+    args: list(required=False)
     schedule: str(required=True)
   toleration:
     key: str(required=True)

--- a/modules/gcp_k8s_service/tf_module/main.tf
+++ b/modules/gcp_k8s_service/tf_module/main.tf
@@ -56,6 +56,8 @@ resource "helm_release" "k8s-service" {
       cron_jobs : var.cron_jobs
       podAnnotations : var.pod_annotations
       podLabels : var.pod_labels
+      commands: var.commands
+      args: var.args
     })
   ]
   atomic          = true

--- a/modules/gcp_k8s_service/tf_module/main.tf
+++ b/modules/gcp_k8s_service/tf_module/main.tf
@@ -56,8 +56,8 @@ resource "helm_release" "k8s-service" {
       cron_jobs : var.cron_jobs
       podAnnotations : var.pod_annotations
       podLabels : var.pod_labels
-      commands: var.commands
-      args: var.args
+      commands : var.commands
+      args : var.args
     })
   ]
   atomic          = true

--- a/modules/gcp_k8s_service/tf_module/variables.tf
+++ b/modules/gcp_k8s_service/tf_module/variables.tf
@@ -237,3 +237,11 @@ variable "readiness_probe_command" {
 variable "pod_labels" {
   type = map(string)
 }
+
+variable "commands" {
+  type = list(string)
+}
+
+variable "args" {
+  type = list(string)
+}

--- a/modules/local_k8s_service/local-k8s-service.json
+++ b/modules/local_k8s_service/local-k8s-service.json
@@ -16,6 +16,16 @@
       "$ref": "/common-types/port-deprecated",
       "description": "Specifies what port your app was made to be listened to. Currently it must be a map of the form\n`http: [PORT_NUMBER_HERE]` or `tcp: [PORT_NUMBER_HERE]`. Use http if you just have a vanilla http server and tcp for\nwebsockets.\n"
     },
+    "commands": {
+      "type": "list",
+      "description": "The commands override to execute in your container (corresponds to EntryPoint in docker)",
+      "default": []
+    },
+    "args": {
+      "type": "list",
+      "description": "The args override to pass to your container (corresponds to Cmd in docker)",
+      "default": []
+    },
     "cron_jobs": {
       "type": "array",
       "description": "A list of cronjobs to execute as part of this service",

--- a/modules/local_k8s_service/local-k8s-service.yaml
+++ b/modules/local_k8s_service/local-k8s-service.yaml
@@ -174,6 +174,16 @@ inputs:
     validator: int(required=False)
     description: The max amount of helm revisions to keep track of (0 for infinite)
     default: 25
+  - name: commands
+    user_facing: true
+    validator: list(required=False)
+    description: The commands override to execute in your container (corresponds to EntryPoint in docker)
+    default: []
+  - name: args
+    user_facing: true
+    validator: list(required=False)
+    description: The args override to pass to your container (corresponds to Cmd in docker)
+    default: []
 extra_validators:
   limits:
     memory: any(int(min=1), str(), required=True)
@@ -182,6 +192,7 @@ extra_validators:
     memory: any(int(min=1), str(), required=True)
   cron_job:
     commands: list(required=True)
+    args: list(required=False)
     schedule: str(required=True)
   toleration:
     key: str(required=True)

--- a/modules/local_k8s_service/tf_module/main.tf
+++ b/modules/local_k8s_service/tf_module/main.tf
@@ -53,8 +53,8 @@ resource "helm_release" "k8s-service" {
       ingressExtraAnnotations : var.ingress_extra_annotations
       tolerations : var.tolerations
       cron_jobs : var.cron_jobs
-      commands: var.commands
-      args: var.args
+      commands : var.commands
+      args : var.args
     })
   ]
   atomic          = true

--- a/modules/local_k8s_service/tf_module/main.tf
+++ b/modules/local_k8s_service/tf_module/main.tf
@@ -53,6 +53,8 @@ resource "helm_release" "k8s-service" {
       ingressExtraAnnotations : var.ingress_extra_annotations
       tolerations : var.tolerations
       cron_jobs : var.cron_jobs
+      commands: var.commands
+      args: var.args
     })
   ]
   atomic          = true

--- a/modules/local_k8s_service/tf_module/variables.tf
+++ b/modules/local_k8s_service/tf_module/variables.tf
@@ -199,3 +199,11 @@ variable "cron_jobs" {
 variable "max_history" {
   type = number
 }
+
+variable "commands" {
+  type = list(string)
+}
+
+variable "args" {
+  type = list(string)
+}

--- a/modules/opta-k8s-service-helm/Chart.yaml
+++ b/modules/opta-k8s-service-helm/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/modules/opta-k8s-service-helm/templates/crons.yaml
+++ b/modules/opta-k8s-service-helm/templates/crons.yaml
@@ -51,6 +51,12 @@ spec:
               {{ range $command := $cron.commands }}
               - {{ $command | quote }}
               {{ end }}
+              {{- if ne (len $cron.args ) 0 }}
+              args:
+              {{ range $arg := $cron.args }}
+                - {{ $arg | quote }}
+              {{ end }}
+              {{- end }}
               env:
               - name: RDS_CA_PATH # This is the path to the public key for the docdb tls
                 value: "/config/rds_ca.pem"

--- a/modules/opta-k8s-service-helm/templates/deployment.yaml
+++ b/modules/opta-k8s-service-helm/templates/deployment.yaml
@@ -117,6 +117,18 @@ spec:
                 - {{ $item }}
                 {{- end }}
           {{- end }}
+          {{- if ne (len .Values.args ) 0 }}
+          args:
+          {{ range $arg := .Values.args }}
+            - {{ $arg | quote }}
+          {{ end }}
+          {{- end }}
+          {{- if ne (len .Values.commands ) 0 }}
+          command:
+          {{ range $arg := .Values.commands }}
+            - {{ $arg | quote }}
+          {{ end }}
+          {{- end }}
           resources:
             limits:
               {{- toYaml .Values.containerResourceLimits | nindent 14 }}

--- a/modules/opta-k8s-service-helm/values.yaml
+++ b/modules/opta-k8s-service-helm/values.yaml
@@ -28,6 +28,8 @@ initialReadinessDelay: null
 livenessProbeCommand: []
 readinessProbeCommand: []
 podLabels: {}
+commands: []
+args: []
 
 serviceAccount:
   # The name of the service account to use.


### PR DESCRIPTION
# Description
To resolve:
https://github.com/run-x/opta/issues/911


# Safety checklist
* [x] This change is backwards compatible and safe to apply by existing users
* [x] This change will NOT lead to data loss
* [x] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
manually
