### PR TITLE
Making input variables unstrict except in apply/deploy commands

### DIFF
--- a/opta/commands/events.py
+++ b/opta/commands/events.py
@@ -52,7 +52,7 @@ def events(
     if local:
         config = local_setup(config, input_variables=var)
     # Configure kubectl
-    layer = Layer.load_from_yaml(config, env)
+    layer = Layer.load_from_yaml(config, env, strict_input_variables=False)
     amplitude_client.send_event(
         amplitude_client.SHELL_EVENT,
         event_properties={"org_name": layer.org_name, "layer_name": layer.name},

--- a/opta/commands/force_unlock.py
+++ b/opta/commands/force_unlock.py
@@ -45,7 +45,9 @@ def force_unlock(
         if local:
             config = local_setup(config, input_variables=var)
         amplitude_client.send_event(amplitude_client.FORCE_UNLOCK_EVENT)
-        layer = Layer.load_from_yaml(config, env, input_variables=var)
+        layer = Layer.load_from_yaml(
+            config, env, input_variables=var, strict_input_variables=False
+        )
         layer.verify_cloud_credentials()
         modules = Terraform.get_existing_modules(layer)
         layer.modules = [x for x in layer.modules if x.name in modules]

--- a/opta/commands/kubectl.py
+++ b/opta/commands/kubectl.py
@@ -38,7 +38,9 @@ def configure_kubectl(
         config = check_opta_file_exists(config)
         if local:
             config = local_setup(config, input_variables=var)
-        layer = Layer.load_from_yaml(config, env, input_variables=var)
+        layer = Layer.load_from_yaml(
+            config, env, input_variables=var, strict_input_variables=False
+        )
         amplitude_client.send_event(
             amplitude_client.CONFIGURE_KUBECTL_EVENT,
             event_properties={"org_name": layer.org_name, "layer_name": layer.name},

--- a/opta/commands/logs.py
+++ b/opta/commands/logs.py
@@ -50,7 +50,9 @@ def logs(
     if local:
         config = local_setup(config, input_variables=var)
     # Configure kubectl
-    layer = Layer.load_from_yaml(config, env, input_variables=var)
+    layer = Layer.load_from_yaml(
+        config, env, input_variables=var, strict_input_variables=False
+    )
     amplitude_client.send_event(
         amplitude_client.SHELL_EVENT,
         event_properties={"org_name": layer.org_name, "layer_name": layer.name},

--- a/opta/commands/output.py
+++ b/opta/commands/output.py
@@ -30,7 +30,9 @@ def output(
     config = check_opta_file_exists(config)
     if local:
         config = local_setup(config, var, None)
-    layer = Layer.load_from_yaml(config, env, input_variables=var)
+    layer = Layer.load_from_yaml(
+        config, env, input_variables=var, strict_input_variables=False
+    )
     amplitude_client.send_event(
         amplitude_client.VIEW_OUTPUT_EVENT,
         event_properties={"org_name": layer.org_name, "layer_name": layer.name},

--- a/opta/commands/secret.py
+++ b/opta/commands/secret.py
@@ -124,7 +124,9 @@ def view(
     if local:
         config = local_setup(config, input_variables=var)
         env = "localopta"
-    layer = Layer.load_from_yaml(config, env, input_variables=var)
+    layer = Layer.load_from_yaml(
+        config, env, input_variables=var, strict_input_variables=False
+    )
     amplitude_client.send_event(
         amplitude_client.VIEW_SECRET_EVENT,
         event_properties={"org_name": layer.org_name, "layer_name": layer.name},
@@ -174,7 +176,9 @@ def list_command(
     if local:
         config = local_setup(config, input_variables=var)
         env = "localopta"
-    layer = Layer.load_from_yaml(config, env, input_variables=var)
+    layer = Layer.load_from_yaml(
+        config, env, input_variables=var, strict_input_variables=False
+    )
     amplitude_client.send_event(amplitude_client.LIST_SECRETS_EVENT)
     secret_name, namespace = get_secret_name_and_namespace(layer, module)
 
@@ -215,7 +219,9 @@ def update(
     if local:
         config = local_setup(config, input_variables=var)
         env = "localopta"
-    layer = Layer.load_from_yaml(config, env, input_variables=var)
+    layer = Layer.load_from_yaml(
+        config, env, input_variables=var, strict_input_variables=False
+    )
     secret_name, namespace = get_secret_name_and_namespace(layer, module)
 
     set_kube_config(layer)
@@ -255,7 +261,9 @@ def delete(
     if local:
         config = local_setup(config, input_variables=var)
         env = "localopta"
-    layer = Layer.load_from_yaml(config, env, input_variables=var)
+    layer = Layer.load_from_yaml(
+        config, env, input_variables=var, strict_input_variables=False
+    )
     secret_name, namespace = get_secret_name_and_namespace(layer, module)
 
     set_kube_config(layer)
@@ -296,7 +304,9 @@ def bulk_update(
     if local:
         config = local_setup(config, input_variables=var)
         env = "localopta"
-    layer = Layer.load_from_yaml(config, env, input_variables=var)
+    layer = Layer.load_from_yaml(
+        config, env, input_variables=var, strict_input_variables=False
+    )
     secret_name, namespace = get_secret_name_and_namespace(layer, module)
 
     set_kube_config(layer)

--- a/opta/commands/shell.py
+++ b/opta/commands/shell.py
@@ -50,7 +50,9 @@ def shell(
     if local:
         config = local_setup(config, input_variables=var)
     # Configure kubectl
-    layer = Layer.load_from_yaml(config, env, input_variables=var)
+    layer = Layer.load_from_yaml(
+        config, env, input_variables=var, strict_input_variables=False
+    )
     amplitude_client.send_event(
         amplitude_client.SHELL_EVENT,
         event_properties={"org_name": layer.org_name, "layer_name": layer.name},

--- a/opta/commands/show.py
+++ b/opta/commands/show.py
@@ -57,7 +57,7 @@ def tf_state(config: str, env: Optional[str]) -> None:
     """
     Show terraform state
     """
-    layer = Layer.load_from_yaml(config, env)
+    layer = Layer.load_from_yaml(config, env, strict_input_variables=False)
     cloud_client = layer.get_cloud_client()
     x = cloud_client.get_remote_state()
     print(x)

--- a/opta/commands/validate.py
+++ b/opta/commands/validate.py
@@ -19,4 +19,6 @@ def validate(
 ) -> None:
     config = check_opta_file_exists(config)
 
-    Layer.load_from_yaml(config, env, json_schema, input_variables=var)
+    Layer.load_from_yaml(
+        config, env, json_schema, input_variables=var, strict_input_variables=False
+    )

--- a/opta/input_variable.py
+++ b/opta/input_variable.py
@@ -51,7 +51,9 @@ class InputVariable:
 
     @staticmethod
     def render_dict(
-        input_variables: List[InputVariable], given_inputs: Dict[str, Any]
+        input_variables: List[InputVariable],
+        given_inputs: Dict[str, Any],
+        strict_input_variables: bool = True,
     ) -> Dict[str, Any]:
         output = {}
         for input_variable in input_variables:
@@ -59,7 +61,7 @@ class InputVariable:
                 output[input_variable.name] = given_inputs[input_variable.name]
             elif input_variable.default is not None:
                 output[input_variable.name] = input_variable.default
-            else:
+            elif strict_input_variables:
                 raise UserErrors(
                     f"Input variable {input_variable.name} was expected, but not given"
                 )

--- a/opta/layer.py
+++ b/opta/layer.py
@@ -224,6 +224,7 @@ class Layer:
         json_schema: bool = False,
         stateless_mode: bool = False,
         input_variables: Optional[Dict[str, str]] = None,
+        strict_input_variables: bool = True,
     ) -> Layer:
         t = None
         if config.startswith("git@"):
@@ -264,7 +265,9 @@ class Layer:
         conf["original_spec"] = config_string
         conf["path"] = config_path
 
-        layer = cls.load_from_dict(conf, env, is_parent, stateless_mode, input_variables)
+        layer = cls.load_from_dict(
+            conf, env, is_parent, stateless_mode, input_variables, strict_input_variables
+        )
         if local:
             pass
         validate_yaml(config_path, layer.cloud, json_schema)
@@ -292,12 +295,13 @@ class Layer:
         is_parent: bool = False,
         stateless_mode: bool = False,
         input_variables: Optional[Dict[str, str]] = None,
+        strict_input_variables: bool = True,
     ) -> Layer:
         input_variables = input_variables or {}
         # Handle input variables
         expected_input_variables = multi_from_dict(InputVariable, conf, "input_variables")
         current_variables = InputVariable.render_dict(
-            expected_input_variables, input_variables
+            expected_input_variables, input_variables, strict_input_variables
         )
         modules_data = conf.get("modules", [])
         environments = conf.pop("environments", None)

--- a/tests/commands/test_kubectl.py
+++ b/tests/commands/test_kubectl.py
@@ -32,7 +32,7 @@ def test_set_kube_config(mocker: MockFixture) -> None:
     result = runner.invoke(configure_kubectl, [])
     assert result.exit_code == 0
     mocked_layer_class.load_from_yaml.assert_called_with(
-        mocker.ANY, None, input_variables={}
+        mocker.ANY, None, input_variables={}, strict_input_variables=False
     )
     mocked_layer.verify_cloud_credentials.assert_called_once_with()
     mocked_configure.assert_called_once_with(mocked_layer)

--- a/tests/commands/test_secret.py
+++ b/tests/commands/test_secret.py
@@ -56,7 +56,7 @@ class TestSecretManager:
         mocked_create_namespace_if_not_exists.assert_called_once_with("dummy_layer")
         mocked_get_secrets.assert_called_once_with("dummy_layer", "manual-secrets")
         mocked_layer.assert_called_once_with(
-            "dummyconfig", "dummyenv", input_variables={}
+            "dummyconfig", "dummyenv", input_variables={}, strict_input_variables=False
         )
         mocked_amplitude_client.send_event.assert_called_once_with(
             amplitude_client.VIEW_SECRET_EVENT,
@@ -97,7 +97,7 @@ class TestSecretManager:
         mocked_create_namespace_if_not_exists.assert_called_once_with("dummy_layer")
         mocked_get_secrets.assert_called_once_with("dummy_layer", "manual-secrets")
         mocked_layer.assert_called_once_with(
-            "dummyconfig", "dummyenv", input_variables={}
+            "dummyconfig", "dummyenv", input_variables={}, strict_input_variables=False
         )
         mocked_amplitude_client.send_event.assert_called_once_with(
             amplitude_client.LIST_SECRETS_EVENT
@@ -144,7 +144,7 @@ class TestSecretManager:
             "dummy_layer", "manual-secrets", "dummysecret"
         )
         mocked_layer.assert_called_once_with(
-            "dummyconfig", "dummyenv", input_variables={}
+            "dummyconfig", "dummyenv", input_variables={}, strict_input_variables=False
         )
         mocked_amplitude_client.send_event.assert_called_once_with(
             amplitude_client.UPDATE_SECRET_EVENT
@@ -204,7 +204,7 @@ class TestSecretManager:
             "dummy_layer", "manual-secrets", {"dummysecret": "dummysecretvalue"}
         )
         mocked_layer.assert_called_once_with(
-            "dummyconfig", "dummyenv", input_variables={}
+            "dummyconfig", "dummyenv", input_variables={}, strict_input_variables=False
         )
         mocked_amplitude_client.send_event.assert_called_once_with(
             amplitude_client.UPDATE_SECRET_EVENT
@@ -256,7 +256,7 @@ class TestSecretManager:
         )
 
         mocked_layer.assert_called_once_with(
-            "dummyconfig", "dummyenv", input_variables={}
+            "dummyconfig", "dummyenv", input_variables={}, strict_input_variables=False
         )
         mocked_amplitude_event.assert_called_once_with(
             amplitude_client.UPDATE_BULK_SECRET_EVENT


### PR DESCRIPTION
# Description
For https://github.com/run-x/opta/issues/907


# Safety checklist
* [x] This change is backwards compatible and safe to apply by existing users
* [x] This change will NOT lead to data loss
* [x] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
manually
