### PR TITLE
Some updates due to tls update in terraform

### DIFF
--- a/modules/aws_k8s_base/tf_module/ingress_nginx.tf
+++ b/modules/aws_k8s_base/tf_module/ingress_nginx.tf
@@ -6,7 +6,6 @@ resource "tls_private_key" "self_signed" {
 
 resource "tls_self_signed_cert" "self_signed" {
   count           = var.expose_self_signed_ssl ? 1 : 0
-  key_algorithm   = "RSA"
   private_key_pem = tls_private_key.self_signed[0].private_key_pem
   dns_names       = ["*.elb.${data.aws_region.current.name}.amazonaws.com"]
 

--- a/modules/aws_k8s_base/tf_module/linkerd.tf
+++ b/modules/aws_k8s_base/tf_module/linkerd.tf
@@ -6,7 +6,6 @@ resource "tls_private_key" "trustanchor_key" {
 }
 
 resource "tls_self_signed_cert" "trustanchor_cert" {
-  key_algorithm         = tls_private_key.trustanchor_key.algorithm
   private_key_pem       = tls_private_key.trustanchor_key.private_key_pem
   validity_period_hours = 87600
   is_ca_certificate     = true
@@ -21,6 +20,9 @@ resource "tls_self_signed_cert" "trustanchor_cert" {
     "server_auth",
     "client_auth"
   ]
+  lifecycle {
+    ignore_changes = [subject]
+  }
 }
 
 resource "tls_private_key" "issuer_key" {
@@ -29,17 +31,18 @@ resource "tls_private_key" "issuer_key" {
 }
 
 resource "tls_cert_request" "issuer_req" {
-  key_algorithm   = tls_private_key.issuer_key.algorithm
   private_key_pem = tls_private_key.issuer_key.private_key_pem
 
   subject {
     common_name = "identity.linkerd.cluster.local"
   }
+  lifecycle {
+    ignore_changes = [subject]
+  }
 }
 
 resource "tls_locally_signed_cert" "issuer_cert" {
   cert_request_pem      = tls_cert_request.issuer_req.cert_request_pem
-  ca_key_algorithm      = tls_private_key.trustanchor_key.algorithm
   ca_private_key_pem    = tls_private_key.trustanchor_key.private_key_pem
   ca_cert_pem           = tls_self_signed_cert.trustanchor_cert.cert_pem
   validity_period_hours = 87600

--- a/modules/azure_k8s_base/tf_module/linkerd.tf
+++ b/modules/azure_k8s_base/tf_module/linkerd.tf
@@ -6,7 +6,6 @@ resource "tls_private_key" "trustanchor_key" {
 }
 
 resource "tls_self_signed_cert" "trustanchor_cert" {
-  key_algorithm         = tls_private_key.trustanchor_key.algorithm
   private_key_pem       = tls_private_key.trustanchor_key.private_key_pem
   validity_period_hours = 87600
   is_ca_certificate     = true
@@ -21,6 +20,9 @@ resource "tls_self_signed_cert" "trustanchor_cert" {
     "server_auth",
     "client_auth"
   ]
+  lifecycle {
+    ignore_changes = [subject]
+  }
 }
 
 resource "tls_private_key" "issuer_key" {
@@ -29,17 +31,18 @@ resource "tls_private_key" "issuer_key" {
 }
 
 resource "tls_cert_request" "issuer_req" {
-  key_algorithm   = tls_private_key.issuer_key.algorithm
   private_key_pem = tls_private_key.issuer_key.private_key_pem
 
   subject {
     common_name = "identity.linkerd.cluster.local"
   }
+  lifecycle {
+    ignore_changes = [subject]
+  }
 }
 
 resource "tls_locally_signed_cert" "issuer_cert" {
   cert_request_pem      = tls_cert_request.issuer_req.cert_request_pem
-  ca_key_algorithm      = tls_private_key.trustanchor_key.algorithm
   ca_private_key_pem    = tls_private_key.trustanchor_key.private_key_pem
   ca_cert_pem           = tls_self_signed_cert.trustanchor_cert.cert_pem
   validity_period_hours = 87600

--- a/modules/gcp_k8s_base/tf_module/linkerd.tf
+++ b/modules/gcp_k8s_base/tf_module/linkerd.tf
@@ -6,7 +6,6 @@ resource "tls_private_key" "trustanchor_key" {
 }
 
 resource "tls_self_signed_cert" "trustanchor_cert" {
-  key_algorithm         = tls_private_key.trustanchor_key.algorithm
   private_key_pem       = tls_private_key.trustanchor_key.private_key_pem
   validity_period_hours = 87600
   is_ca_certificate     = true
@@ -21,6 +20,9 @@ resource "tls_self_signed_cert" "trustanchor_cert" {
     "server_auth",
     "client_auth"
   ]
+  lifecycle {
+    ignore_changes = [subject]
+  }
 }
 
 resource "tls_private_key" "issuer_key" {
@@ -29,17 +31,18 @@ resource "tls_private_key" "issuer_key" {
 }
 
 resource "tls_cert_request" "issuer_req" {
-  key_algorithm   = tls_private_key.issuer_key.algorithm
   private_key_pem = tls_private_key.issuer_key.private_key_pem
 
   subject {
     common_name = "identity.linkerd.cluster.local"
   }
+  lifecycle {
+    ignore_changes = [subject]
+  }
 }
 
 resource "tls_locally_signed_cert" "issuer_cert" {
   cert_request_pem      = tls_cert_request.issuer_req.cert_request_pem
-  ca_key_algorithm      = tls_private_key.trustanchor_key.algorithm
   ca_private_key_pem    = tls_private_key.trustanchor_key.private_key_pem
   ca_cert_pem           = tls_self_signed_cert.trustanchor_cert.cert_pem
   validity_period_hours = 87600


### PR DESCRIPTION
# Description
key algorithm is now inferred from key and doesn't need to be specified again

# Safety checklist
* [x] This change is backwards compatible and safe to apply by existing users
* [x] This change will NOT lead to data loss
* [x] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
manually
