### PR TITLE
Fix issue with public_uri when using var substitution with a list value

### DIFF
--- a/modules/aws_k8s_service/tf_module/variables.tf
+++ b/modules/aws_k8s_service/tf_module/variables.tf
@@ -1,7 +1,8 @@
 data "aws_caller_identity" "current" {}
 
 locals {
-  uri_components = [for s in var.public_uri : {
+  # BUG(RUNX-1312): We apply `flatten` to var.public_uri in case variable subsitution has resulted in var.public_uri containing a nested list.
+  uri_components = [for s in flatten(var.public_uri) : {
     domain : split("/", s)[0],
     pathPrefix : (length(split("/", s)) > 1 ? "/${join("/", slice(split("/", s), 1, length(split("/", s))))}" : "/"),
     pathPrefixName : replace((length(split("/", s)) > 1 ? "/${join("/", slice(split("/", s), 1, length(split("/", s))))}" : "/"), "/", "")
@@ -147,7 +148,8 @@ variable "env_vars" {
 }
 
 variable "public_uri" {
-  type    = list(string)
+  # BUG(RUNX-1312): type=list() instead of type=list(string) because public_uri might be a nested list if variable subsitution is used.
+  type    = list()
   default = []
 }
 

--- a/modules/azure_k8s_service/tf_module/variables.tf
+++ b/modules/azure_k8s_service/tf_module/variables.tf
@@ -10,7 +10,8 @@ data "azurerm_container_registry" "opta" {
 }
 
 locals {
-  uri_components = [for s in var.public_uri : {
+  # BUG(RUNX-1312): We apply `flatten` to var.public_uri in case variable subsitution has resulted in var.public_uri containing a nested list.
+  uri_components = [for s in flatten(var.public_uri) : {
     domain : split("/", s)[0],
     pathPrefix : (length(split("/", s)) > 1 ? "/${join("/", slice(split("/", s), 1, length(split("/", s))))}" : "/"),
     pathPrefixName : replace((length(split("/", s)) > 1 ? "/${join("/", slice(split("/", s), 1, length(split("/", s))))}" : "/"), "/", "")
@@ -148,7 +149,8 @@ variable "env_vars" {
 }
 
 variable "public_uri" {
-  type    = list(string)
+  # BUG(RUNX-1312): type=list() instead of type=list(string) because public_uri might be a nested list if variable subsitution is used.
+  type    = list()
   default = []
 }
 

--- a/modules/base.py
+++ b/modules/base.py
@@ -251,6 +251,8 @@ class K8sServiceModuleProcessor(ModuleProcessor):
             new_uris: List[str] = []
             public_uri: str
             for public_uri in self.module.data["public_uri"]:
+                # BUG(RUNX-1312): Var subtitution is unresolved at this point,
+                # so these special cases won't be seen if public_uri is set via variable substitution.
                 if public_uri.startswith("/"):
                     new_uris.append(f"all{public_uri}")
                 elif public_uri.startswith("*"):

--- a/modules/gcp_k8s_service/tf_module/variables.tf
+++ b/modules/gcp_k8s_service/tf_module/variables.tf
@@ -3,7 +3,8 @@ data "google_client_config" "current" {}
 
 
 locals {
-  uri_components = [for s in var.public_uri : {
+  # BUG(RUNX-1312): We apply `flatten` to var.public_uri in case variable subsitution has resulted in var.public_uri containing a nested list.
+  uri_components = [for s in flatten(var.public_uri) : {
     // We probably don't need the trim anymore but leaving this here for
     // potentional backwards compatibility
     domain : trim(split("/", s)[0], "."),
@@ -146,6 +147,7 @@ variable "env_vars" {
 }
 
 variable "public_uri" {
+  # BUG(RUNX-1312): type=list() instead of type=list(string) because public_uri might be a nested list if variable subsitution is used.
   type    = list(string)
   default = []
 }

--- a/modules/local_k8s_service/tf_module/variables.tf
+++ b/modules/local_k8s_service/tf_module/variables.tf
@@ -1,7 +1,8 @@
 # data "aws_caller_identity" "current" {}
 
 locals {
-  uri_components = [for s in var.public_uri : {
+  # BUG(RUNX-1312): We apply `flatten` to var.public_uri in case variable subsitution has resulted in var.public_uri containing a nested list.
+  uri_components = [for s in flatten(var.public_uri) : {
     domain : split("/", s)[0],
     pathPrefix : (length(split("/", s)) > 1 ? "/${join("/", slice(split("/", s), 1, length(split("/", s))))}" : "/"),
     pathPrefixName : replace((length(split("/", s)) > 1 ? "/${join("/", slice(split("/", s), 1, length(split("/", s))))}" : "/"), "/", "")
@@ -140,7 +141,8 @@ variable "env_vars" {
 }
 
 variable "public_uri" {
-  type    = list(string)
+  # BUG(RUNX-1312): type=list() instead of type=list(string) because public_uri might be a nested list if variable subsitution is used.
+  type    = list()
   default = []
 }
 

--- a/modules/opta-k8s-service-helm/templates/ingress.yaml
+++ b/modules/opta-k8s-service-helm/templates/ingress.yaml
@@ -14,13 +14,13 @@
 
 {{ if $.Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress" }}
 {{ $old_ingress_convention = (lookup "networking.k8s.io/v1beta1" "Ingress" $namespace_name $ingress_name_old_convention) }}
-{{ end }}  
+{{ end }}
 
 {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
 apiVersion: networking.k8s.io/v1
 {{- else if $.Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress" }}
 apiVersion: networking.k8s.io/v1beta1
-{{ end }}  
+{{ end }}
 kind: Ingress
 metadata:
   {{- if $old_ingress_convention }}
@@ -71,7 +71,7 @@ https://linkerd.io/2.9/tasks/using-ingress/#nginx
 spec:
   rules:
     - {{ if not (eq $val.domain "all" ) }}
-      host: {{ $val.domain }}
+      host: {{ $val.domain | quote }}
       {{ end }}
       http:
         paths:
@@ -81,7 +81,7 @@ spec:
             backend:
               service:
                 name: {{ include "k8s-service.serviceName" $ }}
-                port: 
+                port:
                   name: {{ $.Values.httpPort.name | quote }}
             {{- else if $.Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress" }}
             backend:


### PR DESCRIPTION
# Description
When a list var is used via variable substitution on the `k8s-service` `public_uri` input, terraform receives a nested list (e.g. `var=[foo, bar]` results in terraform getting `public_uri=[[foo, bar]]`).

# Safety checklist
* [ ] This change is backwards compatible and safe to apply by existing users
* [ ] This change will NOT lead to data loss
* [ ] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
YOUR_ANSWER
