### PR TITLE
Default to BucketOwnerEnforced s3 bucket ownership controls

### DIFF
--- a/modules/aws_s3/tf_module/bucket.tf
+++ b/modules/aws_s3/tf_module/bucket.tf
@@ -123,6 +123,14 @@ resource "aws_s3_bucket_public_access_block" "block" {
   depends_on              = [aws_s3_bucket_policy.policy]
 }
 
+resource "aws_s3_bucket_ownership_controls" "ownership_controls" {
+  bucket = aws_s3_bucket.bucket.id
+
+  rule {
+    object_ownership = "BucketOwnerEnforced"
+  }
+}
+
 resource "aws_s3_bucket_policy" "policy" {
   bucket = aws_s3_bucket.bucket.id
   policy = data.aws_iam_policy_document.s3_policy.json


### PR DESCRIPTION
# Description

It's useful when you have objects in the s3 bucket which are created by other aws accounts not owned by you.

# Safety checklist
* [x] This change is backwards compatible and safe to apply by existing users
* [x] This change will NOT lead to data loss
* [x] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
It has been tested by attaching the code as custom-terraform to an s3 bucket provisioned via opta
