### PR TITLE
Prevent exporting terraform to the same output directory

### DIFF
--- a/opta/commands/generate_terraform.py
+++ b/opta/commands/generate_terraform.py
@@ -164,7 +164,7 @@ def generate_terraform(
                 # dynamically mark it as not exportable
                 module.desc["is_exportable"] = False
                 continue
-            rel_path = "./" + src_path[src_path.index("modules/"):]
+            rel_path = "./" + src_path[src_path.index("modules/") :]
             abs_path = os.path.join(tmp_dir, rel_path)
             logger.debug(f"Copying module from {module.get_type()} to {abs_path}")
             shutil.copytree(src_path, abs_path, dirs_exist_ok=True)


### PR DESCRIPTION
# Description
Each opta layer is associated with one remote backend definition, so we don't want to allow exporting multiple opta layer into the same output directory as this would override the backend when using the `--remote` option.

With this change, we simplify the `generate-terraform` usage by expecting a distinct directory output for each layer.
If the output directory is not empty the command would fail to prevent the user to accidently alter their terraform files.

# Safety checklist
* [X] This change is backwards compatible and safe to apply by existing users
* [X] This change will NOT lead to data loss
* [X] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
Tested using the getting started example.
